### PR TITLE
Add Pornhub xPath scene scraper

### DIFF
--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -263,6 +263,7 @@ petiteballerinasfucked.com|Nubiles.yml
 petitehdporn.com|Nubiles.yml
 playboy.tv|PlayboyTV.yml
 porngoespro.com|Spizoo.yml
+Pornhub.com|Pornhub.yml
 pornpros.com|AMAMultimedia.yml
 pornstarhardcore.com|Hustler.yml
 pornstartease.com|Spizoo.yml

--- a/pornhub.yml
+++ b/pornhub.yml
@@ -1,0 +1,25 @@
+name: "Pornhub"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - pornhub.com/view_video.php?viewkey=
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h1[@class="title"]/span/text()
+      Details: /html/head/meta[4]/@content
+      Date:
+        selector: /html/head/script[15]/text()
+        replace:
+          - regex: (?:.+useimage = "([^"]+).+) [contains(.,'uploadDate')]
+            with: $1
+        
+        parseDate: 2006-01-02
+      Tags:
+        Name: //div[@class="video-detailed-info"]//div//div//a/text()
+      Image:
+        selector: /html/head/meta[9]/@content
+        
+
+# Last Updated Jun 02, 2020


### PR DESCRIPTION
Adds a xPath scene scraper for pornhub.com
The tags are pulled from both the categories and tags sections as Stash doesn't have those separated.

There is still an issue with the date,pornhub has the videos dates hidden and only visible in a JSON string inside a script node.
For now the date just pulls the entire JSON string instead of the "uploadDate" section