### PR TITLE
Add performerByURL and movieByURL scrapers to Gamma Entertainment and Jules Jordan

### DIFF
--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -102,6 +102,13 @@ sceneByURL:
       - nextdoorebony.com/
       - nextdoorcasting.com/
     scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - evilangel.com/en/pornstar/
+    scraper: performerScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -152,5 +159,10 @@ xPathScrapers:
           replace:
             - regex: .+(?:siteName":")([^"]+).+
               with: $1
+
+  performerScraper:
+    performer:
+      Name: //h1[@class='actorName']
+      Image: //img[@class='actorPicture']/@src
 
 # Last Updated June 22, 2020

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -109,6 +109,12 @@ performerByURL:
       - evilangel.com/en/pornstar/
     scraper: performerScraper
 
+movieByURL:
+  - action: scrapeXPath
+    url:
+      - evilangel.com/en/movie/
+    scraper: movieScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -164,5 +170,19 @@ xPathScrapers:
     performer:
       Name: //h1[@class='actorName']
       Image: //img[@class='actorPicture']/@src
+
+  movieScraper:
+    movie:
+      Name: //h3[@class='dvdTitle']//text()
+      Director: //ul[@class='directedBy']/li/a/text()
+      Duration: //li[@class='length']/text()
+      Date:
+        selector: //li[@class='updatedOn']/text()
+        parseDate: 2006-01-02
+      Synopsis: //p[@class='descriptionText']/text()
+      Studio:
+        Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()
+      FrontImage: //a[@class='frontCoverImg']/@href
+      BackImage: //a[@class='backCoverImg']/@href
 
 # Last Updated June 22, 2020

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -161,10 +161,7 @@ xPathScrapers:
             with: $1?width=960&height=543&enlarge=true
       Studio:
         Name:
-          selector: $detailscript
-          replace:
-            - regex: .+(?:siteName":")([^"]+).+
-              with: $1
+          selector: //span[@class="linkMainCaption"]/text()
 
   performerScraper:
     performer:

--- a/scrapers/JulesJordan.yml
+++ b/scrapers/JulesJordan.yml
@@ -8,6 +8,13 @@ sceneByURL:
       - https://www.theassfactory.com/
       - https://www.spermswallowers.com/
     scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - julesjordan.com/trial/models/
+    scraper: performerScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -34,5 +41,29 @@ xPathScrapers:
             with: $1
           - regex: (^\/)
             with: https://www.julesjordan.com/
+
+  performerScraper:
+    performer:
+      Name: //span[@class='title_bar_hilite']/text()
+      Birthdate:
+        selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Age')]
+        replace:
+          - regex: "Age:"
+            with:
+        parseDate: January 2, 2006
+      Measurements:
+        selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Measurements')]
+        replace:
+          - regex: "Measurements:"
+            with:
+          - regex: " "
+            with:
+      Height:
+        replace:
+          - regex: "Height:"
+            with:
+        selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Height')]
+      Image:
+        selector: //img[contains(@class,'model_bio_thumb')]/@src0_3x
 
 # Last Updated May 20, 2020

--- a/scrapers/JulesJordan.yml
+++ b/scrapers/JulesJordan.yml
@@ -15,6 +15,12 @@ performerByURL:
       - julesjordan.com/trial/models/
     scraper: performerScraper
 
+movieByURL:
+  - action: scrapeXPath
+    url:
+      - julesjordan.com/trial/dvds/
+    scraper: movieScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -71,5 +77,20 @@ xPathScrapers:
           - feetToCm: true
       Image:
         selector: //img[contains(@class,'model_bio_thumb')]/@src0_3x
+
+  movieScraper:
+    movie:
+      Name: //span[@class="title_bar_hilite"]/text()
+      Synopsis:
+        selector: //div[@class="dvd_extra_fields"]/div/text()[not(contains(.,"Studio"))]
+        concat: " "
+        postProcess:
+          - replace:
+            - regex: "Description:"
+              with:
+      Studio:
+        Name: //span[@class="update_date"]/text()[contains(.,"Studio")]/following-sibling::a/text()
+      FrontImage: //div[@class="front"]/a/img/@src0_3x
+      BackImage: //div[@class="back"]/a/img/@src0_3x
 
 # Last Updated May 20, 2020

--- a/scrapers/JulesJordan.yml
+++ b/scrapers/JulesJordan.yml
@@ -24,7 +24,8 @@ xPathScrapers:
       Title: //div[@class="title_bar"]/span/text()
       Date:
         selector: $details//div[@class="cell update_date"]/text()
-        parseDate: 01/02/2006
+        postProcess:
+          - parseDate: 01/02/2006
       Details:
         selector: $details//span[@class="update_description"]/text()
         concat: " "
@@ -36,33 +37,38 @@ xPathScrapers:
         Name: $details//span[@class="update_dvds"]/a/text()
       Image:
         selector: //script[contains(text(),'useimage')]/text()
-        replace:
-          - regex: (?:.+useimage = "([^"]+).+)
-            with: $1
-          - regex: (^\/)
-            with: https://www.julesjordan.com/
+        postProcess:
+          - replace:
+            - regex: (?:.+useimage = "([^"]+).+)
+              with: $1
+            - regex: (^\/)
+              with: https://www.julesjordan.com/
 
   performerScraper:
     performer:
       Name: //span[@class='title_bar_hilite']/text()
       Birthdate:
         selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Age')]
-        replace:
-          - regex: "Age:"
-            with:
-        parseDate: January 2, 2006
+        postProcess:
+          - replace:
+            - regex: "Age:"
+              with:
+          - parseDate: January 2, 2006
       Measurements:
         selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Measurements')]
-        replace:
-          - regex: "Measurements:"
-            with:
-          - regex: " "
-            with:
+        postProcess:
+          - replace:
+            - regex: "Measurements:"
+              with:
+            - regex: " "
+              with:
       Height:
-        replace:
-          - regex: "Height:"
-            with:
         selector: //div[@class='model_bio model_bio_info']//text()[contains(.,'Height')]
+        postProcess:
+          - replace:
+            - regex: "Height:"
+              with:
+          - feetToCm: true
       Image:
         selector: //img[contains(@class,'model_bio_thumb')]/@src0_3x
 


### PR DESCRIPTION
This patch set adds performer scrapers to Gamma Entertainment and Jules Jordan.
GE was only tested with Evil Angel, but works well. I also just scrapes the photo and name, which is enough for my needs.

Jules Jordan currently gets the wrong height in imperial units. To fix this I am going to write a post process in go that converts that at some point.