### PR TITLE
Fix invalid scrapers

### DIFF
--- a/scrapers/FrolicMe.yml
+++ b/scrapers/FrolicMe.yml
@@ -21,7 +21,7 @@ xPathScrapers:
           - replace:
               - regex: .*(datePublished":")(\d{4}-\d{2}-\d{2}).*
                 with: $2
-              - parseDate: 2006-01-02
+          - parseDate: 2006-01-02
       Details:
         selector: //h1[@class="film-entry-description"]|//div[@class="film-content"]/p
         concat: "\n\n"

--- a/scrapers/Mypervmom.yml
+++ b/scrapers/Mypervmom.yml
@@ -22,7 +22,6 @@ xPathScrapers:
         replace:
           - regex: ^Description\:(.+)
             with: $1
-      Name: //div[@class="tags"]//a/text()
       Performers:
         Name: //div[@id="title-single"]//a
       Image:

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -38,7 +38,6 @@ sceneByURL:
       - kendrajames.com
       - maxinex.com
       - povmania.com
-      - maxinex.com
       - girlgirlmania.com
     scraper: sceneScraper
 xPathScrapers:


### PR DESCRIPTION
Fixes invalid scraper configurations on:
- `FrolicMe.yml`: `parseDate` was inside `replace`.
- `Mypervmom.yml`: Odd tag name selector. Sites don't seem to list tags so I just removed the selector.
- `VNAGirls.yml`: Duplicate URL.