### PR TITLE
Add PureTaboo, Bang.com xPath scene scrapers

### DIFF
--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -44,6 +44,7 @@ badmilfs.com|PaperStreetMedia.yml
 badoinkvr.com|BaDoink.yml
 badteenspunished.com|Nubiles.yml
 baeb.com|AMAMultimedia.yml
+bang.com|Bang.yml
 bangbros.com|BangBros.yml
 bangteenpussy.com|Teencoreclub.yml
 barelylegal.com|Hustler.yml
@@ -334,6 +335,7 @@ publicagent.com|RealityKings.yml
 publicpickups.com|RealityKings.yml
 puffynetwork.com|Puffynetwork.yml
 puremature.com|AMAMultimedia.yml
+puretaboo.com|PureTaboo.yml
 ragingstallion.com|GammaEntertainment.yml
 realityjunkies.com|RealityKings.yml
 realitykings.com|RealityKings.yml

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -1,0 +1,31 @@
+name: Bang
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - https://www.bang.com/video
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //meta[@name="og:title"]/@content
+      Details: //meta[@name="description"]/@content
+      Image: //meta[@name="og:image"]/@content
+      Date:
+        selector: //span[@class="hidden-xs fa-text-right fa-text-left"]/text()
+        replace:
+          - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+            with: $1$2$3
+        parseDate: Jan 2 2006
+      Tags:
+        Name:
+          selector: //div[@class="genres bottom-buffer10"]/a
+      Performers:
+        Name:
+          selector: //div/span[@class="fa-text-right" and contains(text(),"With:")]/../span[@class="comma-list-container"]/span/a/text()
+      Studio:
+        Name: //div/span[@class="fa-text-right" and contains(text(),"Studio:")]/a/text()
+driver:
+  useCDP: true
+  sleep: 5
+
+#Last Updated August 4, 2020

--- a/scrapers/PureTaboo.yml
+++ b/scrapers/PureTaboo.yml
@@ -1,0 +1,32 @@
+name: puretaboo
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - https://www.puretaboo.com/en/video
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class="styles_Rms8xL5kg6"]/h2
+      Image: //video[@class="vjs-tech"]/@poster
+      Date:
+        selector: //span[@class="Text ScenePlayer-ReleaseDate-Text styles_3tU3Z2sLeO"]/text()
+        parseDate: 2006-01-02
+      Details:
+        selector: //meta[@name="twitter:description"]/@content
+        replace:
+          - regex: </br>|<br>
+            with: "\n"
+      Tags:
+        Name:
+          selector: //div[@class="BackgroundBox ScenePlayer-SceneCategories-BackgroundBox styles_1khKtnnA8W"]/a
+      Performers:
+        Name:
+          selector: //div[@class="component-ActorThumb-List"]/a/@title
+      Studio:
+        Name:
+          selector: //div[@class="styles_1oxPFmiuVp"]/a/@title
+driver:
+  useCDP: true
+
+#Last Updated August 4, 2020


### PR DESCRIPTION
Adds scrapers for PureTaboo and Bang.com
Since they use CDP latest dev version of stash is required.

For using a a headless chrome instance https://hub.docker.com/r/chromedp/headless-shell/ is recommended



