### PR TITLE
Adds XXXPawn xPath scraper

### DIFF
--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -362,4 +362,6 @@ wowporn.xxx|WowPorn.yml
 x-art.com|X-artcom.yml
 xart.xxx|Xartxxx.yml
 xempire.com|GammaEntertainment.yml
+xxxpawn.com|XXXPawn.yml
+xxxpawn.xxx|XXXPawn.yml
 ztod.com|ZeroTolerance.yml

--- a/scrapers/XXXPawn.yml
+++ b/scrapers/XXXPawn.yml
@@ -1,0 +1,40 @@
+name: "XXXPawn"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - xxxpawn.com
+      - xxxpawn.xxx
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h1/text()|//div[@id="content"]//h2/text()
+      Date:
+        selector: //link[@rel="canonical"]/@href
+        replace:
+          - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+            with: https://xxxpawn.xxx/$1
+        subScraper:
+          selector: //div[@id="title-single"]/span/text()
+          replace:
+            - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+              with: $1$2$3
+        parseDate: January 2 2006
+      Details:
+        selector: //p[@class="videoDetail"]/text()|//p[@class="more"]/text()|//span[@class="morecontent"]/span/text()
+        concat: ''
+      Studio:
+        Name:
+          selector: //link[@rel="canonical"]/@href
+          replace:
+            - regex: .+
+              with: 'XXXPawn'
+      Image:
+        selector: //link[@rel="canonical"]/@href
+        replace:
+          - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+            with: https://xxxpawn.xxx/$1
+        subScraper:
+          selector: //video/@poster
+
+# Last Updated June 22, 2020


### PR DESCRIPTION
Had a bit of an interesting use of the subscraper for this one. One domain has the scene date, and one doesn't, so I used the subscraper to be able to pull the scene date regardless of which domain is used. (One site also has better images, so I doubled down and used it there too)

I'm sure I'm missing something silly here but I do seem to be having a date parsing issue:
`
Warning Error parsing date string 'March 5th, 2017' using format 'January 2nd, 2006': parsing time "March 5th, 2017" as "January 2nd, 2006": cannot parse "th, 2017" as "nd, "
`

I'm not sure what I'm doing wrong with the parse format.