### PR TITLE
Update Javlibrary

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ adultdvdempire.com|AdultEmpire.yml
 aebn.com|AEBN.yml
 evilangel.com|GammaEntertainment.yml
 iafd.com|Iafd.yml
+javlibrary.com (+mirror)|javlibrary.yml
 julesjordan.com|JulesJordan.yml
 private.com|Private.yml
 streaming.iafd.com|IafdStreaming.yml

--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -565,7 +565,6 @@ tushyraw.com|vixenNetwork.yml|
 twistedvisual.com|Analized.yml|
 twistys.com|MindGeek.yml|
 twistysnetwork.com|MindGeek.yml|
-u44r.com|javlibrary.yml|JAV
 unlimitedmilfs.com|NewSensationsNetworkSites.yml|
 vcaxxx.com|Hustler.yml|
 vickyathome.com|VNAGirls.yml|

--- a/SCENE-SCRAPABLE.md
+++ b/SCENE-SCRAPABLE.md
@@ -50,6 +50,7 @@ asiantgirl.com|GroobyNetwork-Partial.yml|Trans
 assholefever.com|GammaEntertainment.yml|
 assmeat.com|Hustler.yml|
 assteenmouth.com|Teencoreclub.yml|
+b47w.com|javlibrary.yml|JAV
 babes.com|RealityKingsOL.yml|
 babesnetwork.com|MindGeek.yml|
 babevr.com|BaDoink.yml|VR

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -9,7 +9,6 @@ sceneByURL:
     url:
       - javlibrary.com/
       - m45e.com/
-      - u44r.com/
       - g46e.com/
       - b47w.com/
     scraper: sceneScraper
@@ -18,7 +17,6 @@ movieByURL:
     url:
       - javlibrary.com/
       - m45e.com/
-      - u44r.com/
       - g46e.com/
       - b47w.com/
     scraper: movieScraper

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -1,4 +1,9 @@
-name: javlibrary
+name: JavLibrary
+sceneByFragment:
+  action: scrapeXPath
+  queryURL: https://www.javlibrary.com/en/vl_searchbyid.php?keyword={title}
+  #Note: Use the title of your scene. So if your filename is SSNI-000.mp4, remove the extension, save, then use the scraper
+  scraper: sceneScraper
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -6,28 +11,69 @@ sceneByURL:
       - m45e.com/
       - u44r.com/
       - g46e.com/
+      - b47w.com/
     scraper: sceneScraper
+movieByURL:
+  - action: scrapeXPath
+    url:
+      - javlibrary.com/
+      - m45e.com/
+      - u44r.com/
+      - g46e.com/
+      - b47w.com/
+    scraper: movieScraper
 xPathScrapers:
   sceneScraper:
     scene:
       Title: //div[@id="video_id"]/table/tbody/tr/td[@class="text"]/text()
+      # Using URL to still get a URL with sceneByFragment if a duplicate exist.
+      URL: 
+        selector: //div[@class="videos"]/div/a/@title[not(contains(.,"(Blu-ray"))]/../@href|//meta[@property="og:url"]/@content
+        postProcess:
+          - replace:
+            - regex: (.*\?)(.*)
+              with: $2
+            - regex: ^
+              with: https://www.javlibrary.com/en/?
       Date:
         selector: //div[@id="video_date"]/table/tbody/tr/td[@class="text"]/text()
       Details:
         selector: //div[@id="video_title"]/h3/a/text()
-        replace:
-          - regex: ^(.*? ){1}
-            with:
+        postProcess:
+          - replace:
+            - regex: ^(.*? ){1}
+              with:
       Tags:
         Name: //div[@id="video_genres"]/table/tbody/tr/td[@class="text"]/span/a
       Performers:
         Name: //div[@id="video_cast"]/table/tbody/tr/td[@class="text"]/span/span/a
       Image:
         selector: //div[@id="video_jacket"]/img/@src
-        replace:
-          - regex: ^
-            with: "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
       Studio:
         Name: //div[@id="video_maker"]/table/tbody/tr/td[@class="text"]/span/a/text()
+  movieScraper:
+    movie:
+      Name: //div[@id="video_id"]/table/tbody/tr/td[@class="text"]/text()
+      Director: //div[@id='video_director']/table/tbody/tr/td[@class="text"]/span/a/text()
+      Duration: //div[@id="video_length"]/table/tbody/tr/td/span[@class="text"]/text()
+      Date: //div[@id="video_date"]/table/tbody/tr/td[@class="text"]/text()
+      Synopsis: 
+        selector: //div[@id="video_title"]/h3/a/text()
+        postProcess:
+          - replace:
+            - regex: ^(.*? ){1}
+              with:
+      Studio:
+        Name: //div[@id="video_maker"]/table/tbody/tr/td[@class="text"]/span/a/text()
+      FrontImage:
+        selector: //div[@id="video_jacket"]/img/@src
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
 
-# Last Updated October 3, 2020
+# Last Updated October 12, 2020


### PR DESCRIPTION
Look like the mirror u44r.com became b47w.com.

- Added sceneByFragment

Use the title to try to find the scene on Javlibrary (you can use mirror too, just replace javlibrary.com). 
**The title must have no extension.** (Like SSNI-000). 
So just remove the extension in Scene edit then save then scrape...

- Added Movie scraper

Sometimes scenes are split in different file since JAV is sometimes more than 4 hours. So the movie scraper can be used to create a link between these files.

-------

Since the `sceneByFragment` need some instruction to use it, i am not sure if it's a good idea to made it...

Note: Cloudflare block the Javlibrary.com atm, try with b47w