### PR TITLE
Add a blank template for url scene scraper

### DIFF
--- a/templates/SceneScraperTemplate.yml
+++ b/templates/SceneScraperTemplate.yml
@@ -1,0 +1,25 @@
+name: "SiteName"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - siteurl.com
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+      Details:
+      Date:
+        selector:
+        parseDate: Jan 2, 2006
+      Image:
+      Studio:
+        Name:
+      Movies:
+        Name:
+      Tags:
+        Name:
+      Performers:
+        Name:
+
+# Last Updated June 24, 2020


### PR DESCRIPTION
I personally would find this useful to have, figured others might as well.

Currently when I create a scene scraper, I duplicate an existing one, then clear out all the existing paths. This adds a blank template that can quickly be duplicated and ready to start building on.