### PR TITLE
Adds GirlsRimming xPath scraper

### DIFF
--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -213,6 +213,7 @@ girlgirl.com|JulesJordan.yml|Lesbian
 girlsandstuds.com|GammaEntertainment.yml|
 girlsgotcream.com|Teencoreclub.yml|
 girlsoutwest.com|GirlsOutWest.yml|Lesbian
+girlsrimming.com|GirlsRimming.yml|Rimjobs
 girlstryanal.com|GammaEntertainment.yml|Lesbian
 gloryholeswallow.com|GloryHoleSwallow.yml|
 grannyghetto.com|GammaEntertainment.yml|Granny

--- a/scrapers/GirlsRimming.yml
+++ b/scrapers/GirlsRimming.yml
@@ -1,0 +1,32 @@
+name: "GirlsRimming"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - girlsrimming.com
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class='updatesBlock']/h2[@class='title']/text()
+      Details: //meta[@name='description']/@content
+      Image: //div[@class='player-thumb']/img/@src0_1x
+      Studio:
+        Name:
+          fixed: GirlsRimming
+      Movies:
+        Name:
+          selector: //div[@class='updatesBlock']/h2[@class='title']/text()
+          postProcess:
+            - replace:
+              - regex: (.+)(?:\sEp\d).*
+                with: $1
+      Tags:
+        Name:
+          selector: //meta[@name='keywords']/@content
+          postProcess:
+            - replace:
+                - regex: "[^,]*Id\\s(\\d+)[^,]*"
+                  with:
+          split: ","
+
+# Last Updated September 30, 2020


### PR DESCRIPTION
Things of note:

- The performer names are listed below each video in related videos and on the performer pages like `https://www.girlsrimming.com/tour/models/alessa-savage.html`, however I could not find a want with a subscraper to get there

- Anything that is part of a series has a date listed on here `https://www.girlsrimming.com/tour/series/series.html` but again, couldn't find a way to get what I need with a subscraper

- Most video has their tags properly listed in the keywords metafield. There are a few poorly entered scenes though like `https://www.girlsrimming.com/tour/trailers/Switch-Me-On-Ep2-Rim-the-Realtor.html` where for some reason the tags field contains a copy of the scene description instead.