### PR TITLE
Tonights Girlfriend - Fix titles, set studio, and grab canonical URLs

### DIFF
--- a/scrapers/Tonightsgirlfriend.yml
+++ b/scrapers/Tonightsgirlfriend.yml
@@ -12,7 +12,7 @@ xPathScrapers:
       Title:
         selector: //head/title/text()
         replace:
-          - regex: " \\| TonightsGirlfriend\\.com"
+          - regex: \sHD\sPorn\s\|\sTonightsGirlfriend\.com
             with:
       Date:
         selector: $sceneinfo/p/span/text()
@@ -24,3 +24,9 @@ xPathScrapers:
       Performers:
         Name: $sceneinfo/p/a
       Image: //img[@class="playcard"]/@src
+      Studio:
+        Name:
+          fixed: "Tonight's Girlfriend"
+      URL: //link[@rel='canonical']/@href
+
+# Last Updated September 2, 2020


### PR DESCRIPTION
This fixes the titles in TG scenes as they were previous coming in with `HD Porn` on the end of their titles.

While I was in here I added a fixed value for the Studio and grabbed canonical URLs (sometimes the URL from navigating to the scene are weird and have extra parameters on them, this cleans up the one we keep on file. EX `https://www.tonightsgirlfriend.com/scenes/tngf_phoenixjohnny2-19253/?&nats=4.10025.58.80.2.0.0.0.0` VS the canonical `https://www.tonightsgirlfriend.com/scenes/phoenix-marie-19253`)

_And added a last updated date_