### PR TITLE
Improve LegalPorno. Add AssTraffic.

### DIFF
--- a/scrapers/AssTraffic.yml
+++ b/scrapers/AssTraffic.yml
@@ -1,0 +1,62 @@
+name: "AssTraffic"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - asstraffic.com/movies/
+    scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - asstraffic.com/models/
+    scraper: performerScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h2
+      Date:
+        selector: //div[@class="container"]//span[contains(.,"Added")]/text()
+        replace:
+          - regex: "Added "
+            with:
+        parseDate: January 2, 2006
+      Details: //p[@class="mg-md"]/text()
+      Performers:
+        Name: //div[@id="video-info"]//a[contains(@href,'/models')]/text()
+      Studio:
+        Name:
+          fixed: AssTraffic
+      Image: //video[@id='video']/@poster
+      Tags:
+        Name: //div[contains(@class,"tag-container")]/a/text()
+
+  performerScraper:
+    performer:
+      Name: //h3[@class="mg-md"]
+      Country:
+        selector: //div[@class='col-md-4 modeldetail']/strong[text() = 'Nationality:']/following-sibling::text()[1]
+        postProcess:
+          - map:
+              Hungarian: Hungary
+              French: France
+              Czech: Czech Republic
+              Romanian: Romania
+              Swiss: Switzerland
+              Spanish: Spain
+              Russian: Russia
+              Austrian: Austria
+              Canadian: Canada
+              Colombian: Colombia
+              Polish: Poland
+              Slovakian: Slovakia
+              Ukrainian: Ukraine
+      Ethnicity:
+        selector: //div[@class='col-md-4 modeldetail']/strong[text() = 'Ethnicity:']/following-sibling::text()[1]
+        postProcess:
+          - map:
+              caucasian: white
+      Gender:
+        fixed: Female
+      Image:
+        selector: //div[@class='col-md-8 bigmodelpic']/img/@src

--- a/scrapers/LegalPorno.py
+++ b/scrapers/LegalPorno.py
@@ -1,0 +1,51 @@
+import json
+import sys
+import requests
+from pathlib import Path
+
+def debug(t):
+  sys.stderr.write(t + "\n")
+
+def query_url(query):
+  res = requests.get(f"https://www.legalporno.com/api/autocomplete/search?q={query}")
+  data = res.json()
+  results = data['terms']
+  if len(results) > 1:
+    debug("Multiple results. Taking first.")
+  return results[0]
+
+def detect_delimiter(title):
+  delimiters = [" ", "_", "-", "."]
+  for d in delimiters:
+    if d in title:
+      return d
+
+  debug(f"Could not determine delimiter of `{title}`")
+
+def find_scene_id(title):
+  # Remove file extension
+  title = Path(title).stem
+  title = title.replace("'", "")
+  delimiter = detect_delimiter(title)
+  parts = title.split(delimiter)
+  for part in parts:
+    if len(part) > 3:
+      if part == part.upper():
+        if not part[0].isdigit() and part[-1].isdigit():
+          return part
+
+if sys.argv[1] == "query":
+  fragment = json.loads(sys.stdin.read())
+  debug(json.dumps(fragment))
+
+  scene_id = find_scene_id(fragment['title'])
+  if not scene_id:
+    debug(f"Could not determine scene id in title: `{fragment['title']}`")
+  else:
+    debug(f"Found scene id: {scene_id}")
+    result = query_url(scene_id)
+    if result["type"] == "scene":
+      debug(f"Found scene {result['name']}")
+      fragment["url"] = result["url"]
+      fragment["title"] = result["name"]
+  print(json.dumps(fragment))

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -4,6 +4,12 @@ sceneByURL:
     url:
       - legalporno.com/watch/
     scraper: sceneScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - https://www.legalporno.com
+    scraper: performerScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -28,4 +34,10 @@ xPathScrapers:
           - regex: .+(https[^"]+).+
             with: $1
 
+  performerScraper:
+    performer:
+      Name: //h2
+      Country: //td[@class='text-danger']//a[contains(@href,'nationality')]/text()
+      Image:
+        selector: //div[@class='model--avatar']//img/@src
 # Last Updated May 24, 2020

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -9,6 +9,12 @@ performerByURL:
     url:
       - https://www.legalporno.com
     scraper: performerScraper
+sceneByFragment:
+    action: script
+    script:
+      - python
+      - LegalPorno.py
+      - query
 
 xPathScrapers:
   sceneScraper:


### PR DESCRIPTION
This pull request adds performer support to the LegalPorno scraper. It implements a fragment scraper for scenes that retrieves the correct scene title and URL if a valid scene ID was found. This can be then scraped with the scene by URL parser.

Furthermore this PR contains a scene and performer scraper for AssTraffic.com.