### PR TITLE
Fix image scraping in BangBros scraper

### DIFF
--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -15,7 +15,7 @@ xPathScrapers:
       Performers:
         Name: //div[@class="vdoCast"]/a[position()>1]/text()
       Image:
-        selector: //img[@id="player-overlay-image"]/@src
+        selector: //video/@poster
         replace:
           - regex: ^
             with: "https:"
@@ -29,5 +29,5 @@ xPathScrapers:
         subScraper:
           selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
         parseDate: Jan 2, 2006
-        
-# Last Updated June 9, 2020
+
+# Last Updated June 17, 2020


### PR DESCRIPTION
This fixes an issue with the BangBros scraper pulling dead image links.

If you look at the page source on a video like `https://bangbros.com/video24949/the-afro-fuck` the source for the `img` isn't actually the scene image. The proper one is linked in the `video` though.