### PR TITLE
Adds NewSenstations Network Sites xPath scraper

### DIFF
--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -6,6 +6,7 @@ Supported Site|Scraper
 8thstreetlatinas.com|RealityKings.yml
 aebn.com|AEBN.yml
 allherluv.com|AllHerLuv.yml
+ashlynnbrooke.com/tour_ab/|NewSensationsNetworkSites.yml
 babes.com|RealityKings.yml
 babesnetwork.com|RealityKings.yml
 backroomcastingcouch.com|Backroomcastingcouch.yml
@@ -66,6 +67,8 @@ familystrokes.com|PaperStreetMedia.yml
 familyxxx.com|FamilyXXX.yml
 fantasyhd.com|AMAMultimedia.yml
 finishesthejob.com|FinishesTheJob.yml
+fourfingerclub.com/tour_ffc/|NewSensationsNetworkSites.yml
+freshouttahighschool.com/tour_fohs/|NewSensationsNetworkSites.yml
 gaycastings.com|AMAMultimedia.yml
 gaycreeps.com|AMAMultimedia.yml
 gayroom.com|AMAMultimedia.yml
@@ -81,6 +84,7 @@ hustler.com|Hustler.yml
 iknowthatgirl.com|RealityKings.yml
 innocenthigh.com|PaperStreetMedia.yml
 japanhdv.com|JapanHDV.yml
+jizzbomb.com/tour_jb/|NewSensationsNetworkSites.yml
 julesjordan.com|JulesJordan.yml
 kink.com|Kink.yml
 lesbea.com|RealityKings.yml
@@ -116,8 +120,10 @@ myveryfirsttime.com|AMAMultimedia.yml
 nannyspy.com|AMAMultimedia.yml
 naughtyamerica.com|NaughtyAmerica.yml
 newsensations.com/tour_ns/|NewSensationsMain.yml
+newsensations.com/tour_rs/|NewSensationsNetworkSites.yml
 officecock.com|AMAMultimedia.yml
 outhim.com|AMAMultimedia.yml
+parodypass.com/tour_pp/|NewSensationsNetworkSites.yml
 passion-hd.com|AMAMultimedia.yml
 pervmom.com|PaperStreetMedia.yml
 petite.xxx|Cherrypimps.yml
@@ -135,6 +141,7 @@ rk.com|RealityKings.yml
 roundandbrown.com|RealityKings.yml
 seancody.com|RealityKings.yml
 sexyhub.com|RealityKings.yml
+shanedieselsbanginbabes.com/tour_sdbb/|NewSensationsNetworkSites.yml
 shoplyfter.com|PaperStreetMedia.yml
 shoplyftermylf.com|PaperStreetMedia.yml
 showerbait.com|AMAMultimedia.yml
@@ -151,6 +158,8 @@ teensloveblackcocks.com|PaperStreetMedia.yml
 teenslovehugecocks.com|RealityKings.yml
 theassfactory.com|JulesJordan.yml
 thedicksuckers.com|FinishesTheJob.yml
+thelesbianexperience.com/tour_tle/|NewSensationsNetworkSites.yml
+thetabutales.com/tour_tt/|NewSensationsNetworkSites.yml
 thickandbig.com|AMAMultimedia.yml
 thickumz.com|PaperStreetMedia.yml
 tiny4k.com|AMAMultimedia.yml
@@ -158,6 +167,7 @@ tokyo-hot.com|Tokyohot.yml
 tonightsgirlfriend.com|Tonightsgirlfriend.yml
 transsensual.com|RealityKings.yml
 twistysnetwork.com|RealityKings.yml
+unlimitedmilfs.com/tour_um/|NewSensationsNetworkSites.yml
 vivid.com|Vivid.yml
 welivetogether.com|RealityKings.yml
 wetvr.com|AMAMultimedia.yml

--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -1,0 +1,33 @@
+name: "NewSensationsNetworkSites"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - https://thetabutales.com/tour_tt/
+      - https://www.jizzbomb.com/tour_jb/
+      - https://freshouttahighschool.com/tour_fohs/
+      - https://newsensations.com/tour_rs/
+      - https://fourfingerclub.com/tour_ffc/
+      - https://ashlynnbrooke.com/tour_ab/
+      - https://thelesbianexperience.com/tour_tle/
+      - https://unlimitedmilfs.com/tour_um/
+      - https://shanedieselsbanginbabes.com/tour_sdbb/
+      - https://www.parodypass.com/tour_pp/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class="update_title"]/text()
+      Date:
+        selector: //div[@class="cell update_date"]/text()
+        replace:
+          - regex: Released:\s
+            with:
+        parseDate: 01/02/2006
+      Details: //span[@class="update_description"]/text()
+      Tags:
+        Name: //span[@class="update_tags"]/a/text()
+      Performers:
+        Name: //span[@class="update_models"]/a/text()
+      Image: //video/@poster
+
+# Last Updated May 19, 2020


### PR DESCRIPTION
Of note the `/tour` part of these links is important, which is why I left it in for the site list.

i.e.
`newsensations.com/tour_ns/` is completely different from `newsensations.com/tour_rs/` with how they have set things up (and thus why they need to be in separate scrapers)