### PR TITLE
Adding Url Matching for AdultDvdMarketPlace.yml 

### DIFF
--- a/scrapers/AdultDvdMarketPlace.yml
+++ b/scrapers/AdultDvdMarketPlace.yml
@@ -4,6 +4,7 @@ movieByURL:
   - action: scrapeXPath
     url:
       - adultdvdmarketplace.com/xcart/adult_dvd/dvd_view.php?adult_dvd_id=
+      - adultdvdmarketplace.com/dvd_view
     scraper: movieScraper
 
 xPathScrapers:
@@ -21,4 +22,4 @@ xPathScrapers:
       FrontImage: //strong[contains(text(),"Large Front")]/parent::a/@href
       BackImage: //strong[contains(text(),"Large Back")]/parent::a/@href
 
-# Last Updated August 30, 2020
+# Last Updated September 07, 2020


### PR DESCRIPTION
I don't know how you get the `adultdvdmarketplace.com/xcart/adult_dvd/dvd_view.php?adult_dvd_id=` URL.