### PR TITLE
Tweak Clips4Sale xPath scraper

### DIFF
--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -9,8 +9,11 @@ xPathScrapers:
     scene:
       Title: //div[@class="clipTitle"]/h3/text()
       Details:
-        selector: //div[@class="clip"]/div/p[position() > 1]//text()
+        selector: //div[@class="clip"]/div/p//text()
         concat: " "
+        replace:
+          - regex: "Description:"
+            with:
       Date:
         selector: //div[@class="clearfix infoRow2 clip_details"]/div/div[2]/div[3]//span[@class="highlight"]/text()
         replace:


### PR DESCRIPTION
In practice I found my Clips4Sale scraper would fail in certain scene descriptions if they had icons in them after the description like `https://www.clips4sale.com/studio/47321/5246239/milf-jerk-wmv` This fixes that issue.