### PR TITLE
Trans500 normal and espanol scraper of their site

### DIFF
--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -1,4 +1,4 @@
-name: trans500
+name: Trans500
 sceneByURL:
   - action: scrapeXPath
     url: 

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -1,0 +1,20 @@
+name: trans500
+sceneByURL:
+  - action: scrapeXPath
+    url: 
+      - trans500.com/tour/
+      - trans500.com/tour3/
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class="col-sm-12"]/p/../h2/text()
+      Details: //p[@class="description"]
+      Image:
+        selector: //video[@id="my-video"]/@poster
+        replace:
+          - regex: ^
+            with: "http://www.trans500.com"
+      Studio: 
+        Name: //p[@class="pull-right"]/b/text()

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -36,8 +36,21 @@ xPathScrapers:
         # replace: 
           # - regex: http 
             # with: https
-      Studio: 
+      Studio:
         Name: 
-          fixed: Trans500
+          selector: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
+          concat: ","
+          postProcess:
+            - replace:
+                - regex: .*(superramon).*
+                  with: "Super Ramon"
+                - regex: .*(tsgirlfriendexperience).*|.*(TSGFE).*
+                  with: "TS Girlfriend Experience"
+                - regex: .*(ikillitts).*|.*(I Kill it TS).*|.*(IKI).*
+                  with: "I Kill It TS"
+                - regex: .*(transatplay).*|.*(TAP).*|.*(trans at play).*
+                  with: "Trans at Play"
+                - regex: .*(behindtrans500).*|.*(behind the scenes).*
+                  with: "Behind Trans500" 
       Tags:  # Either //meta[@name="keywords"]/@content OR: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
         Name: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -1,0 +1,43 @@
+name: trans500
+sceneByURL:
+  - action: scrapeXPath
+    url: 
+      - trans500.com/tourespanol
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: 
+        selector: //header[@id="scene-info"]/h1/text()[contains(., ":")]
+        postProcess: 
+          - replace: 
+            - regex: .*:.
+              with: 
+      Date:
+        selector: //div[contains(text(), "Added:")]/text()  # or //div[@class="scene-infobrick"][contains(text(), "Added:")]/text()
+        postProcess: 
+          - replace: 
+            - regex: ".*:"
+              with: 
+          - parseDate: 01/02/2006
+      Performers: 
+        Name: //div[@class="scene-infobrick"][contains(text(), "TSGirls:")]/a/text()
+      Details: //section[@id="scene-desc"]/p/text()
+      Image:
+        selector: //meta[@name="twitter:image0"]/@content
+        replace: 
+          - regex: http
+            with: https
+        # selector: //div[@class="vjs-poster"]/@style
+        # replace:
+          # - regex: ^.+(http[^\&]+).+$
+            # with: $1
+        # replace: 
+          # - regex: http 
+            # with: https
+      Studio: 
+        Name: 
+          fixed: Trans500
+      Tags:  # Either //meta[@name="keywords"]/@content OR: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
+        Name: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -1,4 +1,4 @@
-name: trans500
+name: Trans500espanol
 sceneByURL:
   - action: scrapeXPath
     url: 


### PR DESCRIPTION
Found that if you go to the espanol version. e.g. `/tourespanol/` instead of `/tour/` or `/tour3/` in the URL, there is more metadata showing at the scene-page. Here's both versions, since studio is then missing on the espanol part...
Supported Site|Scraper|Content
------------- | ------------- | -------------
trans500.com/tour/|Trans500.yml|Trans
trans500.com/tour3/|Trans500.yml|Trans
trans500.com/tourespanol|Trans500espanol|Trans

Perhaps using Subscraper, could combine them into one, and support the "standard url path" with all fields from both.