### PR TITLE
Add a gitignore entry for .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
This is just a quality of life feature. I need to constantly delete `.DS_Store` files to avoid accidentally committing them. 