### PR TITLE
Update all scrapers to use `postProcess`

### DIFF
--- a/scrapers/21Roles.yml
+++ b/scrapers/21Roles.yml
@@ -12,18 +12,18 @@ xPathScrapers:
         selector: //title/text()
         postProcess:
           - replace:
-            - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
-              with: $1
+              - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
+                with: $1
       Details: //div[@class="info"]/p/text()
       Tags:
         Name:
           selector: //title/text()
           postProcess:
             - replace:
-              - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
-                with: https://21roles.com/site/search/keyword/$1
-              - regex: (.+)(?:\s-\sInteractive).+
-                with: https://lifeselector.com/site/search/keyword/$1
+                - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
+                  with: https://21roles.com/site/search/keyword/$1
+                - regex: (.+)(?:\s-\sInteractive).+
+                  with: https://lifeselector.com/site/search/keyword/$1
             - subScraper:
                 selector: //div[@class="details"]/div[contains(.,'Labels')]//a/text()
                 concat: ","
@@ -33,8 +33,8 @@ xPathScrapers:
           selector: //div[@class="modelBlock"]/div[@class="description"]/h1/a/text()
           postProcess:
             - replace:
-              - regex: .+(?:\/)(\d+)+
-                with: https://21roles.com/game/DisplayPlayer/gameId/$1/view/cast
+                - regex: .+(?:\/)(\d+)+
+                  with: https://21roles.com/game/DisplayPlayer/gameId/$1/view/cast
             - subScraper:
                 selector: //div[@class="content"]//h1/a/text()
                 concat: ","
@@ -43,8 +43,8 @@ xPathScrapers:
         selector: //div[@class="signup-right-col"]//input[@id="requestUri"]/@value
         postProcess:
           - replace:
-            - regex: .+(?:\/)(\d+)+
-              with: https://i.c7cdn.com/generator/games/$1/images/poster/1_size1600.jpg
+              - regex: .+(?:\/)(\d+)+
+                with: https://i.c7cdn.com/generator/games/$1/images/poster/1_size1600.jpg
       Studio:
         Name:
           selector: //meta[@property='og:site_name']/@content

--- a/scrapers/21Roles.yml
+++ b/scrapers/21Roles.yml
@@ -10,37 +10,41 @@ xPathScrapers:
     scene:
       Title:
         selector: //title/text()
-        replace:
-          - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
+              with: $1
       Details: //div[@class="info"]/p/text()
       Tags:
         Name:
           selector: //title/text()
-          replace:
-            - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
-              with: https://21roles.com/site/search/keyword/$1
-            - regex: (.+)(?:\s-\sInteractive).+
-              with: https://lifeselector.com/site/search/keyword/$1
-          subScraper:
-            selector: //div[@class="details"]/div[contains(.,'Labels')]//a/text()
-            concat: ","
+          postProcess:
+            - replace:
+              - regex: .+(?:DisplayPlayer\s-\s)(.+)(?:\s-\sDisplayPlayer)+
+                with: https://21roles.com/site/search/keyword/$1
+              - regex: (.+)(?:\s-\sInteractive).+
+                with: https://lifeselector.com/site/search/keyword/$1
+            - subScraper:
+                selector: //div[@class="details"]/div[contains(.,'Labels')]//a/text()
+                concat: ","
           split: ","
       Performers:
         Name:
           selector: //div[@class="modelBlock"]/div[@class="description"]/h1/a/text()
-          replace:
-            - regex: .+(?:\/)(\d+)+
-              with: https://21roles.com/game/DisplayPlayer/gameId/$1/view/cast
-          subScraper:
-            selector: //div[@class="content"]//h1/a/text()
-            concat: ","
+          postProcess:
+            - replace:
+              - regex: .+(?:\/)(\d+)+
+                with: https://21roles.com/game/DisplayPlayer/gameId/$1/view/cast
+            - subScraper:
+                selector: //div[@class="content"]//h1/a/text()
+                concat: ","
           split: ","
       Image:
         selector: //div[@class="signup-right-col"]//input[@id="requestUri"]/@value
-        replace:
-          - regex: .+(?:\/)(\d+)+
-            with: https://i.c7cdn.com/generator/games/$1/images/poster/1_size1600.jpg
+        postProcess:
+          - replace:
+            - regex: .+(?:\/)(\d+)+
+              with: https://i.c7cdn.com/generator/games/$1/images/poster/1_size1600.jpg
       Studio:
         Name:
           selector: //meta[@property='og:site_name']/@content

--- a/scrapers/21Roles.yml
+++ b/scrapers/21Roles.yml
@@ -58,4 +58,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated October 12, 2020
+# Last Updated November 4, 2020

--- a/scrapers/21Roles.yml
+++ b/scrapers/21Roles.yml
@@ -58,4 +58,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -76,3 +76,5 @@ xPathScrapers:
               with: "https:"
             - regex: "\\?s=293w"
               with:
+
+# Last Updated November 4, 2020

--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -13,16 +13,17 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //h1[@class="dts-section-page-heading-title"]|//div[@class="dts-section-page-heading-title"]/h1
-      Date: 
+      Date:
         selector: //li[@class="section-detail-list-item-release-date"]//text()
-        replace:
-          - regex: "Released:"
-            with:
-          - regex: ","
-            with:
-          - regex: "Sept"
-            with: "Sep" 
-        parseDate: Jan 2 2006
+        postProcess:
+          - replace:
+            - regex: "Released:"
+              with:
+            - regex: ","
+              with:
+            - regex: "Sept"
+              with: "Sep"
+          - parseDate: Jan 2 2006
       Details:
         selector: //div[@class="dts-section-page-detail-description-body"]//text()
       Performers:
@@ -31,11 +32,12 @@ xPathScrapers:
         Name: //span[@class="dts-image-display-name"]//text()
       Image:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
-        replace:
-          - regex: ^
-            with: "https:"
-          - regex: "\\?s=293w"
-            with:
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
+            - regex: "\\?s=293w"
+              with:
 
   movieScraper:
     movie:
@@ -44,30 +46,33 @@ xPathScrapers:
         selector: //li[@class='section-detail-list-item-director']//span//a
         concat: ", "
       Duration: //li[@class='section-detail-list-item-duration']/text()
-      Date: 
+      Date:
         selector: //li[@class="section-detail-list-item-release-date"]
-        replace:
-          - regex: "Released:"
-            with:
-          - regex: ","
-            with:
-          - regex: "Sept"
-            with: "Sep" 
-        parseDate: Jan 2 2006
+        postProcess:
+          - replace:
+            - regex: "Released:"
+              with:
+            - regex: ","
+              with:
+            - regex: "Sept"
+              with: "Sep"
+          - parseDate: Jan 2 2006
       Synopsis: //div[@class="dts-section-page-detail-description-body"]//text()
       Studio:
         Name: //div[@class='dts-studio-name-wrapper']/a/text()
       FrontImage:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
-        replace:
-          - regex: ^
-            with: "https:"
-          - regex: "\\?s=293w"
-            with:
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
+            - regex: "\\?s=293w"
+              with:
       BackImage:
         selector: //picture[@class="dts-movie-boxcover-back"]/img/@src
-        replace:
-          - regex: ^
-            with: "https:"
-          - regex: "\\?s=293w"
-            with:
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
+            - regex: "\\?s=293w"
+              with:

--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -17,12 +17,12 @@ xPathScrapers:
         selector: //li[@class="section-detail-list-item-release-date"]//text()
         postProcess:
           - replace:
-            - regex: "Released:"
-              with:
-            - regex: ","
-              with:
-            - regex: "Sept"
-              with: "Sep"
+              - regex: "Released:"
+                with:
+              - regex: ","
+                with:
+              - regex: "Sept"
+                with: "Sep"
           - parseDate: Jan 2 2006
       Details:
         selector: //div[@class="dts-section-page-detail-description-body"]//text()
@@ -34,10 +34,10 @@ xPathScrapers:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
-            - regex: "\\?s=293w"
-              with:
+              - regex: ^
+                with: "https:"
+              - regex: "\\?s=293w"
+                with:
 
   movieScraper:
     movie:
@@ -50,12 +50,12 @@ xPathScrapers:
         selector: //li[@class="section-detail-list-item-release-date"]
         postProcess:
           - replace:
-            - regex: "Released:"
-              with:
-            - regex: ","
-              with:
-            - regex: "Sept"
-              with: "Sep"
+              - regex: "Released:"
+                with:
+              - regex: ","
+                with:
+              - regex: "Sept"
+                with: "Sep"
           - parseDate: Jan 2 2006
       Synopsis: //div[@class="dts-section-page-detail-description-body"]//text()
       Studio:
@@ -64,17 +64,17 @@ xPathScrapers:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
-            - regex: "\\?s=293w"
-              with:
+              - regex: ^
+                with: "https:"
+              - regex: "\\?s=293w"
+                with:
       BackImage:
         selector: //picture[@class="dts-movie-boxcover-back"]/img/@src
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
-            - regex: "\\?s=293w"
-              with:
+              - regex: ^
+                with: "https:"
+              - regex: "\\?s=293w"
+                with:
 
 # Last Updated November 4, 2020

--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -77,4 +77,4 @@ xPathScrapers:
               - regex: "\\?s=293w"
                 with:
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/AllHerLuv.yml
+++ b/scrapers/AllHerLuv.yml
@@ -27,4 +27,4 @@ xPathScrapers:
             - regex: .+(?:poster=")([^"]*).+
               with: https://www.allherluv.com$1
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/AllHerLuv.yml
+++ b/scrapers/AllHerLuv.yml
@@ -10,10 +10,11 @@ xPathScrapers:
       Title: //p[@class="raiting-section__title"]/text()
       Date:
         selector: //p[@class="dvd-scenes__data"][1]/text()[1]
-        replace:
-          - regex: (?:.+Added:\s)([\d/]*).+
-            with: $1
-        parseDate: 01/02/2006
+        postProcess:
+          - replace:
+            - regex: (?:.+Added:\s)([\d/]*).+
+              with: $1
+          - parseDate: 01/02/2006
       Details: //strong/text()
       Tags:
         Name: //p[@class="dvd-scenes__data"][2]/a/text()
@@ -21,8 +22,9 @@ xPathScrapers:
         Name: //p[@class="dvd-scenes__data"][1]/a/text()
       Image:
         selector: //script[contains(text(),'hidden_fake_trailer')]/text()
-        replace:
-          - regex: .+(?:poster=")([^"]*).+
-            with: https://www.allherluv.com$1
+        postProcess:
+          - replace:
+            - regex: .+(?:poster=")([^"]*).+
+              with: https://www.allherluv.com$1
 
 # Last Updated October 3, 2020

--- a/scrapers/AllHerLuv.yml
+++ b/scrapers/AllHerLuv.yml
@@ -12,8 +12,8 @@ xPathScrapers:
         selector: //p[@class="dvd-scenes__data"][1]/text()[1]
         postProcess:
           - replace:
-            - regex: (?:.+Added:\s)([\d/]*).+
-              with: $1
+              - regex: (?:.+Added:\s)([\d/]*).+
+                with: $1
           - parseDate: 01/02/2006
       Details: //strong/text()
       Tags:
@@ -24,7 +24,7 @@ xPathScrapers:
         selector: //script[contains(text(),'hidden_fake_trailer')]/text()
         postProcess:
           - replace:
-            - regex: .+(?:poster=")([^"]*).+
-              with: https://www.allherluv.com$1
+              - regex: .+(?:poster=")([^"]*).+
+                with: https://www.allherluv.com$1
 
 # Last Updated November 4, 2020

--- a/scrapers/AllHerLuv.yml
+++ b/scrapers/AllHerLuv.yml
@@ -27,4 +27,4 @@ xPathScrapers:
               - regex: .+(?:poster=")([^"]*).+
                 with: https://www.allherluv.com$1
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/AmateurAllure.yml
+++ b/scrapers/AmateurAllure.yml
@@ -35,4 +35,4 @@ xPathScrapers:
                 - replace:
                   - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
                     with: https://www.amateurallure.com$1
-# Last Updated July 09, 2020
+# Last Updated November 4, 2020

--- a/scrapers/AmateurAllure.yml
+++ b/scrapers/AmateurAllure.yml
@@ -25,14 +25,14 @@ xPathScrapers:
         selector: $title
         postProcess:
           - replace:
-            - regex: \s
-              with: "+"
-            - regex: ^
-              with: "https://www.amateurallure.com/tour/search.php?st=advanced&qall=&qany=&qex="
+              - regex: \s
+                with: "+"
+              - regex: ^
+                with: "https://www.amateurallure.com/tour/search.php?st=advanced&qall=&qany=&qex="
           - subScraper:
               selector: //img/@srcset
               postProcess:
                 - replace:
-                  - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
-                    with: https://www.amateurallure.com$1
+                    - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
+                      with: https://www.amateurallure.com$1
 # Last Updated November 4, 2020

--- a/scrapers/AmateurAllure.yml
+++ b/scrapers/AmateurAllure.yml
@@ -35,4 +35,4 @@ xPathScrapers:
                 - replace:
                     - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
                       with: https://www.amateurallure.com$1
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/AmateurAllure.yml
+++ b/scrapers/AmateurAllure.yml
@@ -14,7 +14,8 @@ xPathScrapers:
       Title: $title
       Date:
         selector: //div[@class='cell update_date']
-        parseDate: 01/02/2006
+        postProcess:
+          - parseDate: 01/02/2006
       Details: //span[@class='update_description']
       Tags:
         Name: //span[@class='update_tags']//a/text()
@@ -22,14 +23,16 @@ xPathScrapers:
         Name: //span[@class='update_models']//a
       Image:
         selector: $title
-        replace:
-          - regex: \s
-            with: "+"
-          - regex: ^
-            with: "https://www.amateurallure.com/tour/search.php?st=advanced&qall=&qany=&qex="
-        subScraper:
-            selector: //img/@srcset
-            replace:
-              - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
-                with: https://www.amateurallure.com$1
+        postProcess:
+          - replace:
+            - regex: \s
+              with: "+"
+            - regex: ^
+              with: "https://www.amateurallure.com/tour/search.php?st=advanced&qall=&qany=&qex="
+          - subScraper:
+              selector: //img/@srcset
+              postProcess:
+                - replace:
+                  - regex: .+(/tour/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
+                    with: https://www.amateurallure.com$1
 # Last Updated July 09, 2020

--- a/scrapers/AngelaWhite.yml
+++ b/scrapers/AngelaWhite.yml
@@ -32,8 +32,8 @@ xPathScrapers:
           selector: $search
           postProcess:
             - replace:
-              - regex: (^\d+)\s.+
-                with: "http://angelawhite.com/tour/search?query=$1"
+                - regex: (^\d+)\s.+
+                  with: "http://angelawhite.com/tour/search?query=$1"
             - subScraper:
                 selector: //div[@class="categories-list"]/a/text()
                 concat: ","
@@ -42,18 +42,18 @@ xPathScrapers:
         selector: $search
         postProcess:
           - replace:
-            - regex: \s
-              with: "+"
-            - regex: ^
-              with: "http://angelawhite.com/tour/search?query=\""
-            - regex: $
-              with: "\""
+              - regex: \s
+                with: "+"
+              - regex: ^
+                with: "http://angelawhite.com/tour/search?query=\""
+              - regex: $
+                with: "\""
           - subScraper:
               selector: //img/@src0
               postProcess:
                 - replace:
-                  - regex: ^
-                    with: http://angelawhite.com
+                    - regex: ^
+                      with: http://angelawhite.com
       Studio:
         Name: //a[@class="logo-aw"]/@title
 

--- a/scrapers/AngelaWhite.yml
+++ b/scrapers/AngelaWhite.yml
@@ -13,42 +13,47 @@ xPathScrapers:
       Title: $info/h2/text()
       Date:
         selector: $info/span/text()
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details: $info//p/text()
       Performers:
         Name:
           selector: $search
-          replace:
-            - regex: (^\d+)\s.+
-              with: "http://angelawhite.com/tour/search?query=$1"
-          subScraper:
-            selector: //div[@class="models-list"]/a/text()
-            concat: ","
+          postProcess:
+            - replace:
+                - regex: (^\d+)\s.+
+                  with: "http://angelawhite.com/tour/search?query=$1"
+            - subScraper:
+                selector: //div[@class="models-list"]/a/text()
+                concat: ","
           split: ","
       Tags:
         Name:
           selector: $search
-          replace:
-            - regex: (^\d+)\s.+
-              with: "http://angelawhite.com/tour/search?query=$1"
-          subScraper:
-            selector: //div[@class="categories-list"]/a/text()
-            concat: ","
+          postProcess:
+            - replace:
+              - regex: (^\d+)\s.+
+                with: "http://angelawhite.com/tour/search?query=$1"
+            - subScraper:
+                selector: //div[@class="categories-list"]/a/text()
+                concat: ","
           split: ","
       Image:
         selector: $search
-        replace:
-          - regex: \s
-            with: "+"
-          - regex: ^
-            with: "http://angelawhite.com/tour/search?query=\""
-          - regex: $
-            with: "\""
-        subScraper:
-          selector: //img/@src0
-          replace:
+        postProcess:
+          - replace:
+            - regex: \s
+              with: "+"
             - regex: ^
-              with: http://angelawhite.com
+              with: "http://angelawhite.com/tour/search?query=\""
+            - regex: $
+              with: "\""
+          - subScraper:
+              selector: //img/@src0
+              postProcess:
+                - replace:
+                  - regex: ^
+                    with: http://angelawhite.com
       Studio:
         Name: //a[@class="logo-aw"]/@title
 

--- a/scrapers/AngelaWhite.yml
+++ b/scrapers/AngelaWhite.yml
@@ -57,4 +57,4 @@ xPathScrapers:
       Studio:
         Name: //a[@class="logo-aw"]/@title
 
-# Last Updated June 18, 2020
+# Last Updated November 4, 2020

--- a/scrapers/AngelaWhite.yml
+++ b/scrapers/AngelaWhite.yml
@@ -57,4 +57,4 @@ xPathScrapers:
       Studio:
         Name: //a[@class="logo-aw"]/@title
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ArchAngelVideo.yml
+++ b/scrapers/ArchAngelVideo.yml
@@ -37,4 +37,4 @@ xPathScrapers:
       Performers:
         Name: $videoContent//a[contains(@href, "/models/")]/text()
 
-# Last Updated July 21, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ArchAngelVideo.yml
+++ b/scrapers/ArchAngelVideo.yml
@@ -14,23 +14,26 @@ xPathScrapers:
       Date:
         selector: $videoContent//ul[@class="item-meta"]//li[1]/text()
         concat: " "
-        replace:
-          - regex: " "
-            with:
-        parseDate: January2,2006
-      Studio:
-        Name: 
-          selector: //div[@id="logo"]/h1/a/img/@alt
-          replace:
-            - regex: \ Productions$
+        postProcess:
+          - replace:
+            - regex: " "
               with:
+          - parseDate: January2,2006
+      Studio:
+        Name:
+          selector: //div[@id="logo"]/h1/a/img/@alt
+          postProcess:
+            - replace:
+              - regex: \ Productions$
+                with:
       Image:
         selector: //div[@class="player-thumb"]/img/@src0_1x|//script[contains(.,"poster=")]
-        replace:
-          - regex: .+poster="([^"]+)".+
-            with: $1
-          - regex: ^
-            with: "https://www.archangelvideo.com"
+        postProcess:
+          - replace:
+            - regex: .+poster="([^"]+)".+
+              with: $1
+            - regex: ^
+              with: "https://www.archangelvideo.com"
       Performers:
         Name: $videoContent//a[contains(@href, "/models/")]/text()
 

--- a/scrapers/ArchAngelVideo.yml
+++ b/scrapers/ArchAngelVideo.yml
@@ -37,4 +37,4 @@ xPathScrapers:
       Performers:
         Name: $videoContent//a[contains(@href, "/models/")]/text()
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ArchAngelVideo.yml
+++ b/scrapers/ArchAngelVideo.yml
@@ -16,24 +16,24 @@ xPathScrapers:
         concat: " "
         postProcess:
           - replace:
-            - regex: " "
-              with:
+              - regex: " "
+                with:
           - parseDate: January2,2006
       Studio:
         Name:
           selector: //div[@id="logo"]/h1/a/img/@alt
           postProcess:
             - replace:
-              - regex: \ Productions$
-                with:
+                - regex: \ Productions$
+                  with:
       Image:
         selector: //div[@class="player-thumb"]/img/@src0_1x|//script[contains(.,"poster=")]
         postProcess:
           - replace:
-            - regex: .+poster="([^"]+)".+
-              with: $1
-            - regex: ^
-              with: "https://www.archangelvideo.com"
+              - regex: .+poster="([^"]+)".+
+                with: $1
+              - regex: ^
+                with: "https://www.archangelvideo.com"
       Performers:
         Name: $videoContent//a[contains(@href, "/models/")]/text()
 

--- a/scrapers/AssTraffic.yml
+++ b/scrapers/AssTraffic.yml
@@ -19,8 +19,8 @@ xPathScrapers:
         selector: //div[@class="container"]//span[contains(.,"Added")]/text()
         postProcess:
           - replace:
-            - regex: "Added "
-              with:
+              - regex: "Added "
+                with:
           - parseDate: January 2, 2006
       Details: //p[@class="mg-md"]/text()
       Performers:

--- a/scrapers/AssTraffic.yml
+++ b/scrapers/AssTraffic.yml
@@ -61,4 +61,4 @@ xPathScrapers:
         fixed: Female
       Image:
         selector: //div[@class='col-md-8 bigmodelpic']/img/@sr
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/AssTraffic.yml
+++ b/scrapers/AssTraffic.yml
@@ -61,4 +61,4 @@ xPathScrapers:
         fixed: Female
       Image:
         selector: //div[@class='col-md-8 bigmodelpic']/img/@sr
-#Last Updated August 12, 2020
+# Last Updated November 4, 2020

--- a/scrapers/AssTraffic.yml
+++ b/scrapers/AssTraffic.yml
@@ -17,10 +17,11 @@ xPathScrapers:
       Title: //h2
       Date:
         selector: //div[@class="container"]//span[contains(.,"Added")]/text()
-        replace:
-          - regex: "Added "
-            with:
-        parseDate: January 2, 2006
+        postProcess:
+          - replace:
+            - regex: "Added "
+              with:
+          - parseDate: January 2, 2006
       Details: //p[@class="mg-md"]/text()
       Performers:
         Name: //div[@id="video-info"]//a[contains(@href,'/models')]/text()

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -31,4 +31,4 @@ xPathScrapers:
         Name: //meta[@name="dl8-customization-brand-name"]/@content
       Image: //img[@class="video-image"]/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -19,8 +19,8 @@ xPathScrapers:
         selector: $details//p[@class="video-upload-date"]/text()
         postProcess:
           - replace:
-            - regex: Uploaded:\s
-              with:
+              - regex: Uploaded:\s
+                with:
           - parseDate: January 02, 2006
       Details: $details//p[@class="video-description"]/text()
       Tags:

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -31,4 +31,4 @@ xPathScrapers:
         Name: //meta[@name="dl8-customization-brand-name"]/@content
       Image: //img[@class="video-image"]/@src
 
-# Last Updated July 11, 2020
+# Last Updated November 4, 2020

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -17,10 +17,11 @@ xPathScrapers:
       Title: $details/h1/text()
       Date:
         selector: $details//p[@class="video-upload-date"]/text()
-        replace:
-          - regex: Uploaded:\s
-            with:
-        parseDate: January 02, 2006
+        postProcess:
+          - replace:
+            - regex: Uploaded:\s
+              with:
+          - parseDate: January 02, 2006
       Details: $details//p[@class="video-description"]/text()
       Tags:
         Name: $details//p[@class="video-tags"]//a/text()

--- a/scrapers/Backroomcastingcouch.yml
+++ b/scrapers/Backroomcastingcouch.yml
@@ -15,10 +15,11 @@ xPathScrapers:
       Name: //title/text()
       Image:
         selector: //a[@id='Main_PicLink']/img/@src
-        # URL is a partial url, add the first part
-        replace:
-          - regex: ^
-            with: https://backroomcastingcouch.com
+        postProcess:
+          # URL is a partial url, add the first part
+          - replace:
+            - regex: ^
+              with: https://backroomcastingcouch.com
   sceneScraper:
     common:
       $performer: //title/text()
@@ -34,7 +35,8 @@ xPathScrapers:
         Name: $studio/text()
       Image:
         selector: //a[@id='Main_PicLink']/img/@src
-        # URL is a partial url, add the first part
-        replace:
-          - regex: ^
-            with: https://backroomcastingcouch.com
+        postProcess:
+          # URL is a partial url, add the first part
+          - replace:
+            - regex: ^
+              with: https://backroomcastingcouch.com

--- a/scrapers/Backroomcastingcouch.yml
+++ b/scrapers/Backroomcastingcouch.yml
@@ -18,8 +18,8 @@ xPathScrapers:
         postProcess:
           # URL is a partial url, add the first part
           - replace:
-            - regex: ^
-              with: https://backroomcastingcouch.com
+              - regex: ^
+                with: https://backroomcastingcouch.com
   sceneScraper:
     common:
       $performer: //title/text()
@@ -38,7 +38,7 @@ xPathScrapers:
         postProcess:
           # URL is a partial url, add the first part
           - replace:
-            - regex: ^
-              with: https://backroomcastingcouch.com
+              - regex: ^
+                with: https://backroomcastingcouch.com
 
 # Last Updated November 4, 2020

--- a/scrapers/Backroomcastingcouch.yml
+++ b/scrapers/Backroomcastingcouch.yml
@@ -41,4 +41,4 @@ xPathScrapers:
               - regex: ^
                 with: https://backroomcastingcouch.com
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Backroomcastingcouch.yml
+++ b/scrapers/Backroomcastingcouch.yml
@@ -40,3 +40,5 @@ xPathScrapers:
           - replace:
             - regex: ^
               with: https://backroomcastingcouch.com
+
+# Last Updated November 4, 2020

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -34,4 +34,4 @@ driver:
   useCDP: true
   sleep: 5
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -34,4 +34,4 @@ driver:
   useCDP: true
   sleep: 5
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -12,15 +12,16 @@ xPathScrapers:
       Image:
         selector: //meta[@name="og:image"]/@content
         postProcess:
-            - replace:
-                - regex: (.+)(\?.+)
-                  with: $1
+          - replace:
+            - regex: (.+)(\?.+)
+              with: $1
       Date:
         selector: //span[@class="hidden-xs fa-text-right fa-text-left"]/text()
-        replace:
-          - regex: (\w+\s)(\d+)\w+,(\s\d{4})
-            with: $1$2$3
-        parseDate: Jan 2 2006
+        postProcess:
+          - replace:
+            - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+              with: $1$2$3
+          - parseDate: Jan 2 2006
       Tags:
         Name:
           selector: //div[@class="genres bottom-buffer10"]/a

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -13,14 +13,14 @@ xPathScrapers:
         selector: //meta[@name="og:image"]/@content
         postProcess:
           - replace:
-            - regex: (.+)(\?.+)
-              with: $1
+              - regex: (.+)(\?.+)
+                with: $1
       Date:
         selector: //span[@class="hidden-xs fa-text-right fa-text-left"]/text()
         postProcess:
           - replace:
-            - regex: (\w+\s)(\d+)\w+,(\s\d{4})
-              with: $1$2$3
+              - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+                with: $1$2$3
           - parseDate: Jan 2 2006
       Tags:
         Name:

--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -33,4 +33,4 @@ xPathScrapers:
               selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
           - parseDate: Jan 2, 2006
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -17,18 +17,20 @@ xPathScrapers:
       Image:
         selector: //video/@poster
         #selector: //img[@id="player-overlay-image"]/@src # Better image but can fail on older scenes
-        replace:
-          - regex: ^
-            with: "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
       Studio:
         Name: //div[@class="vdoCast"]/a[1]/text()
       Date:
         selector: //div[@class="vdoCast" and contains(text(), "Release:")]
-        replace:
-          - regex: "^Release: "
-            with: "https://bangbros.com/search/"
-        subScraper:
-          selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
-        parseDate: Jan 2, 2006
+        postProcess:
+          - replace:
+            - regex: "^Release: "
+              with: "https://bangbros.com/search/"
+          - subScraper:
+              selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
+          - parseDate: Jan 2, 2006
 
 # Last Updated October 3, 2020

--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -33,4 +33,4 @@ xPathScrapers:
               selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
           - parseDate: Jan 2, 2006
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -19,16 +19,16 @@ xPathScrapers:
         #selector: //img[@id="player-overlay-image"]/@src # Better image but can fail on older scenes
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+              - regex: ^
+                with: "https:"
       Studio:
         Name: //div[@class="vdoCast"]/a[1]/text()
       Date:
         selector: //div[@class="vdoCast" and contains(text(), "Release:")]
         postProcess:
           - replace:
-            - regex: "^Release: "
-              with: "https://bangbros.com/search/"
+              - regex: "^Release: "
+                with: "https://bangbros.com/search/"
           - subScraper:
               selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
           - parseDate: Jan 2, 2006

--- a/scrapers/BigBootyTGirls.yml
+++ b/scrapers/BigBootyTGirls.yml
@@ -23,4 +23,4 @@ xPathScrapers:
         Name:
           fixed: BigBootyTGirls
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/BigBootyTGirls.yml
+++ b/scrapers/BigBootyTGirls.yml
@@ -10,16 +10,17 @@ xPathScrapers:
       Title: //div[@class="titleBlock2 clear"]/h3/text()
       Date:
         selector: //span[@class="availdate"]/text()
-        parseDate: 01/02/2006
+        postProcess:
+          - parseDate: 01/02/2006
       Details: //span[@class="latest_update_description"]/text()
       Tags:
         Name: //span[@class="update_tags"]/a/text()
       Performers:
         Name: //span[@class="tour_update_models"]/a/text()
-      Image: 
+      Image:
         selector: //meta[@property="og:image"]/@content
-      Studio: 
-        Name: 
+      Studio:
+        Name:
           fixed: BigBootyTGirls
 
 # Last Updated September 2, 2020

--- a/scrapers/BigBootyTGirls.yml
+++ b/scrapers/BigBootyTGirls.yml
@@ -23,4 +23,4 @@ xPathScrapers:
         Name:
           fixed: BigBootyTGirls
 
-# Last Updated September 2, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -205,4 +205,4 @@ xPathScrapers:
 #        fixed: "Female"
       URL: //link[@rel="canonical"]/@href
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -30,8 +30,8 @@ xPathScrapers:
         selector: $result/@href
         postProcess:
           - replace:
-            - regex: ^
-              with: https://www.brazzers.com
+              - regex: ^
+                with: https://www.brazzers.com
 
   sceneScraper:
     common:
@@ -72,8 +72,8 @@ xPathScrapers:
         selector: //*[contains(.,"Birth Place")]/following-sibling::span/text()[not(contains(.,"N/A"))]
         postProcess:
           - replace:
-            - regex: .*?,\s
-              with: ""
+              - regex: .*?,\s
+                with: ""
           - map:
               AK: "USA"
               AL: "USA"

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -205,4 +205,4 @@ xPathScrapers:
 #        fixed: "Female"
       URL: //link[@rel="canonical"]/@href
 
-# Last Updated October 5, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -28,9 +28,10 @@ xPathScrapers:
       Name: $result/@title
       URL:
         selector: $result/@href
-        replace:
-          - regex: ^
-            with: https://www.brazzers.com
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://www.brazzers.com
 
   sceneScraper:
     common:

--- a/scrapers/Carib.yml
+++ b/scrapers/Carib.yml
@@ -67,4 +67,4 @@ xPathScrapers:
             - map:
                 caribbeancompr: Caribbeancom Premium
                 caribbeancom: Caribbeancom
-#Last Updated October 24, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Carib.yml
+++ b/scrapers/Carib.yml
@@ -67,4 +67,4 @@ xPathScrapers:
             - map:
                 caribbeancompr: Caribbeancom Premium
                 caribbeancom: Caribbeancom
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Carib.yml
+++ b/scrapers/Carib.yml
@@ -51,11 +51,12 @@ xPathScrapers:
         Name: //ul/li/span[contains(.,"Tags")]/../span/a[contains(@class,"spec")]
       Image:
         selector: //link[@hreflang="ja-JP"]/@href|//script[contains(.,"posterImage = '/moviepages/'+movie_id+'/images/")]
-        replace:
-          - regex: index\.html$
-            with: images/l.jpg
-          - regex: .*posterImage\s*=\s*\'/moviepages/\'\+movie_id\+\'/images/([^\']+)\'(.|\s)*MoviePlayer\.setImage..movie_id\s.*:\s\'(\d+_\d+)\'.*
-            with: https://en.caribbeancompr.com/moviepages/$3/images/$1
+        postProcess:
+          - replace:
+            - regex: index\.html$
+              with: images/l.jpg
+            - regex: .*posterImage\s*=\s*\'/moviepages/\'\+movie_id\+\'/images/([^\']+)\'(.|\s)*MoviePlayer\.setImage..movie_id\s.*:\s\'(\d+_\d+)\'.*
+              with: https://en.caribbeancompr.com/moviepages/$3/images/$1
       Studio:
         Name:
           selector: //ul[@class="footer-copyright"]/li[contains(.,"©")]

--- a/scrapers/Carib.yml
+++ b/scrapers/Carib.yml
@@ -53,10 +53,10 @@ xPathScrapers:
         selector: //link[@hreflang="ja-JP"]/@href|//script[contains(.,"posterImage = '/moviepages/'+movie_id+'/images/")]
         postProcess:
           - replace:
-            - regex: index\.html$
-              with: images/l.jpg
-            - regex: .*posterImage\s*=\s*\'/moviepages/\'\+movie_id\+\'/images/([^\']+)\'(.|\s)*MoviePlayer\.setImage..movie_id\s.*:\s\'(\d+_\d+)\'.*
-              with: https://en.caribbeancompr.com/moviepages/$3/images/$1
+              - regex: index\.html$
+                with: images/l.jpg
+              - regex: .*posterImage\s*=\s*\'/moviepages/\'\+movie_id\+\'/images/([^\']+)\'(.|\s)*MoviePlayer\.setImage..movie_id\s.*:\s\'(\d+_\d+)\'.*
+                with: https://en.caribbeancompr.com/moviepages/$3/images/$1
       Studio:
         Name:
           selector: //ul[@class="footer-copyright"]/li[contains(.,"©")]

--- a/scrapers/ChristianXXX.yml
+++ b/scrapers/ChristianXXX.yml
@@ -15,8 +15,8 @@ xPathScrapers:
         selector: //div[@class="video_description"]/h4[not(contains(.,"Featured"))]
         postProcess:
           - replace:
-            - regex: .*[|]
-              with:
+              - regex: .*[|]
+                with:
           - parseDate: 2006-01-02
       Performers:
         Name: //ul[@class="featuredModels"]/li/a/span[not(@class)]/text()
@@ -31,10 +31,10 @@ xPathScrapers:
         concat: "|"
         postProcess:
           - replace:
-            - regex: .+image:\s+"(.+jpg)[^|]+(\|)(.+)
-              with: $1$2$3
-            - regex: ([^|]+)\|(.+)/tour/$
-              with: $2$1
-            - regex: ^\/\/
-              with: "https://"
+              - regex: .+image:\s+"(.+jpg)[^|]+(\|)(.+)
+                with: $1$2$3
+              - regex: ([^|]+)\|(.+)/tour/$
+                with: $2$1
+              - regex: ^\/\/
+                with: "https://"
 # Last Updated November 4, 2020

--- a/scrapers/ChristianXXX.yml
+++ b/scrapers/ChristianXXX.yml
@@ -13,10 +13,11 @@ xPathScrapers:
       Details: //div[@class="aboutvideo"]/p
       Date:
         selector: //div[@class="video_description"]/h4[not(contains(.,"Featured"))]
-        replace: 
-           - regex: .*[|]
-             with: 
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: .*[|]
+              with:
+          - parseDate: 2006-01-02
       Performers:
         Name: //ul[@class="featuredModels"]/li/a/span[not(@class)]/text()
       Studio:

--- a/scrapers/ChristianXXX.yml
+++ b/scrapers/ChristianXXX.yml
@@ -37,4 +37,4 @@ xPathScrapers:
                 with: $2$1
               - regex: ^\/\/
                 with: "https://"
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ChristianXXX.yml
+++ b/scrapers/ChristianXXX.yml
@@ -37,4 +37,4 @@ xPathScrapers:
               with: $2$1
             - regex: ^\/\/
               with: "https://"
-# Last Updated October 24, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -11,15 +11,17 @@ xPathScrapers:
       Details:
         selector: //div[@class="clip"]/div/p//text()
         concat: " "
-        replace:
-          - regex: "Description:"
-            with:
+        postProcess:
+          - replace:
+            - regex: "Description:"
+              with:
       Date:
         selector: //div[@class="clearfix infoRow2 clip_details"]/div/div[2]/div[3]//span[@class="highlight"]/text()
-        replace:
-          - regex: \s.+
-            with:
-        parseDate: 1/2/06
+        postProcess:
+          - replace:
+            - regex: \s.+
+              with:
+          - parseDate: 1/2/06
       Tags:
         Name: //div[@class="clipInfo clip_details"]//a/text()
       # Clips4Sale doesn't have an explict performer field, but performers are
@@ -28,9 +30,10 @@ xPathScrapers:
         Name: //div[@class="clipInfo clip_details"]//a/text()
       Image:
         selector: //div[@class="clipImage"]/img/@src
-        replace:
-          - regex: ^\/\/
-            with: "https://"
+        postProcess:
+          - replace:
+            - regex: ^\/\/
+              with: "https://"
       URL: //meta[@property='og:url']/@content
 
 # Last Updated October 12, 2020

--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -36,4 +36,4 @@ xPathScrapers:
                 with: "https://"
       URL: //meta[@property='og:url']/@content
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -13,14 +13,14 @@ xPathScrapers:
         concat: " "
         postProcess:
           - replace:
-            - regex: "Description:"
-              with:
+              - regex: "Description:"
+                with:
       Date:
         selector: //div[@class="clearfix infoRow2 clip_details"]/div/div[2]/div[3]//span[@class="highlight"]/text()
         postProcess:
           - replace:
-            - regex: \s.+
-              with:
+              - regex: \s.+
+                with:
           - parseDate: 1/2/06
       Tags:
         Name: //div[@class="clipInfo clip_details"]//a/text()
@@ -32,8 +32,8 @@ xPathScrapers:
         selector: //div[@class="clipImage"]/img/@src
         postProcess:
           - replace:
-            - regex: ^\/\/
-              with: "https://"
+              - regex: ^\/\/
+                with: "https://"
       URL: //meta[@property='og:url']/@content
 
 # Last Updated November 4, 2020

--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -36,4 +36,4 @@ xPathScrapers:
               with: "https://"
       URL: //meta[@property='og:url']/@content
 
-# Last Updated October 12, 2020
+# Last Updated November 4, 2020

--- a/scrapers/CzechVR.yml
+++ b/scrapers/CzechVR.yml
@@ -33,4 +33,4 @@ xPathScrapers:
           - replace:
               - regex: \s\./category
                 with: /category 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/CzechVR.yml
+++ b/scrapers/CzechVR.yml
@@ -31,6 +31,6 @@ xPathScrapers:
         concat: " "
         postProcess:
           - replace:
-            - regex: \s\./category
-              with: /category 
+              - regex: \s\./category
+                with: /category 
 # Last Updated November 4, 2020

--- a/scrapers/CzechVR.yml
+++ b/scrapers/CzechVR.yml
@@ -15,7 +15,8 @@ xPathScrapers:
       Title: $info//div[@class="nazev"]/h2/text()
       Date:
         selector: $info//div[@class="datum"]/text()
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details:
         selector: //div[@class="textDetail"]/text()
         concat: " "
@@ -28,7 +29,8 @@ xPathScrapers:
       Image: 
         selector: $url|//dl8-video/@poster
         concat: " "
-        replace:
-          - regex: \s\./category
-            with: /category 
+        postProcess:
+          - replace:
+            - regex: \s\./category
+              with: /category 
 # Last Updated July 26, 2020

--- a/scrapers/CzechVR.yml
+++ b/scrapers/CzechVR.yml
@@ -33,4 +33,4 @@ xPathScrapers:
           - replace:
             - regex: \s\./category
               with: /category 
-# Last Updated July 26, 2020
+# Last Updated November 4, 2020

--- a/scrapers/DogFart.yml
+++ b/scrapers/DogFart.yml
@@ -30,4 +30,4 @@ xPathScrapers:
               - regex: ^
                 with: "https:"
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/DogFart.yml
+++ b/scrapers/DogFart.yml
@@ -30,4 +30,4 @@ xPathScrapers:
             - regex: ^
               with: "https:"
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/DogFart.yml
+++ b/scrapers/DogFart.yml
@@ -13,8 +13,8 @@ xPathScrapers:
         selector: //meta[@itemprop="uploadDate"]/@content
         postProcess:
           - replace:
-            - regex: ([\d-]*).+
-              with: $1
+              - regex: ([\d-]*).+
+                with: $1
           - parseDate: 2006-01-02
       Details:
         selector: //div[@class="description shorten"]/text()|//span[@class="more-desc hide"]/text()
@@ -27,7 +27,7 @@ xPathScrapers:
         selector: //meta[@itemprop="thumbnailUrl"]/@content
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+              - regex: ^
+                with: "https:"
 
 # Last Updated November 4, 2020

--- a/scrapers/DogFart.yml
+++ b/scrapers/DogFart.yml
@@ -11,10 +11,11 @@ xPathScrapers:
       Title: //h1[@class="description-title"]/text()
       Date:
         selector: //meta[@itemprop="uploadDate"]/@content
-        replace:
-          - regex: ([\d-]*).+
-            with: $1
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: ([\d-]*).+
+              with: $1
+          - parseDate: 2006-01-02
       Details:
         selector: //div[@class="description shorten"]/text()|//span[@class="more-desc hide"]/text()
         concat: " "
@@ -24,8 +25,9 @@ xPathScrapers:
         Name: //h4[@class="more-scenes"]/a/text()
       Image:
         selector: //meta[@itemprop="thumbnailUrl"]/@content
-        replace:
-          - regex: ^
-            with: "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
 
 # Last Updated October 3, 2020

--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -11,34 +11,39 @@ xPathScrapers:
       Title: //h1/text()
       Date:
         selector: //meta[@itemprop="uploadDate"]/@content
-        parseDate: 2006-01-02T15:04:05-07:00
+        postProcess:
+          - parseDate: 2006-01-02T15:04:05-07:00
       Details:
         selector: //div[@class="entry-content"]/p/text()
         concat: "\n"
-        replace:
-          - regex: "\n"
-            with: "\n"
+        postProcess:
+          - replace:
+            - regex: "\n"
+              with: "\n"
       Tags:
         Name: //p[@class="post-meta"]//a/text()
       Performers:
         Name:
           selector: //div[@class="entry-content"]/p[contains(text(),'***')]|
-          replace:
-            - regex: \*\*\*|Starring\s
-              with:
+          postProcess:
+            - replace:
+              - regex: \*\*\*|Starring\s
+                with:
           split: ' & '
       Studio:
         Name:
           selector: //h1/text()
-          replace:
-            - regex: .+
-              with: 'FamilyTherapyXXX'
+          postProcess:
+            - replace:
+              - regex: .+
+                with: 'FamilyTherapyXXX'
       Image:
         selector: //meta[@itemprop="contentUrl"]/@content
-        replace:
-          - regex: .+(?:\d{4}\/\d{2}\/)([\w]+)(?:\.\w+)
-            with: https://familytherapyxxx.com/?s=$1
-        subScraper:
-          selector: //div[@id="left-area"]/article[1]//img/@src
+        postProcess:
+          - replace:
+            - regex: .+(?:\d{4}\/\d{2}\/)([\w]+)(?:\.\w+)
+              with: https://familytherapyxxx.com/?s=$1
+          - subScraper:
+              selector: //div[@id="left-area"]/article[1]//img/@src
 
 # Last Updated June 19, 2020

--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -18,8 +18,8 @@ xPathScrapers:
         concat: "\n"
         postProcess:
           - replace:
-            - regex: "\n"
-              with: "\n"
+              - regex: "\n"
+                with: "\n"
       Tags:
         Name: //p[@class="post-meta"]//a/text()
       Performers:
@@ -27,22 +27,22 @@ xPathScrapers:
           selector: //div[@class="entry-content"]/p[contains(text(),'***')]|
           postProcess:
             - replace:
-              - regex: \*\*\*|Starring\s
-                with:
+                - regex: \*\*\*|Starring\s
+                  with:
           split: ' & '
       Studio:
         Name:
           selector: //h1/text()
           postProcess:
             - replace:
-              - regex: .+
-                with: 'FamilyTherapyXXX'
+                - regex: .+
+                  with: 'FamilyTherapyXXX'
       Image:
         selector: //meta[@itemprop="contentUrl"]/@content
         postProcess:
           - replace:
-            - regex: .+(?:\d{4}\/\d{2}\/)([\w]+)(?:\.\w+)
-              with: https://familytherapyxxx.com/?s=$1
+              - regex: .+(?:\d{4}\/\d{2}\/)([\w]+)(?:\.\w+)
+                with: https://familytherapyxxx.com/?s=$1
           - subScraper:
               selector: //div[@id="left-area"]/article[1]//img/@src
 

--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -46,4 +46,4 @@ xPathScrapers:
           - subScraper:
               selector: //div[@id="left-area"]/article[1]//img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -46,4 +46,4 @@ xPathScrapers:
           - subScraper:
               selector: //div[@id="left-area"]/article[1]//img/@src
 
-# Last Updated June 19, 2020
+# Last Updated November 4, 2020

--- a/scrapers/FamilyXXX.yml
+++ b/scrapers/FamilyXXX.yml
@@ -12,10 +12,11 @@ xPathScrapers:
       Title: $info//h2/text()
       Date:
         selector: $info//div[@class="sceneDateP"]/span/text()
-        replace:
-          - regex: ",$"
-            with:
-        parseDate: 01/02/2006
+        postProcess:
+          - replace:
+            - regex: ",$"
+              with:
+          - parseDate: 01/02/2006
       Details: //div[@class="description"]/p/text()
       Performers:
         Name: $info//span[@class="tour_update_models"]/a/text()

--- a/scrapers/FamilyXXX.yml
+++ b/scrapers/FamilyXXX.yml
@@ -22,4 +22,4 @@ xPathScrapers:
         Name: $info//span[@class="tour_update_models"]/a/text()
       Image: //span[@id="trailer_thumb"]/span[1]/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/FamilyXXX.yml
+++ b/scrapers/FamilyXXX.yml
@@ -14,8 +14,8 @@ xPathScrapers:
         selector: $info//div[@class="sceneDateP"]/span/text()
         postProcess:
           - replace:
-            - regex: ",$"
-              with:
+              - regex: ",$"
+                with:
           - parseDate: 01/02/2006
       Details: //div[@class="description"]/p/text()
       Performers:

--- a/scrapers/FamilyXXX.yml
+++ b/scrapers/FamilyXXX.yml
@@ -22,4 +22,4 @@ xPathScrapers:
         Name: $info//span[@class="tour_update_models"]/a/text()
       Image: //span[@id="trailer_thumb"]/span[1]/img/@src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/FuckingAwesome.yml
+++ b/scrapers/FuckingAwesome.yml
@@ -27,4 +27,4 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
 
-# Last Updated June 10, 2020
+# Last Updated November 4, 2020

--- a/scrapers/FuckingAwesome.yml
+++ b/scrapers/FuckingAwesome.yml
@@ -27,4 +27,4 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/FuckingAwesome.yml
+++ b/scrapers/FuckingAwesome.yml
@@ -20,8 +20,8 @@ xPathScrapers:
           selector: //meta[@property="og:site_name"]/@content
           postProcess:
             - replace:
-              - regex: \.com$
-                with:
+                - regex: \.com$
+                  with:
       Date:
         selector: //div[@class="videodate"]/strong/text()
         postProcess:

--- a/scrapers/FuckingAwesome.yml
+++ b/scrapers/FuckingAwesome.yml
@@ -18,11 +18,13 @@ xPathScrapers:
       Studio:
         Name:
           selector: //meta[@property="og:site_name"]/@content
-          replace:
-            - regex: \.com$
-              with:
+          postProcess:
+            - replace:
+              - regex: \.com$
+                with:
       Date:
         selector: //div[@class="videodate"]/strong/text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
 
 # Last Updated June 10, 2020

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -190,4 +190,4 @@ xPathScrapers:
         Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()
       FrontImage: //a[@class='frontCoverImg']/@href
       BackImage: //a[@class='backCoverImg']/@href
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -129,24 +129,24 @@ xPathScrapers:
         selector: //li[@class="updatedDate"]/text()[2]|//div[@class="updatedDate"]/text()[2]|//p[@class="updatedDate"]/text()[2]|//div[@class="sceneCol updatedDate"]/span/text()|//p[@class="p-updated"]/text()
         postProcess:
           - replace:
-            - regex: (\d{4})-(\d{2})-(\d{2})
-              with: $2-$3-$1
-            - regex: (\d{2})\/(\d{2})\/(\d{4})
-              with: $1-$2-$3
-            - regex: ":"
-              with:
+              - regex: (\d{4})-(\d{2})-(\d{2})
+                with: $2-$3-$1
+              - regex: (\d{2})\/(\d{2})\/(\d{4})
+                with: $1-$2-$3
+              - regex: ":"
+                with:
           - parseDate: 01-02-2006
       Details:
         selector: $detailscript
         postProcess:
           - replace:
-            - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
-              with: $1
+              - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
+                with: $1
               # Second regex in case no description is provided.
-            - regex: .+(?:"sceneDescription":"").+
-              with:
-            - regex: <\\\/br>|<br\s\\\/>|<br>|<br\\/>
-              with: "\n"
+              - regex: .+(?:"sceneDescription":"").+
+                with:
+              - regex: <\\\/br>|<br\s\\\/>|<br>|<br\\/>
+                with: "\n"
       Tags:
         Name: $tags/a/text()|//div[@class="sceneCol categories"]/a/text()|//div[@class="sceneCol sceneColCategories"]//span[not(@class="categorySeparator")]/text()|//div[@class="sceneCategories"]/a/text()
       Performers:
@@ -157,12 +157,12 @@ xPathScrapers:
         selector: //script[contains(text(), 'picPreview')]/text()
         postProcess:
           - replace:
-            - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
-              with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
+              - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
+                with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
               # if using the transport subdomain, parameters need to be passed
               # otherwise a cropped square image is returned by default
-            - regex: (https:\/\/transform.+)
-              with: $1?width=960&height=543&enlarge=true
+              - regex: (https:\/\/transform.+)
+                with: $1?width=960&height=543&enlarge=true
       Studio:
         Name:
           selector: //*[local-name()="div" or local-name()=p][contains(text(),"is a site owned and operated by Gamma")]

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -127,24 +127,26 @@ xPathScrapers:
       Title: //div[@id="breadcrumb"]/span[3]/text()|//div[@id="breadCrumb"]/span[3]/text()|//div[@id="BreadcrumbMenu"]/span[3]/text()|//h1[@class="sceneTitle"]/text()|//div[@id="playerWrapper"]//h1/text()|//div[@id="scenePlayer"]//h1/text()|//div[@id="scenePlayerScene"]//h1/text()|//h3[@class="sceneTitle"]/text()
       Date:
         selector: //li[@class="updatedDate"]/text()[2]|//div[@class="updatedDate"]/text()[2]|//p[@class="updatedDate"]/text()[2]|//div[@class="sceneCol updatedDate"]/span/text()|//p[@class="p-updated"]/text()
-        replace:
-          - regex: (\d{4})-(\d{2})-(\d{2})
-            with: $2-$3-$1
-          - regex: (\d{2})\/(\d{2})\/(\d{4})
-            with: $1-$2-$3
-          - regex: ":"
-            with:
-        parseDate: 01-02-2006
+        postProcess:
+          - replace:
+            - regex: (\d{4})-(\d{2})-(\d{2})
+              with: $2-$3-$1
+            - regex: (\d{2})\/(\d{2})\/(\d{4})
+              with: $1-$2-$3
+            - regex: ":"
+              with:
+          - parseDate: 01-02-2006
       Details:
         selector: $detailscript
-        replace:
-          - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
-            with: $1
-            # Second regex in case no description is provided.
-          - regex: .+(?:"sceneDescription":"").+
-            with:
-          - regex: <\\\/br>|<br\s\\\/>|<br>|<br\\/>
-            with: "\n"
+        postProcess:
+          - replace:
+            - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
+              with: $1
+              # Second regex in case no description is provided.
+            - regex: .+(?:"sceneDescription":"").+
+              with:
+            - regex: <\\\/br>|<br\s\\\/>|<br>|<br\\/>
+              with: "\n"
       Tags:
         Name: $tags/a/text()|//div[@class="sceneCol categories"]/a/text()|//div[@class="sceneCol sceneColCategories"]//span[not(@class="categorySeparator")]/text()|//div[@class="sceneCategories"]/a/text()
       Performers:
@@ -153,13 +155,14 @@ xPathScrapers:
         Name: $info/a/img/@title|//a[@class="sceneLink  "]/@title|//a[@class="dvdLink  "]/@title
       Image:
         selector: //script[contains(text(), 'picPreview')]/text()
-        replace:
-          - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
-            with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
-            # if using the transport subdomain, parameters need to be passed
-            # otherwise a cropped square image is returned by default
-          - regex: (https:\/\/transform.+)
-            with: $1?width=960&height=543&enlarge=true
+        postProcess:
+          - replace:
+            - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
+              with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
+              # if using the transport subdomain, parameters need to be passed
+              # otherwise a cropped square image is returned by default
+            - regex: (https:\/\/transform.+)
+              with: $1?width=960&height=543&enlarge=true
       Studio:
         Name:
           selector: //*[local-name()="div" or local-name()=p][contains(text(),"is a site owned and operated by Gamma")]
@@ -180,7 +183,8 @@ xPathScrapers:
       Duration: //li[@class='length']/text()
       Date:
         selector: //li[@class='updatedOn']/text()
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Synopsis: //p[@class='descriptionText']/text()
       Studio:
         Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -190,4 +190,4 @@ xPathScrapers:
         Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()
       FrontImage: //a[@class='frontCoverImg']/@href
       BackImage: //a[@class='backCoverImg']/@href
-# Last Updated October 8, 2020
+# Last Updated November 4, 2020

--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -24,4 +24,4 @@ xPathScrapers:
           fixed: GloryHole Swallow
       URL: //link[@rel='canonical']/@href
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -24,4 +24,4 @@ xPathScrapers:
           fixed: GloryHole Swallow
       URL: //link[@rel='canonical']/@href
 
-# Last Updated September 2, 2020
+# Last Updated November 4, 2020

--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -15,9 +15,10 @@ xPathScrapers:
         Name: $info//p[contains(text(),'Tags')]//a/text()
       Image:
         selector: //div[@id='fakeplayer']//img/@src0_1x
-        replace:
-          - regex: ^
-            with: https://gloryholeswallow.com
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://gloryholeswallow.com
       Studio:
         Name:
           fixed: GloryHole Swallow

--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -17,8 +17,8 @@ xPathScrapers:
         selector: //div[@id='fakeplayer']//img/@src0_1x
         postProcess:
           - replace:
-            - regex: ^
-              with: https://gloryholeswallow.com
+              - regex: ^
+                with: https://gloryholeswallow.com
       Studio:
         Name:
           fixed: GloryHole Swallow

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -38,4 +38,4 @@ xPathScrapers:
             - regex: ^// # bobstgirls
               with: "https://"
         
-# Last Updated September 02, 2020.
+# Last Updated November 4, 2020

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -24,7 +24,8 @@ xPathScrapers:
       Title: //p[@class="trailertitle"]/text()
       Date:
         selector: //div[@class="setdesc"]//b[contains(.,"Added")]/following-sibling::text()[1]
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details: //div[@class="trailerpage_info"]/p[not(@class)]/text()
       Performers:
         Name: //div[@class="setdesc"]//a/text()

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -35,7 +35,7 @@ xPathScrapers:
         selector: //meta[@property="og:image"]/@content
         postProcess:
           - replace:
-            - regex: ^// # bobstgirls
-              with: "https://"
+              - regex: ^// # bobstgirls
+                with: "https://"
         
 # Last Updated November 4, 2020

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -38,4 +38,4 @@ xPathScrapers:
               - regex: ^// # bobstgirls
                 with: "https://"
         
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Heyzo.yml
+++ b/scrapers/Heyzo.yml
@@ -47,4 +47,4 @@ xPathScrapers:
       Studio:
         Name:
           fixed: Heyzo
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Heyzo.yml
+++ b/scrapers/Heyzo.yml
@@ -26,7 +26,8 @@ xPathScrapers:
       #Details: //section/div[@id="movie"]/h1
       Date:
         selector: $table/td[contains(.,"Released")]/following-sibling::td/text()
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Performers:
         Name: $table/td[contains(.,"Actress")]/following-sibling::td/a/text()
       Image:

--- a/scrapers/Heyzo.yml
+++ b/scrapers/Heyzo.yml
@@ -47,4 +47,4 @@ xPathScrapers:
       Studio:
         Name:
           fixed: Heyzo
-#Last Updated October 24, 2020
+# Last Updated November 4, 2020

--- a/scrapers/HotWifeXXX.yml
+++ b/scrapers/HotWifeXXX.yml
@@ -22,4 +22,4 @@ xPathScrapers:
         Name: $info//span[@class="tour_update_models"]/a/text()
       Image: //span[@id="trailer_thumb"]/span[1]/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/HotWifeXXX.yml
+++ b/scrapers/HotWifeXXX.yml
@@ -14,8 +14,8 @@ xPathScrapers:
         selector: $info//div[@class="released2 trailerStarr"]/text()
         postProcess:
           - replace:
-            - regex: (,.+)
-              with:
+              - regex: (,.+)
+                with:
           - parseDate: 01/02/2006
       Details: $info//div[@class="videoDetails"]/p/text()
       Performers:

--- a/scrapers/HotWifeXXX.yml
+++ b/scrapers/HotWifeXXX.yml
@@ -12,10 +12,11 @@ xPathScrapers:
       Title: $info//h2/text()
       Date:
         selector: $info//div[@class="released2 trailerStarr"]/text()
-        replace:
-          - regex: (,.+)
-            with:
-        parseDate: 01/02/2006
+        postProcess:
+          - replace:
+            - regex: (,.+)
+              with:
+          - parseDate: 01/02/2006
       Details: $info//div[@class="videoDetails"]/p/text()
       Performers:
         Name: $info//span[@class="tour_update_models"]/a/text()

--- a/scrapers/HotWifeXXX.yml
+++ b/scrapers/HotWifeXXX.yml
@@ -22,4 +22,4 @@ xPathScrapers:
         Name: $info//span[@class="tour_update_models"]/a/text()
       Image: //span[@id="trailer_thumb"]/span[1]/img/@src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/HungarianHoneys.yml
+++ b/scrapers/HungarianHoneys.yml
@@ -21,9 +21,9 @@ xPathScrapers:
         selector: //script[contains(text(),'poster')]/text()
         postProcess:
           - replace:
-            - regex: .+(?:poster=")([^"]+).+
-              with: $1
-            - regex: ^
-              with: https://hungarianhoneys.com
+              - regex: .+(?:poster=")([^"]+).+
+                with: $1
+              - regex: ^
+                with: https://hungarianhoneys.com
 
 # Last Updated November 4, 2020

--- a/scrapers/HungarianHoneys.yml
+++ b/scrapers/HungarianHoneys.yml
@@ -10,7 +10,8 @@ xPathScrapers:
       Title: //div[@class="video-player"]//h2/text()
       Date:
         selector: //div[@class="col-md-6"]/div[1]/text()[2]
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details: //div[@class="col-md-9 col-sm-12"]/div[1]/text()[2]
       Tags:
         Name: //div[@class="col-md-9 col-sm-12"]/div[2]//a/text()
@@ -18,10 +19,11 @@ xPathScrapers:
         Name: //div[@class="update-info-block models-list-thumbs"]//span/text()
       Image:
         selector: //script[contains(text(),'poster')]/text()
-        replace:
-          - regex: .+(?:poster=")([^"]+).+
-            with: $1
-          - regex: ^
-            with: https://hungarianhoneys.com
+        postProcess:
+          - replace:
+            - regex: .+(?:poster=")([^"]+).+
+              with: $1
+            - regex: ^
+              with: https://hungarianhoneys.com
 
 # Last Updated October 3, 2020

--- a/scrapers/HungarianHoneys.yml
+++ b/scrapers/HungarianHoneys.yml
@@ -26,4 +26,4 @@ xPathScrapers:
             - regex: ^
               with: https://hungarianhoneys.com
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/HungarianHoneys.yml
+++ b/scrapers/HungarianHoneys.yml
@@ -26,4 +26,4 @@ xPathScrapers:
               - regex: ^
                 with: https://hungarianhoneys.com
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -52,15 +52,15 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-            - regex: .+\"datePublished\"\:\s\"(\d\d/\d\d/\d\d\d\d)\".+
-              with: $1
+              - regex: .+\"datePublished\"\:\s\"(\d\d/\d\d/\d\d\d\d)\".+
+                with: $1
           - parseDate: "01/02/2006"
       Image:
         selector: $script
         postProcess:
           - replace:
-            - regex: .+\"thumbnailUrl\"\:\s\"(https.+\.jpg)\".+
-              with: $1
+              - regex: .+\"thumbnailUrl\"\:\s\"(https.+\.jpg)\".+
+                with: $1
       Tags:
         Name: //span[@class="gallery-meta"]/span[@class="left"]/a/text()
 

--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -64,4 +64,4 @@ xPathScrapers:
       Tags:
         Name: //span[@class="gallery-meta"]/span[@class="left"]/a/text()
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -64,4 +64,4 @@ xPathScrapers:
       Tags:
         Name: //span[@class="gallery-meta"]/span[@class="left"]/a/text()
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -50,15 +50,17 @@ xPathScrapers:
         Name: $info/h4/a/text()
       Date:
         selector: $script
-        replace:
-          - regex: .+\"datePublished\"\:\s\"(\d\d/\d\d/\d\d\d\d)\".+
-            with: $1
-        parseDate: "01/02/2006"
+        postProcess:
+          - replace:
+            - regex: .+\"datePublished\"\:\s\"(\d\d/\d\d/\d\d\d\d)\".+
+              with: $1
+          - parseDate: "01/02/2006"
       Image:
         selector: $script
-        replace:
-          - regex: .+\"thumbnailUrl\"\:\s\"(https.+\.jpg)\".+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+\"thumbnailUrl\"\:\s\"(https.+\.jpg)\".+
+              with: $1
       Tags:
         Name: //span[@class="gallery-meta"]/span[@class="left"]/a/text()
 

--- a/scrapers/IKissGirls.yml
+++ b/scrapers/IKissGirls.yml
@@ -33,4 +33,4 @@ xPathScrapers:
             - regex: ^
               with: https://ikissgirls.com
 
-# Last Updated June 22, 2020
+# Last Updated November 4, 2020

--- a/scrapers/IKissGirls.yml
+++ b/scrapers/IKissGirls.yml
@@ -11,12 +11,14 @@ xPathScrapers:
     scene:
       Title:
         selector: $player//h2/text()
-        replace:
-          - regex: :\sVideo
-            with:
+        postProcess:
+          - replace:
+            - regex: :\sVideo
+              with:
       Date:
         selector: //div[strong/text()='Released:']/text()[2]
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details: //div[h3/text()='Description:']/text()[2]
       Tags:
         Name: //ul[@class='tags']//a/text()
@@ -26,8 +28,9 @@ xPathScrapers:
         Name: //meta[@name="author"]/@content
       Image:
         selector: //img[@id="set-target-35"]/@src0_1x
-        replace:
-          - regex: ^
-            with: https://ikissgirls.com
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://ikissgirls.com
 
 # Last Updated June 22, 2020

--- a/scrapers/IKissGirls.yml
+++ b/scrapers/IKissGirls.yml
@@ -13,8 +13,8 @@ xPathScrapers:
         selector: $player//h2/text()
         postProcess:
           - replace:
-            - regex: :\sVideo
-              with:
+              - regex: :\sVideo
+                with:
       Date:
         selector: //div[strong/text()='Released:']/text()[2]
         postProcess:
@@ -30,7 +30,7 @@ xPathScrapers:
         selector: //img[@id="set-target-35"]/@src0_1x
         postProcess:
           - replace:
-            - regex: ^
-              with: https://ikissgirls.com
+              - regex: ^
+                with: https://ikissgirls.com
 
 # Last Updated November 4, 2020

--- a/scrapers/IKissGirls.yml
+++ b/scrapers/IKissGirls.yml
@@ -33,4 +33,4 @@ xPathScrapers:
               - regex: ^
                 with: https://ikissgirls.com
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Iafd.yml
+++ b/scrapers/Iafd.yml
@@ -424,4 +424,4 @@ xPathScrapers:
         selector: //div[@class="col-sm-12"]/dl/dd
         concat: ", "
 
-# Last Updated September 24, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Iafd.yml
+++ b/scrapers/Iafd.yml
@@ -25,7 +25,8 @@ xPathScrapers:
       Title: //h1/text()
       Date: 
         selector: //div[@class="col-xs-12 col-sm-3"]//p[text() = 'Release Date']/following-sibling::p[1]
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details:  //div[@id="synopsis"]/div[@class="padded-panel"]//text()
       Studio:
         Name: //div[@class="col-xs-12 col-sm-3"]//p[text() = 'Studio']/following-sibling::p[1]
@@ -37,9 +38,10 @@ xPathScrapers:
       Name: //table[@id='tblFem' or @id='tblMal']//td[a[img]]/following-sibling::td[1]/a/text()
       URL: 
         selector: //table[@id='tblFem' or @id='tblMal']//td[a[img]]/following-sibling::td[1]/a/@href
-        replace:
-          - regex: ^
-            with: https://www.iafd.com
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://www.iafd.com
   
   performerScraper:
     performer:

--- a/scrapers/Iafd.yml
+++ b/scrapers/Iafd.yml
@@ -424,4 +424,4 @@ xPathScrapers:
         selector: //div[@class="col-sm-12"]/dl/dd
         concat: ", "
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Iafd.yml
+++ b/scrapers/Iafd.yml
@@ -40,8 +40,8 @@ xPathScrapers:
         selector: //table[@id='tblFem' or @id='tblMal']//td[a[img]]/following-sibling::td[1]/a/@href
         postProcess:
           - replace:
-            - regex: ^
-              with: https://www.iafd.com
+              - regex: ^
+                with: https://www.iafd.com
   
   performerScraper:
     performer:
@@ -57,14 +57,14 @@ xPathScrapers:
         selector: //p[@class='biodata']/a[contains(text(),"http://twitter.com/")]/@href
         postProcess:
           - replace:
-            - regex: https://twitter.com/
-              with: ""
+              - regex: https://twitter.com/
+                with: ""
       Instagram: 
         selector: //p[@class='biodata']/a[contains(text(),"http://instagram.com/")]/@href
         postProcess:
           - replace:
-            - regex: https://instagram.com/
-              with: ""
+              - regex: https://instagram.com/
+                with: ""
       Birthdate:
         selector: //div[p[text()='Birthday']]/p[@class='biodata']/a[contains(@href, '/calendar.')]/text()
         # reference date is: 2006/01/02
@@ -382,17 +382,17 @@ xPathScrapers:
         selector: //div/p[text()='Height']/following-sibling::p[1]/text()
         postProcess:
           - replace:
-            - regex: \d+\D+\d+\D+
-              with: ""
-            - regex:  \D+$
-              with: ""
+              - regex: \d+\D+\d+\D+
+                with: ""
+              - regex:  \D+$
+                with: ""
       Measurements: //div/p[text()='Measurements']/following-sibling::p[1]/text()
       CareerLength: 
         selector: //div/p[@class='biodata'][contains(text(),"Started around")]/text()
         postProcess:
           - replace:
-            - regex: (\D+\d\d\D+)$
-              with: ""     
+              - regex: (\D+\d\d\D+)$
+                with: ""     
       Aliases: //div[p[@class='bioheading']]//div[@class='biodata']/text()
       Tattoos: //div/p[text()='Tattoos']/following-sibling::p[1]/text()
       Piercings: //div/p[text()='Piercings']/following-sibling::p[1]/text()
@@ -409,8 +409,8 @@ xPathScrapers:
         selector: //h1/text()
         postProcess:
           - replace:
-            - regex: \([0-9]+\)
-              with:
+              - regex: \([0-9]+\)
+                with:
       Director: $biohead[contains(text(), "Directors")]/$biodata_link
       Duration: $biohead[contains(text(), "Minutes")]/$biodata
       Synopsis: //div[@id="synopsis"]/div[@class="padded-panel"]//text()

--- a/scrapers/IsThisReal.yml
+++ b/scrapers/IsThisReal.yml
@@ -15,63 +15,63 @@ xPathScrapers:
         selector: $videoscript
         postProcess:
           - replace:
-            - regex: .+(?:"sceneTitle":")([^"]+).+
-              with: $1
-            - regex: .+(?:"sceneTitle":"").+
-              with:
+              - regex: .+(?:"sceneTitle":")([^"]+).+
+                with: $1
+              - regex: .+(?:"sceneTitle":"").+
+                with:
       Date:
         selector: $videoscript
         postProcess:
           - replace:
-            - regex: .+(?:"sceneReleaseDate":")([^"]+).+
-              with: $1
+              - regex: .+(?:"sceneReleaseDate":")([^"]+).+
+                with: $1
           - parseDate: 2006-01-02
       Details:
         selector: $datascript
         postProcess:
           - replace:
-            - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
-              with: $1
-            - regex: .+(?:"sceneDescription":"").+
-              with:
-            - regex: <\\\/br>|<br\s\\\/>|<br>
-              with: "\n"
+              - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
+                with: $1
+              - regex: .+(?:"sceneDescription":"").+
+                with:
+              - regex: <\\\/br>|<br\s\\\/>|<br>
+                with: "\n"
       Tags:
         Name:
           selector: $datascript
           postProcess:
             - replace:
-              - regex: .+(?:sceneCategories":\[)(.+)(?:\],"sceneViews").+
-                with: $1
-              - regex: \"
-                with:
+                - regex: .+(?:sceneCategories":\[)(.+)(?:\],"sceneViews").+
+                  with: $1
+                - regex: \"
+                  with:
           split: ","
       Performers:
         Name:
           selector: $datascript
           postProcess:
             - replace:
-              - regex: .+(?:"sceneActors":)(.+)(?:,"sceneCategories")
-                with: $1
-              - regex: \{"actorId":"\d+","actorName":|}|\[|\]|"
-                with:
+                - regex: .+(?:"sceneActors":)(.+)(?:,"sceneCategories")
+                  with: $1
+                - regex: \{"actorId":"\d+","actorName":|}|\[|\]|"
+                  with:
           split: ","
       Image:
         selector: $imagescript
         postProcess:
           - replace:
-            - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
-              with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
+              - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
+                with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
               # if using the transport subdomain, parameters need to be passed
               # otherwise a cropped square image is returned by default
-            - regex: (https:\/\/transform.+)
-              with: $1?width=960&height=543&enlarge=true
+              - regex: (https:\/\/transform.+)
+                with: $1?width=960&height=543&enlarge=true
       Studio:
         Name:
           selector: //link[@rel="canonical"]/@href
           postProcess:
             - replace:
-              - regex: .+(?:\/video\/)([^\/]+).+
-                with: $1
+                - regex: .+(?:\/video\/)([^\/]+).+
+                  with: $1
 
 # Last Updated November 4, 2020

--- a/scrapers/IsThisReal.yml
+++ b/scrapers/IsThisReal.yml
@@ -74,4 +74,4 @@ xPathScrapers:
                 - regex: .+(?:\/video\/)([^\/]+).+
                   with: $1
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/IsThisReal.yml
+++ b/scrapers/IsThisReal.yml
@@ -13,58 +13,65 @@ xPathScrapers:
     scene:
       Title:
         selector: $videoscript
-        replace:
-          - regex: .+(?:"sceneTitle":")([^"]+).+
-            with: $1
-          - regex: .+(?:"sceneTitle":"").+
-            with:
+        postProcess:
+          - replace:
+            - regex: .+(?:"sceneTitle":")([^"]+).+
+              with: $1
+            - regex: .+(?:"sceneTitle":"").+
+              with:
       Date:
         selector: $videoscript
-        replace:
-          - regex: .+(?:"sceneReleaseDate":")([^"]+).+
-            with: $1
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: .+(?:"sceneReleaseDate":")([^"]+).+
+              with: $1
+          - parseDate: 2006-01-02
       Details:
         selector: $datascript
-        replace:
-          - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
-            with: $1
-          - regex: .+(?:"sceneDescription":"").+
-            with:
-          - regex: <\\\/br>|<br\s\\\/>|<br>
-            with: "\n"
+        postProcess:
+          - replace:
+            - regex: .+(?:sceneDescription":")(.+)(?:","sceneActors).+
+              with: $1
+            - regex: .+(?:"sceneDescription":"").+
+              with:
+            - regex: <\\\/br>|<br\s\\\/>|<br>
+              with: "\n"
       Tags:
         Name:
           selector: $datascript
-          replace:
-            - regex: .+(?:sceneCategories":\[)(.+)(?:\],"sceneViews").+
-              with: $1
-            - regex: \"
-              with:
+          postProcess:
+            - replace:
+              - regex: .+(?:sceneCategories":\[)(.+)(?:\],"sceneViews").+
+                with: $1
+              - regex: \"
+                with:
           split: ","
       Performers:
         Name:
           selector: $datascript
-          replace:
-            - regex: .+(?:"sceneActors":)(.+)(?:,"sceneCategories")
-              with: $1
-            - regex: \{"actorId":"\d+","actorName":|}|\[|\]|"
-              with:
+          postProcess:
+            - replace:
+              - regex: .+(?:"sceneActors":)(.+)(?:,"sceneCategories")
+                with: $1
+              - regex: \{"actorId":"\d+","actorName":|}|\[|\]|"
+                with:
           split: ","
       Image:
         selector: $imagescript
-        replace:
-          - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
-            with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
-            # if using the transport subdomain, parameters need to be passed
-            # otherwise a cropped square image is returned by default
-          - regex: (https:\/\/transform.+)
-            with: $1?width=960&height=543&enlarge=true
+        postProcess:
+          - replace:
+            - regex: .+(?:picPreview":")([\w:]+)(?:[\\\/]+)([\w-\.]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\d_]+)(?:[\\\/]+)(\w+)(?:[\\\/]+)(\d+)(?:[\\\/]+)(\d+)(?:[\\\/]+)([\w]+)(?:[\\\/]+)([\w.]+).+
+              with: $1//$2/$3/$4/$5/$6/$7/$8/$9/$10
+              # if using the transport subdomain, parameters need to be passed
+              # otherwise a cropped square image is returned by default
+            - regex: (https:\/\/transform.+)
+              with: $1?width=960&height=543&enlarge=true
       Studio:
         Name:
           selector: //link[@rel="canonical"]/@href
-          replace:
-            - regex: .+(?:\/video\/)([^\/]+).+
-              with: $1
+          postProcess:
+            - replace:
+              - regex: .+(?:\/video\/)([^\/]+).+
+                with: $1
 
 # Last Updated June 22, 2020

--- a/scrapers/IsThisReal.yml
+++ b/scrapers/IsThisReal.yml
@@ -74,4 +74,4 @@ xPathScrapers:
               - regex: .+(?:\/video\/)([^\/]+).+
                 with: $1
 
-# Last Updated June 22, 2020
+# Last Updated November 4, 2020

--- a/scrapers/JapanHDV.yml
+++ b/scrapers/JapanHDV.yml
@@ -13,14 +13,16 @@ xPathScrapers:
       Details: //div[@class="pure-u-xs-1-1 pure-u-sm-1-1 pure-u-2-3 text-black video-description"]/text()
       Date: 
         selector: //meta[@itemprop="datePublished"]/@content
-        parseDate: 2006-01-02T15:04:05-07:00
+        postProcess:
+          - parseDate: 2006-01-02T15:04:05-07:00
       Performers: 
         Name: $movieinfo/p[2]/a/text()
       Tags:
         Name: $movieinfo/p[5]/a
       Image:
         selector: //video[@id="videohtml5tour"]/@poster
-        replace:
-          - regex: ^
-            with:  "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with:  "https:"
 

--- a/scrapers/JapanHDV.yml
+++ b/scrapers/JapanHDV.yml
@@ -26,4 +26,4 @@ xPathScrapers:
               - regex: ^
                 with:  "https:"
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/JapanHDV.yml
+++ b/scrapers/JapanHDV.yml
@@ -23,7 +23,7 @@ xPathScrapers:
         selector: //video[@id="videohtml5tour"]/@poster
         postProcess:
           - replace:
-            - regex: ^
-              with:  "https:"
+              - regex: ^
+                with:  "https:"
 
 # Last Updated November 4, 2020

--- a/scrapers/JapanHDV.yml
+++ b/scrapers/JapanHDV.yml
@@ -26,3 +26,4 @@ xPathScrapers:
             - regex: ^
               with:  "https:"
 
+# Last Updated November 4, 2020

--- a/scrapers/JaysPov.yml
+++ b/scrapers/JaysPov.yml
@@ -34,4 +34,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="video-performer"]/a/span/span/text()
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/JaysPov.yml
+++ b/scrapers/JaysPov.yml
@@ -11,15 +11,15 @@ xPathScrapers:
         selector: //div[@class="container-fluid video-title"]/h1/text()
         postProcess:
           - replace:
-            - regex: '^(.+?)\ \-\ (.+)$'
-              with: $2
+              - regex: '^(.+?)\ \-\ (.+)$'
+                with: $2
       Details: //meta[@name="og:description"]/@content
       Date:
         selector: //div[@class="release-date" and contains(.,"Released:")]/text()
         postProcess:
           - replace:
-            - regex: '^Released\:(.*)$'
-              with: $1
+              - regex: '^Released\:(.*)$'
+                with: $1
           - parseDate: Jan 2, 2006
       Image: //meta[@property="og:image"]/@content
       Studio:
@@ -27,8 +27,8 @@ xPathScrapers:
           selector: //div[@class="studio"]
           postProcess:
             - replace:
-              - regex: Studio:[\t]+([\w\s]+)
-                with: $1
+                - regex: Studio:[\t]+([\w\s]+)
+                  with: $1
       Tags:
         Name: //div[@class="container mb-3"]//div[@class="tags"]//a//text()
       Performers:

--- a/scrapers/JaysPov.yml
+++ b/scrapers/JaysPov.yml
@@ -9,23 +9,26 @@ xPathScrapers:
     scene:
       Title:
         selector: //div[@class="container-fluid video-title"]/h1/text()
-        replace:
-          - regex: '^(.+?)\ \-\ (.+)$'
-            with: $2
+        postProcess:
+          - replace:
+            - regex: '^(.+?)\ \-\ (.+)$'
+              with: $2
       Details: //meta[@name="og:description"]/@content
       Date:
         selector: //div[@class="release-date" and contains(.,"Released:")]/text()
-        replace:
-          - regex: '^Released\:(.*)$'
-            with: $1
-        parseDate: Jan 2, 2006
+        postProcess:
+          - replace:
+            - regex: '^Released\:(.*)$'
+              with: $1
+          - parseDate: Jan 2, 2006
       Image: //meta[@property="og:image"]/@content
       Studio:
         Name:
           selector: //div[@class="studio"]
-          replace:
-            - regex: Studio:[\t]+([\w\s]+)
-              with: $1
+          postProcess:
+            - replace:
+              - regex: Studio:[\t]+([\w\s]+)
+                with: $1
       Tags:
         Name: //div[@class="container mb-3"]//div[@class="tags"]//a//text()
       Performers:

--- a/scrapers/JaysPov.yml
+++ b/scrapers/JaysPov.yml
@@ -34,4 +34,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="video-performer"]/a/span/span/text()
 
-# Last Updated July 21, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Karups.yml
+++ b/scrapers/Karups.yml
@@ -12,8 +12,8 @@ xPathScrapers:
         selector: //span[@class="date"]/span[@class="content"]/text()
         postProcess:
           - replace:
-            - regex: (st|nd|rd|th)\,
-              with: ","
+              - regex: (st|nd|rd|th)\,
+                with: ","
           - parseDate: Jan 02, 2006
       Details:
         selector: //div[@class="content-information-description"]/p/text()

--- a/scrapers/Karups.yml
+++ b/scrapers/Karups.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Image:
         selector: //video[@id="player"]/@poster|//div[@class="video-poster"]/img/@src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Karups.yml
+++ b/scrapers/Karups.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Image:
         selector: //video[@id="player"]/@poster|//div[@class="video-poster"]/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Karups.yml
+++ b/scrapers/Karups.yml
@@ -10,10 +10,11 @@ xPathScrapers:
       Title: //h1[@class="page-heading"]/span[@class="title"]/text()
       Date:
         selector: //span[@class="date"]/span[@class="content"]/text()
-        replace:
-          - regex: (st|nd|rd|th)\,
-            with: ","
-        parseDate: Jan 02, 2006
+        postProcess:
+          - replace:
+            - regex: (st|nd|rd|th)\,
+              with: ","
+          - parseDate: Jan 02, 2006
       Details:
         selector: //div[@class="content-information-description"]/p/text()
       Performers:

--- a/scrapers/KellyMadisonMedia.yml
+++ b/scrapers/KellyMadisonMedia.yml
@@ -51,4 +51,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated September 5, 2020
+# Last Updated November 4, 2020

--- a/scrapers/KellyMadisonMedia.yml
+++ b/scrapers/KellyMadisonMedia.yml
@@ -20,17 +20,17 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-            - regex: .+(?:chromecast.+\stitle:\s')([^']+).+
-              with: $1
-            - regex: '&#039;'
-              with: "'"
+              - regex: .+(?:chromecast.+\stitle:\s')([^']+).+
+                with: $1
+              - regex: '&#039;'
+                with: "'"
       Details: $summary//div[contains(h4,'Episode Summary')]/p/text()
       Date:
         selector: $summary//div/h4[contains(.,'Published:')]/text()[2]
         postProcess:
           - replace:
-            - regex: Published:\s
-              with:
+              - regex: Published:\s
+                with:
           - parseDate: 2006-01-02
       Performers:
         Name: $summary/div//div/h4[contains(.,'Starring')]/a/text()
@@ -38,15 +38,15 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-            - regex: .+(?:poster:\s")([^"]+).+
-              with: $1
+              - regex: .+(?:poster:\s")([^"]+).+
+                with: $1
       Studio:
         Name:
           selector: //head/title/text()
           postProcess:
             - replace:
-              - regex: .+Official\s(\w+).+
-                with: $1
+                - regex: .+Official\s(\w+).+
+                  with: $1
 
 driver:
   useCDP: true

--- a/scrapers/KellyMadisonMedia.yml
+++ b/scrapers/KellyMadisonMedia.yml
@@ -18,31 +18,35 @@ xPathScrapers:
     scene:
       Title:
         selector: $script
-        replace:
-          - regex: .+(?:chromecast.+\stitle:\s')([^']+).+
-            with: $1
-          - regex: '&#039;'
-            with: "'"
+        postProcess:
+          - replace:
+            - regex: .+(?:chromecast.+\stitle:\s')([^']+).+
+              with: $1
+            - regex: '&#039;'
+              with: "'"
       Details: $summary//div[contains(h4,'Episode Summary')]/p/text()
       Date:
         selector: $summary//div/h4[contains(.,'Published:')]/text()[2]
-        replace:
-          - regex: Published:\s
-            with:
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: Published:\s
+              with:
+          - parseDate: 2006-01-02
       Performers:
         Name: $summary/div//div/h4[contains(.,'Starring')]/a/text()
       Image:
         selector: $script
-        replace:
-          - regex: .+(?:poster:\s")([^"]+).+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(?:poster:\s")([^"]+).+
+              with: $1
       Studio:
         Name:
           selector: //head/title/text()
-          replace:
-            - regex: .+Official\s(\w+).+
-              with: $1
+          postProcess:
+            - replace:
+              - regex: .+Official\s(\w+).+
+                with: $1
 
 driver:
   useCDP: true

--- a/scrapers/KellyMadisonMedia.yml
+++ b/scrapers/KellyMadisonMedia.yml
@@ -51,4 +51,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -24,29 +24,33 @@ xPathScrapers:
       Title: //h1[@class="shoot-title"]/text()
       Date:
         selector: //span[@class="shoot-date"]/text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details:
         selector: //span[@class="description-text"]/p
         concat: "\n\n"
       Performers:
         Name:
           selector: //p[@class="starring"]/span[@class="names h5"]/a/text()
-          replace:
-            - regex: \,
-              with: ""
+          postProcess:
+            - replace:
+              - regex: \,
+                with: ""
       Tags:
         Name:
           selector: //a[@class="tag"]
-          replace:
-            - regex: \,
-              with: ""
+          postProcess:
+            - replace:
+              - regex: \,
+                with: ""
       Image:
         selector: //video[@class="video-js vjs-fluid video-player"]/@poster
       Studio:
         Name:
           selector: //div[@class="column shoot-logo"]/a/@href
-          replace:
-            - regex: /channel/
-              with: ""
+          postProcess:
+            - replace:
+              - regex: /channel/
+                with: ""
       URL: //link[@rel="canonical"]/@href
 # Last Updated October 25, 2020

--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -34,15 +34,15 @@ xPathScrapers:
           selector: //p[@class="starring"]/span[@class="names h5"]/a/text()
           postProcess:
             - replace:
-              - regex: \,
-                with: ""
+                - regex: \,
+                  with: ""
       Tags:
         Name:
           selector: //a[@class="tag"]
           postProcess:
             - replace:
-              - regex: \,
-                with: ""
+                - regex: \,
+                  with: ""
       Image:
         selector: //video[@class="video-js vjs-fluid video-player"]/@poster
       Studio:
@@ -50,7 +50,7 @@ xPathScrapers:
           selector: //div[@class="column shoot-logo"]/a/@href
           postProcess:
             - replace:
-              - regex: /channel/
-                with: ""
+                - regex: /channel/
+                  with: ""
       URL: //link[@rel="canonical"]/@href
 # Last Updated November 4, 2020

--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -53,4 +53,4 @@ xPathScrapers:
               - regex: /channel/
                 with: ""
       URL: //link[@rel="canonical"]/@href
-# Last Updated October 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -53,4 +53,4 @@ xPathScrapers:
                 - regex: /channel/
                   with: ""
       URL: //link[@rel="canonical"]/@href
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -49,4 +49,4 @@ xPathScrapers:
       Country: //td[@class='text-danger']//a[contains(@href,'nationality')]/text()
       Image:
         selector: //div[@class='model--avatar']//img/@src
-# Last Updated August 12, 2020
+# Last Updated November 4, 2020

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -40,8 +40,8 @@ xPathScrapers:
         selector: //div[@id="player"]/@style
         postProcess:
           - replace:
-            - regex: .+(https[^"]+).+
-              with: $1
+              - regex: .+(https[^"]+).+
+                with: $1
 
   performerScraper:
     performer:

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -49,4 +49,4 @@ xPathScrapers:
       Country: //td[@class='text-danger']//a[contains(@href,'nationality')]/text()
       Image:
         selector: //div[@class='model--avatar']//img/@src
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -27,7 +27,8 @@ xPathScrapers:
         concat: " "
       Date:
         selector: //span[@title="Release date"]/a/text()
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Details: $description/div[3]/dd/text()
       Performers:
         Name: $description/div[1]/dd/a[contains(@href,'legalporno.com/model')]/text()
@@ -37,9 +38,10 @@ xPathScrapers:
         Name: $description/div[2]//a/text()
       Image:
         selector: //div[@id="player"]/@style
-        replace:
-          - regex: .+(https[^"]+).+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(https[^"]+).+
+              with: $1
 
   performerScraper:
     performer:

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -38,4 +38,4 @@ xPathScrapers:
         Name: $actors/h4/a//text()
       Image: //picture[@class="poster"]/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -38,4 +38,4 @@ xPathScrapers:
         Name: $actors/h4/a//text()
       Image: //picture[@class="poster"]/img/@src
 
-# Last Updated June 22, 2020
+# Last Updated November 4, 2020

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -20,14 +20,14 @@ xPathScrapers:
         selector: //title/text()
         postProcess:
           - replace:
-            - regex: (.+)(?:\s\|.+)
-              with: $1
+              - regex: (.+)(?:\s\|.+)
+                with: $1
       Date:
         selector: //meta[@itemprop="uploadDate"]/@content
         postProcess:
           - replace:
-            - regex: (\d{4})-(\d{2})-(\d{2}).+
-              with: $1-$2-$3
+              - regex: (\d{4})-(\d{2})-(\d{2}).+
+                with: $1-$2-$3
           - parseDate: 2006-01-02
       Details: //meta[@name="description"]/@content
       Tags:

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -18,15 +18,17 @@ xPathScrapers:
     scene:
       Title:
         selector: //title/text()
-        replace:
-          - regex: (.+)(?:\s\|.+)
-            with: $1
+        postProcess:
+          - replace:
+            - regex: (.+)(?:\s\|.+)
+              with: $1
       Date:
         selector: //meta[@itemprop="uploadDate"]/@content
-        replace:
-          - regex: (\d{4})-(\d{2})-(\d{2}).+
-            with: $1-$2-$3
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: (\d{4})-(\d{2})-(\d{2}).+
+              with: $1-$2-$3
+          - parseDate: 2006-01-02
       Details: //meta[@name="description"]/@content
       Tags:
         Name: $details//div[@class="col"][4]//a/text()|$details//div[@class="col"][6]//a/text()

--- a/scrapers/LittleCapriceDreams.yml
+++ b/scrapers/LittleCapriceDreams.yml
@@ -19,4 +19,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="vid_info_content"][1]//a
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/LittleCapriceDreams.yml
+++ b/scrapers/LittleCapriceDreams.yml
@@ -14,7 +14,8 @@ xPathScrapers:
         Name: //meta[@property="og:site_name"]/@content
       Date:
         selector: //div[@class="vid_date"]
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Performers:
         Name: //div[@class="vid_info_content"][1]//a
 

--- a/scrapers/LittleCapriceDreams.yml
+++ b/scrapers/LittleCapriceDreams.yml
@@ -19,4 +19,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="vid_info_content"][1]//a
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -141,4 +141,4 @@ xPathScrapers:
             - regex: '.*\.svg$'
               with: ''
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -37,8 +37,8 @@ xPathScrapers:
         selector: //*[contains(concat(' ', normalize-space(@class), ' '), ' profile-pic-name ')]/a/@href
         postProcess:
           - replace:
-            - regex: '/(?:Store/Videos/)?$'
-              with: /About/
+              - regex: '/(?:Store/Videos/)?$'
+                with: /About/
 
   performerScraper:
     common:
@@ -49,54 +49,54 @@ xPathScrapers:
         selector: $aboutlabel[contains(text(), 'Gender')]/following-sibling::*
         postProcess:
           - replace:
-            - regex: Trans
-              with: transgender_female
+              - regex: Trans
+                with: transgender_female
       URL: //a[@data-tab='about']/@href
       Twitter:
         selector: //*[@class='mv-about__banner-social']/a/i[@class='icon twitter-icon']/../@href
         postProcess:
           - replace:
-            - regex: ^.*twitter\.com/([^/?]+).*$
-              with: $1
+              - regex: ^.*twitter\.com/([^/?]+).*$
+                with: $1
       Instagram:
         selector: //*[@class='mv-about__banner-social']/a/i[@class='icon instagram-icon']/../@href
         postProcess:
           - replace:
-            - regex: ^.*instagram\.com/([^/?]+).*$
-              with: $1
+              - regex: ^.*instagram\.com/([^/?]+).*$
+                with: $1
       Birthdate:
         selector: $aboutlabel[contains(text(), 'Age')]/following-sibling::*
         postProcess:
           - replace:
-            - regex: ' \(.*\)$'
-              with: ''
+              - regex: ' \(.*\)$'
+                with: ''
           - parseDate: 2006.01.02
       Ethnicity:
         selector: $aboutlabel[contains(text(), 'Ethnicity')]/following-sibling::*
         postProcess:
           - replace:
-            - regex: 'Alaskan'
-              with: 'alaskan'
-            - regex: 'Aisan'
-              with: 'aisan'
-            - regex: 'Black / Ebony'
-              with: 'black'
-            - regex: 'East Indian'
-              with: 'east indian'
-            - regex: 'Latino / Hispanic'
-              with: 'hispanic'
-            - regex: 'Middle Eastern'
-              with: 'middle eastern'
-            - regex: 'Mixed'
-              with: 'mixed'
-            - regex: 'Native American'
-              with: 'native american'
-            - regex: 'Pacific Islander'
-              with: 'pacific islander'
-            - regex: 'White / Caucasian'
-              with: 'white'
-            - regex: 'Other'
-              with: 'other'
+              - regex: 'Alaskan'
+                with: 'alaskan'
+              - regex: 'Aisan'
+                with: 'aisan'
+              - regex: 'Black / Ebony'
+                with: 'black'
+              - regex: 'East Indian'
+                with: 'east indian'
+              - regex: 'Latino / Hispanic'
+                with: 'hispanic'
+              - regex: 'Middle Eastern'
+                with: 'middle eastern'
+              - regex: 'Mixed'
+                with: 'mixed'
+              - regex: 'Native American'
+                with: 'native american'
+              - regex: 'Pacific Islander'
+                with: 'pacific islander'
+              - regex: 'White / Caucasian'
+                with: 'white'
+              - regex: 'Other'
+                with: 'other'
       Country:
         selector: $aboutlabel[contains(text(), 'Nationality')]/following-sibling::*/img/@alt
       EyeColor:
@@ -105,30 +105,30 @@ xPathScrapers:
         selector: $aboutlabel[contains(text(), 'Height')]/following-sibling::*
         postProcess:
           - replace:
-            - regex: '.*?or '
-              with: ''
-            - regex: ' cm$'
-              with: ''
-            - regex: \D+[\s\S]+
-              with: ""
+              - regex: '.*?or '
+                with: ''
+              - regex: ' cm$'
+                with: ''
+              - regex: \D+[\s\S]+
+                with: ""
       Measurements:
         selector: $aboutlabel[contains(text(), 'Measurements')]/following-sibling::* | $aboutlabel[contains(text(), 'Breast Size')]/following-sibling::*
       FakeTits:
         selector: $aboutlabel[contains(text(), 'Breast Size')]/following-sibling::*[contains(text(), 'Natural') or contains(text(), 'Cohesive Gel') or contains(text(), 'Silicon') or contains(text(), 'Saline')]
         postProcess:
           - replace:
-            - regex: '^Natural.*$'
-              with: 'No'
-            - regex: '\s+?[0-9]+.*'
-              with: ''
+              - regex: '^Natural.*$'
+                with: 'No'
+              - regex: '\s+?[0-9]+.*'
+                with: ''
       CareerLength:
         selector: //*[@class='mv-about__banner-info']/strong/text()
         postProcess:
           - replace:
-            - regex: '^Joined '
-              with: ''
-            - regex: $
-              with: ' - today'
+              - regex: '^Joined '
+                with: ''
+              - regex: $
+                with: ' - today'
       Tattoos:
         selector: $aboutlabel[contains(text(), 'Tattoos')]/following-sibling::*
       Piercings:
@@ -138,7 +138,7 @@ xPathScrapers:
         selector: //*[contains(concat(' ',normalize-space(@class),' '),' mv-model-display ')][not(@data-current-portrait = '')]/@data-current-portrait | //*[contains(concat(' ',normalize-space(@class),' '),' mv-model-display ')][not(@data-current-avatar = '')]/@data-current-avatar
         postProcess:
           - replace:
-            - regex: '.*\.svg$'
-              with: ''
+              - regex: '.*\.svg$'
+                with: ''
 
 # Last Updated November 4, 2020

--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -24,7 +24,8 @@ xPathScrapers:
       # Only partial dates provides, which would currently be made as 0000-01-01
       # Date:
       #   selector: //div[@class="mb-1"]/span[2]/text()
-      #   parseDate: Jan 02
+      #   postProcess:
+      #     - parseDate: Jan 02
       Performers:
         Name: $details//h4/a/text()
       Image: //div[@id="rmpPlayer"]/@data-video-screenshot
@@ -34,9 +35,10 @@ xPathScrapers:
       Name: //*[contains(concat(' ', normalize-space(@class), ' '), ' profile-pic-name ')]/a/text()
       URL:
         selector: //*[contains(concat(' ', normalize-space(@class), ' '), ' profile-pic-name ')]/a/@href
-        replace:
-          - regex: '/(?:Store/Videos/)?$'
-            with: /About/
+        postProcess:
+          - replace:
+            - regex: '/(?:Store/Videos/)?$'
+              with: /About/
 
   performerScraper:
     common:
@@ -45,80 +47,88 @@ xPathScrapers:
       Name: //*[@class='mv-about__banner-name ']/text()
       Gender:
         selector: $aboutlabel[contains(text(), 'Gender')]/following-sibling::*
-        replace:
-          - regex: Trans
-            with: transgender_female
+        postProcess:
+          - replace:
+            - regex: Trans
+              with: transgender_female
       URL: //a[@data-tab='about']/@href
       Twitter:
         selector: //*[@class='mv-about__banner-social']/a/i[@class='icon twitter-icon']/../@href
-        replace:
-          - regex: ^.*twitter\.com/([^/?]+).*$
-            with: $1
+        postProcess:
+          - replace:
+            - regex: ^.*twitter\.com/([^/?]+).*$
+              with: $1
       Instagram:
         selector: //*[@class='mv-about__banner-social']/a/i[@class='icon instagram-icon']/../@href
-        replace:
-          - regex: ^.*instagram\.com/([^/?]+).*$
-            with: $1
+        postProcess:
+          - replace:
+            - regex: ^.*instagram\.com/([^/?]+).*$
+              with: $1
       Birthdate:
         selector: $aboutlabel[contains(text(), 'Age')]/following-sibling::*
-        replace:
-          - regex: ' \(.*\)$'
-            with: ''
-        parseDate: 2006.01.02
+        postProcess:
+          - replace:
+            - regex: ' \(.*\)$'
+              with: ''
+          - parseDate: 2006.01.02
       Ethnicity:
         selector: $aboutlabel[contains(text(), 'Ethnicity')]/following-sibling::*
-        replace:
-          - regex: 'Alaskan'
-            with: 'alaskan'
-          - regex: 'Aisan'
-            with: 'aisan'
-          - regex: 'Black / Ebony'
-            with: 'black'
-          - regex: 'East Indian'
-            with: 'east indian'
-          - regex: 'Latino / Hispanic'
-            with: 'hispanic'
-          - regex: 'Middle Eastern'
-            with: 'middle eastern'
-          - regex: 'Mixed'
-            with: 'mixed'
-          - regex: 'Native American'
-            with: 'native american'
-          - regex: 'Pacific Islander'
-            with: 'pacific islander'
-          - regex: 'White / Caucasian'
-            with: 'white'
-          - regex: 'Other'
-            with: 'other'
+        postProcess:
+          - replace:
+            - regex: 'Alaskan'
+              with: 'alaskan'
+            - regex: 'Aisan'
+              with: 'aisan'
+            - regex: 'Black / Ebony'
+              with: 'black'
+            - regex: 'East Indian'
+              with: 'east indian'
+            - regex: 'Latino / Hispanic'
+              with: 'hispanic'
+            - regex: 'Middle Eastern'
+              with: 'middle eastern'
+            - regex: 'Mixed'
+              with: 'mixed'
+            - regex: 'Native American'
+              with: 'native american'
+            - regex: 'Pacific Islander'
+              with: 'pacific islander'
+            - regex: 'White / Caucasian'
+              with: 'white'
+            - regex: 'Other'
+              with: 'other'
       Country:
         selector: $aboutlabel[contains(text(), 'Nationality')]/following-sibling::*/img/@alt
       EyeColor:
         selector: $aboutlabel[contains(text(), 'Eye Color')]/following-sibling::*
       Height:
         selector: $aboutlabel[contains(text(), 'Height')]/following-sibling::*
-        replace:
-          - regex: '.*?or '
-            with: ''
-          - regex: ' cm$'
-            with: ''
-          - regex: \D+[\s\S]+
-            with: ""
+        postProcess:
+          - replace:
+            - regex: '.*?or '
+              with: ''
+            - regex: ' cm$'
+              with: ''
+            - regex: \D+[\s\S]+
+              with: ""
       Measurements:
         selector: $aboutlabel[contains(text(), 'Measurements')]/following-sibling::* | $aboutlabel[contains(text(), 'Breast Size')]/following-sibling::*
       FakeTits:
         selector: $aboutlabel[contains(text(), 'Breast Size')]/following-sibling::*[contains(text(), 'Natural') or contains(text(), 'Cohesive Gel') or contains(text(), 'Silicon') or contains(text(), 'Saline')]
-        replace:
-          - regex: '^Natural.*$'
-            with: 'No'
-          - regex: '\s+?[0-9]+.*'
-            with: ''
+        postProcess:
+          - replace:
+            - regex: '^Natural.*$'
+              with: 'No'
+            - regex: '\s+?[0-9]+.*'
+              with: ''
       CareerLength:
         selector: //*[@class='mv-about__banner-info']/strong/text()
-        replace:
-          - regex: '^Joined '
-            with: ''
-          - regex: $
-            with: ' - today'
+        postProcess:
+          - replace:
+            - regex: '^Joined '
+              with: ''
+            - regex: $
+              with: ' - today'
       Tattoos:
         selector: $aboutlabel[contains(text(), 'Tattoos')]/following-sibling::*
       Piercings:
@@ -126,8 +136,9 @@ xPathScrapers:
 
       Image:
         selector: //*[contains(concat(' ',normalize-space(@class),' '),' mv-model-display ')][not(@data-current-portrait = '')]/@data-current-portrait | //*[contains(concat(' ',normalize-space(@class),' '),' mv-model-display ')][not(@data-current-avatar = '')]/@data-current-avatar
-        replace:
-          - regex: '.*\.svg$'
-            with: ''
+        postProcess:
+          - replace:
+            - regex: '.*\.svg$'
+              with: ''
 
 # Last Updated October 3, 2020

--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -141,4 +141,4 @@ xPathScrapers:
               - regex: '.*\.svg$'
                 with: ''
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/MilfVR.yml
+++ b/scrapers/MilfVR.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: //div[@class="detail__header detail__header-lg"]/h1
       Date:
         selector: $info//span[@class="detail__date"]/text()
-        parseDate: 2 January, 2006
+        postProcess:
+          - parseDate: 2 January, 2006
       Details:
         selector: //div[@class="detail__txt detail__txt-show_lg"]/text()|//span[@class="more__body"]/text()
         concat: " "

--- a/scrapers/MilfVR.yml
+++ b/scrapers/MilfVR.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
       Image: (//div[@class="photo-strip__body"]/div[@class="photo-strip__slide"])[1]/@data-src
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/MilfVR.yml
+++ b/scrapers/MilfVR.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Performers:
         Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
       Image: (//div[@class="photo-strip__body"]/div[@class="photo-strip__slide"])[1]/@data-src
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -95,7 +95,8 @@ xPathScrapers:
       Title: $section//h1/text()|$section//h2/text()
       Date:
         selector: //div[text()="Release Date:"]/../text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details: //div[text()="Description:"]/../div[not(@class)]/text()
       Tags:
         Name: //a[contains(@href,"/scenes?tags")]/text()[1]
@@ -119,7 +120,8 @@ xPathScrapers:
       Name: $section//h1/text()|$section//h2/text()
       Date:
         selector: //div[text()="Release Date:"]/../text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Synopsis: //div[text()="Description:"]/../div[not(@class)]/text()
       Studio:
         Name: 

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -269,4 +269,4 @@ xPathScrapers:
 #        fixed: "Female"
       URL: //link[@rel="canonical"]/@href
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -128,12 +128,12 @@ xPathScrapers:
           selector: //link[@rel="canonical"]/@href
           postProcess:
             - replace: 
-              - regex: .*www\.
-                with: ""
-              - regex: \.com.+
-                with: ""
-              - regex: " "
-                with: ""
+                - regex: .*www\.
+                  with: ""
+                - regex: \.com.+
+                  with: ""
+                - regex: " "
+                  with: ""
             - map:
                 digitalplayground: "Digital Playground"
                 transsensual: TransSensual
@@ -154,8 +154,8 @@ xPathScrapers:
         selector: //li[contains(.,"Birth Place")]/span/text()[not(contains(.,"N/A"))]
         postProcess:
           - replace:
-            - regex: .*?,\s
-              with: ""
+              - regex: .*?,\s
+                with: ""
           - map:
               AK: "USA"
               AL: "USA"

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -269,4 +269,4 @@ xPathScrapers:
 #        fixed: "Female"
       URL: //link[@rel="canonical"]/@href
 
-# Last Updated October 10, 2020
+# Last Updated November 4, 2020

--- a/scrapers/MissaX.yml
+++ b/scrapers/MissaX.yml
@@ -27,4 +27,4 @@ xPathScrapers:
               - regex: .+(?:poster=")([^"]*).+
                 with: https://missax.com$1
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/MissaX.yml
+++ b/scrapers/MissaX.yml
@@ -12,8 +12,8 @@ xPathScrapers:
         selector: //p[@class="dvd-scenes__data"][1]/text()[1]
         postProcess:
           - replace:
-            - regex: (?:.+Added:\s)([\d/]*).+
-              with: $1
+              - regex: (?:.+Added:\s)([\d/]*).+
+                with: $1
           - parseDate: 01/02/2006
       Details: //strong/text()
       Tags:
@@ -24,7 +24,7 @@ xPathScrapers:
         selector: //script[contains(text(),'hidden_fake_trailer')]/text()
         postProcess:
           - replace:
-            - regex: .+(?:poster=")([^"]*).+
-              with: https://missax.com$1
+              - regex: .+(?:poster=")([^"]*).+
+                with: https://missax.com$1
 
 # Last Updated November 4, 2020

--- a/scrapers/MissaX.yml
+++ b/scrapers/MissaX.yml
@@ -27,4 +27,4 @@ xPathScrapers:
             - regex: .+(?:poster=")([^"]*).+
               with: https://missax.com$1
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/MissaX.yml
+++ b/scrapers/MissaX.yml
@@ -10,10 +10,11 @@ xPathScrapers:
       Title: //p[@class="raiting-section__title"]/text()
       Date:
         selector: //p[@class="dvd-scenes__data"][1]/text()[1]
-        replace:
-          - regex: (?:.+Added:\s)([\d/]*).+
-            with: $1
-        parseDate: 01/02/2006
+        postProcess:
+          - replace:
+            - regex: (?:.+Added:\s)([\d/]*).+
+              with: $1
+          - parseDate: 01/02/2006
       Details: //strong/text()
       Tags:
         Name: //p[@class="dvd-scenes__data"][2]/a/text()
@@ -21,8 +22,9 @@ xPathScrapers:
         Name: //p[@class="dvd-scenes__data"][1]/a/text()
       Image:
         selector: //script[contains(text(),'hidden_fake_trailer')]/text()
-        replace:
-          - regex: .+(?:poster=")([^"]*).+
-            with: https://missax.com$1
+        postProcess:
+          - replace:
+            - regex: .+(?:poster=")([^"]*).+
+              with: https://missax.com$1
 
 # Last Updated October 3, 2020

--- a/scrapers/Modelhub.yml
+++ b/scrapers/Modelhub.yml
@@ -112,4 +112,4 @@ xPathScrapers:
       Details: //p[@ class="videoDescription"]
       Performers:
         Name: //div[@class='videoAvatar']/div[1]/a[2]
-# Last Updated Jul 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Modelhub.yml
+++ b/scrapers/Modelhub.yml
@@ -33,7 +33,8 @@ xPathScrapers:
       Name: //div[@class="infoSection"]/h1/text()
       Birthdate:
         selector: //span[@class='bday js_lazy_bkg']/text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Gender:
         selector: //ul[@class="allStats"]/li[contains(.,"Gender")]/span
         postProcess:

--- a/scrapers/Modelhub.yml
+++ b/scrapers/Modelhub.yml
@@ -112,4 +112,4 @@ xPathScrapers:
       Details: //p[@ class="videoDescription"]
       Performers:
         Name: //div[@class='videoAvatar']/div[1]/a[2]
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Mypervmom.yml
+++ b/scrapers/Mypervmom.yml
@@ -15,15 +15,15 @@ xPathScrapers:
         selector: //div[@id="title-single"]/span
         postProcess:
           - replace:
-            - regex: (\w+\s)(\d+)\w+,(\s\d\d\d\d)
-              with: $1$2$3
+              - regex: (\w+\s)(\d+)\w+,(\s\d\d\d\d)
+                with: $1$2$3
           - parseDate: January 2 2006
       Details:
         selector: //p[@class="more"]|//span[@class="more"]/text()
         postProcess:
           - replace:
-            - regex: ^Description\:(.+)
-              with: $1
+              - regex: ^Description\:(.+)
+                with: $1
       Performers:
         Name: //div[@id="title-single"]//a
       Image:

--- a/scrapers/Mypervmom.yml
+++ b/scrapers/Mypervmom.yml
@@ -13,15 +13,17 @@ xPathScrapers:
       Title: //h2
       Date:
         selector: //div[@id="title-single"]/span
-        replace:
-          - regex: (\w+\s)(\d+)\w+,(\s\d\d\d\d)
-            with: $1$2$3
-        parseDate: January 2 2006
+        postProcess:
+          - replace:
+            - regex: (\w+\s)(\d+)\w+,(\s\d\d\d\d)
+              with: $1$2$3
+          - parseDate: January 2 2006
       Details:
         selector: //p[@class="more"]|//span[@class="more"]/text()
-        replace:
-          - regex: ^Description\:(.+)
-            with: $1
+        postProcess:
+          - replace:
+            - regex: ^Description\:(.+)
+              with: $1
       Performers:
         Name: //div[@id="title-single"]//a
       Image:

--- a/scrapers/Mypervmom.yml
+++ b/scrapers/Mypervmom.yml
@@ -28,3 +28,5 @@ xPathScrapers:
         Name: //div[@id="title-single"]//a
       Image:
         selector: //div[@class="entry"]//video/@poster
+
+# Last Updated November 4, 2020

--- a/scrapers/Mypervmom.yml
+++ b/scrapers/Mypervmom.yml
@@ -29,4 +29,4 @@ xPathScrapers:
       Image:
         selector: //div[@class="entry"]//video/@poster
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/NaughtyAmerica.yml
+++ b/scrapers/NaughtyAmerica.yml
@@ -33,4 +33,4 @@ xPathScrapers:
             - regex: ^
               with: "https:"
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/NaughtyAmerica.yml
+++ b/scrapers/NaughtyAmerica.yml
@@ -18,8 +18,8 @@ xPathScrapers:
         selector: //div[@class="synopsis grey-text"]
         postProcess:
           - replace:
-            - regex: "Synopsis"
-              with: ""
+              - regex: "Synopsis"
+                with: ""
       Tags:
         Name: //div[@class="categories grey-text"]/a
       Performers:
@@ -30,7 +30,7 @@ xPathScrapers:
         selector: //img[@class="start-card lazyload"]/@data-src|//img[@class="start-card"]/@src|//dl8-video[@id="vr_player"]/@poster
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+              - regex: ^
+                with: "https:"
 
 # Last Updated November 4, 2020

--- a/scrapers/NaughtyAmerica.yml
+++ b/scrapers/NaughtyAmerica.yml
@@ -33,4 +33,4 @@ xPathScrapers:
               - regex: ^
                 with: "https:"
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/NaughtyAmerica.yml
+++ b/scrapers/NaughtyAmerica.yml
@@ -12,12 +12,14 @@ xPathScrapers:
       Title: $sceneinfo/h1[@class="scene-title grey-text"]
       Date:
         selector: //div[@class="date-tags"]/span
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details:
         selector: //div[@class="synopsis grey-text"]
-        replace:
-           - regex: "Synopsis"
-             with: ""
+        postProcess:
+          - replace:
+            - regex: "Synopsis"
+              with: ""
       Tags:
         Name: //div[@class="categories grey-text"]/a
       Performers:
@@ -26,8 +28,9 @@ xPathScrapers:
         Name: $sceneinfo/a[@class="site-title grey-text link"]
       Image:
         selector: //img[@class="start-card lazyload"]/@data-src|//img[@class="start-card"]/@src|//dl8-video[@id="vr_player"]/@poster
-        replace:
-          - regex: ^
-            with: "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
 
 # Last Updated October 3, 2020

--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -31,4 +31,4 @@ xPathScrapers:
         Name: //span[@class="update_models"]/a/text()
       Image: //video/@poster
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -21,8 +21,8 @@ xPathScrapers:
         selector: //div[@class="cell update_date"]/text()
         postProcess:
           - replace:
-            - regex: Released:\s
-              with:
+              - regex: Released:\s
+                with:
           - parseDate: 01/02/2006
       Details: //span[@class="update_description"]/text()
       Tags:

--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -31,4 +31,4 @@ xPathScrapers:
         Name: //span[@class="update_models"]/a/text()
       Image: //video/@poster
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -19,10 +19,11 @@ xPathScrapers:
       Title: //div[@class="update_title"]/text()
       Date:
         selector: //div[@class="cell update_date"]/text()
-        replace:
-          - regex: Released:\s
-            with:
-        parseDate: 01/02/2006
+        postProcess:
+          - replace:
+            - regex: Released:\s
+              with:
+          - parseDate: 01/02/2006
       Details: //span[@class="update_description"]/text()
       Tags:
         Name: //span[@class="update_tags"]/a/text()

--- a/scrapers/PlayboyTV.yml
+++ b/scrapers/PlayboyTV.yml
@@ -10,17 +10,19 @@ xPathScrapers:
       Title: //h2[@class="title"]/text()
       Date:
         selector: //small[@class="subtitle"]/text()
-        replace:
-          - regex: .+(?:• Added on )(.+)
-            with: $1
-        # Date is not always present, but when it is, it is in a set format in
-        # the description field
-        parseDate: 02 January 2006
+        postProcess:
+          - replace:
+            - regex: .+(?:• Added on )(.+)
+              with: $1
+          # Date is not always present, but when it is, it is in a set format in
+          # the description field
+          - parseDate: 02 January 2006
       Details:
         selector: //small[@class="subtitle"]/text()
-        replace:
-          - regex: (.+)(?:• Added on )(?:.+)
-            with: $1
+        postProcess:
+          - replace:
+            - regex: (.+)(?:• Added on )(?:.+)
+              with: $1
         # The field sometimes, has a description, sometimes has episode details.
         # When it has episode details, the date can be stripped out.
       Image: //video[@id="video"]/@poster

--- a/scrapers/PlayboyTV.yml
+++ b/scrapers/PlayboyTV.yml
@@ -12,8 +12,8 @@ xPathScrapers:
         selector: //small[@class="subtitle"]/text()
         postProcess:
           - replace:
-            - regex: .+(?:• Added on )(.+)
-              with: $1
+              - regex: .+(?:• Added on )(.+)
+                with: $1
           # Date is not always present, but when it is, it is in a set format in
           # the description field
           - parseDate: 02 January 2006
@@ -21,8 +21,8 @@ xPathScrapers:
         selector: //small[@class="subtitle"]/text()
         postProcess:
           - replace:
-            - regex: (.+)(?:• Added on )(?:.+)
-              with: $1
+              - regex: (.+)(?:• Added on )(?:.+)
+                with: $1
         # The field sometimes, has a description, sometimes has episode details.
         # When it has episode details, the date can be stripped out.
       Image: //video[@id="video"]/@poster

--- a/scrapers/PlayboyTV.yml
+++ b/scrapers/PlayboyTV.yml
@@ -27,4 +27,4 @@ xPathScrapers:
         # When it has episode details, the date can be stripped out.
       Image: //video[@id="video"]/@poster
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/PlayboyTV.yml
+++ b/scrapers/PlayboyTV.yml
@@ -27,4 +27,4 @@ xPathScrapers:
         # When it has episode details, the date can be stripped out.
       Image: //video[@id="video"]/@poster
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/PlumperPass.yml
+++ b/scrapers/PlumperPass.yml
@@ -36,4 +36,4 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/PlumperPass.yml
+++ b/scrapers/PlumperPass.yml
@@ -11,8 +11,8 @@ xPathScrapers:
         selector: //div[@class="clearfix"]/h1/span/text()
         postProcess:
           - replace:
-            - regex: \"
-              with:
+              - regex: \"
+                with:
       Details: //div[@class="movie-desc"]/text()
       Tags:
         Name:
@@ -24,10 +24,10 @@ xPathScrapers:
         selector: //script[contains(.,'jwplayer("videoplayer").setup')]/text()
         postProcess:
           - replace:
-            - regex: (.+image:\s+")(.+jpg)(.+)
-              with: $2
-            - regex: ^
-              with: "https://www.plumperpass.com/t1/"
+              - regex: (.+image:\s+")(.+jpg)(.+)
+                with: $2
+              - regex: ^
+                with: "https://www.plumperpass.com/t1/"
       Studio:
         Name:
           fixed: "Plumperpass"

--- a/scrapers/PlumperPass.yml
+++ b/scrapers/PlumperPass.yml
@@ -36,4 +36,4 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
 
-# Last Updated August 13, 2020
+# Last Updated November 4, 2020

--- a/scrapers/PlumperPass.yml
+++ b/scrapers/PlumperPass.yml
@@ -22,11 +22,12 @@ xPathScrapers:
         Name: //div[@class="clearfix"]/h1/a[1]/text()
       Image:
         selector: //script[contains(.,'jwplayer("videoplayer").setup')]/text()
-        replace:
-          - regex: (.+image:\s+")(.+jpg)(.+)
-            with: $2
-          - regex: ^
-            with: "https://www.plumperpass.com/t1/"
+        postProcess:
+          - replace:
+            - regex: (.+image:\s+")(.+jpg)(.+)
+              with: $2
+            - regex: ^
+              with: "https://www.plumperpass.com/t1/"
       Studio:
         Name:
           fixed: "Plumperpass"

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -22,8 +22,8 @@ xPathScrapers:
         selector: //div[@class="wrap"]/div[@class="thumbnail-info-wrapper"]/a[@class="title"]/@href
         postProcess:
           - replace:
-            - regex: ^
-              with: "https://www.pornhub.com"
+              - regex: ^
+                with: "https://www.pornhub.com"
   performerScraper:
     common:
       $infoPiece: //div[@class="infoPiece"]/span
@@ -41,8 +41,8 @@ xPathScrapers:
         selector: $infoPiece[text() = 'Height:']/../span[@class="smallInfo"]
         postProcess:
           - replace:
-            - regex: .*\((\d+) cm\)
-              with: $1
+              - regex: .*\((\d+) cm\)
+                with: $1
       Ethnicity: $infoPiece[text() = 'Ethnicity:']/../span[@class="smallInfo"]
       FakeTits: $infoPiece[text() = 'Fake Boobs:']/../span[@class="smallInfo"]
       Piercings: $infoPiece[text() = 'Piercings:']/../span[@class="smallInfo"]
@@ -51,8 +51,8 @@ xPathScrapers:
         selector: $infoPiece[text() = 'Career Start and End:']/../span[@class="smallInfo"]
         postProcess:
           - replace:
-            - regex: \s+to\s+
-              with: "-"
+              - regex: \s+to\s+
+                with: "-"
       URL: //link[@rel="canonical"][1]/@href
   sceneScraper:
     common:
@@ -65,10 +65,10 @@ xPathScrapers:
         selector: //script[contains(., 'uploadDate')]/text()
         postProcess:
           - replace:
-            - regex: .+(?:"uploadDate":\s")([^"]+).+
-              with: $1
-            - regex: (.+)T.+
-              with: $1
+              - regex: .+(?:"uploadDate":\s")([^"]+).+
+                with: $1
+              - regex: (.+)T.+
+                with: $1
           - parseDate: 2006-01-02
       Tags:
         Name: //div[@class="categoriesWrapper"]//a[not(@class="add-btn-small ")]|//div[@class="tagsWrapper"]//a[not(@class="add-btn-small")]

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -81,4 +81,4 @@ xPathScrapers:
         Name: $studio
         URL: $studio/@href
         
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -20,9 +20,10 @@ xPathScrapers:
       Name: //div[@class="wrap"]/div[@class="thumbnail-info-wrapper"]/a[@class="title"]/text()
       URL:
         selector: //div[@class="wrap"]/div[@class="thumbnail-info-wrapper"]/a[@class="title"]/@href
-        replace:
-          - regex: ^
-            with: "https://www.pornhub.com"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https://www.pornhub.com"
   performerScraper:
     common:
       $infoPiece: //div[@class="infoPiece"]/span
@@ -30,25 +31,28 @@ xPathScrapers:
       Name: //h1[@itemprop="name"]
       Birthdate:
         selector: //span[@itemprop="birthDate"]
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Gender: //span[@itemprop="gender"]
       Twitter: //span[text() = 'Twitter']/../@href
       Instagram: //span[text() = 'Instagram']/../@href
       Measurements: $infoPiece[text() = 'Measurements:']/../span[@class="smallInfo"]
       Height:
         selector: $infoPiece[text() = 'Height:']/../span[@class="smallInfo"]
-        replace:
-          - regex: .*\((\d+) cm\)
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .*\((\d+) cm\)
+              with: $1
       Ethnicity: $infoPiece[text() = 'Ethnicity:']/../span[@class="smallInfo"]
       FakeTits: $infoPiece[text() = 'Fake Boobs:']/../span[@class="smallInfo"]
       Piercings: $infoPiece[text() = 'Piercings:']/../span[@class="smallInfo"]
       Tattoos: $infoPiece[text() = 'Tattoos:']/../span[@class="smallInfo"]
       CareerLength:
         selector: $infoPiece[text() = 'Career Start and End:']/../span[@class="smallInfo"]
-        replace:
-          - regex: \s+to\s+
-            with: "-"
+        postProcess:
+          - replace:
+            - regex: \s+to\s+
+              with: "-"
       URL: //link[@rel="canonical"][1]/@href
   sceneScraper:
     common:
@@ -59,12 +63,13 @@ xPathScrapers:
       Details: //meta[@property="og:description"][1]/@content
       Date:
         selector: //script[contains(., 'uploadDate')]/text()
-        replace:
-          - regex: .+(?:"uploadDate":\s")([^"]+).+
-            with: $1
-          - regex: (.+)T.+
-            with: $1
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: .+(?:"uploadDate":\s")([^"]+).+
+              with: $1
+            - regex: (.+)T.+
+              with: $1
+          - parseDate: 2006-01-02
       Tags:
         Name: //div[@class="categoriesWrapper"]//a[not(@class="add-btn-small ")]|//div[@class="tagsWrapper"]//a[not(@class="add-btn-small")]
       Image:

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -81,4 +81,4 @@ xPathScrapers:
         Name: $studio
         URL: $studio/@href
         
-# Last Updated Jun 10, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ProducersFun.yml
+++ b/scrapers/ProducersFun.yml
@@ -13,8 +13,8 @@ xPathScrapers:
         selector: //p[@class="video-date"]/text()[2]
         postProcess:
           - replace:
-            - regex: (st|nd|rd|th)\,
-              with: ","
+              - regex: (st|nd|rd|th)\,
+                with: ","
           - parseDate: January 2, 2006
       Image: //section[@class="top-wrapper"]/div//video/@poster
       Tags:

--- a/scrapers/ProducersFun.yml
+++ b/scrapers/ProducersFun.yml
@@ -21,4 +21,4 @@ xPathScrapers:
         Name:
           selector: //p[@class="video-tags"]/a/text()
 
-# Last Updated July 21, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ProducersFun.yml
+++ b/scrapers/ProducersFun.yml
@@ -21,4 +21,4 @@ xPathScrapers:
         Name:
           selector: //p[@class="video-tags"]/a/text()
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ProducersFun.yml
+++ b/scrapers/ProducersFun.yml
@@ -11,10 +11,11 @@ xPathScrapers:
       Details: (//div[@class="shadow video-details"]/p[not(@class)])[1]/text()
       Date:
         selector: //p[@class="video-date"]/text()[2]
-        replace:
-          - regex: (st|nd|rd|th)\,
-            with: ","
-        parseDate: January 2, 2006
+        postProcess:
+          - replace:
+            - regex: (st|nd|rd|th)\,
+              with: ","
+          - parseDate: January 2, 2006
       Image: //section[@class="top-wrapper"]/div//video/@poster
       Tags:
         Name:

--- a/scrapers/RealSensual.yml
+++ b/scrapers/RealSensual.yml
@@ -26,4 +26,4 @@ xPathScrapers:
                   with:
       Image: //video[@class="ampVideo"]/@poster
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/RealSensual.yml
+++ b/scrapers/RealSensual.yml
@@ -22,8 +22,8 @@ xPathScrapers:
           selector: $info/div[1]/div[1]/a/text()
           postProcess:
             - replace:
-              - regex: \.$
-                with:
+                - regex: \.$
+                  with:
       Image: //video[@class="ampVideo"]/@poster
 
 # Last Updated November 4, 2020

--- a/scrapers/RealSensual.yml
+++ b/scrapers/RealSensual.yml
@@ -12,16 +12,18 @@ xPathScrapers:
       Title: //h2[@class="titular col-12"]/text()
       Date:
         selector: $info//p[@class="date"]/text()
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Details: //p[@class="description-scene"]/text()
       Tags:
         Name: $info/div[2]//a/text()
       Performers:
         Name:
           selector: $info/div[1]/div[1]/a/text()
-          replace:
-            - regex: \.$
-              with:
+          postProcess:
+            - replace:
+              - regex: \.$
+                with:
       Image: //video[@class="ampVideo"]/@poster
 
 # Last Updated October 3, 2020

--- a/scrapers/RealSensual.yml
+++ b/scrapers/RealSensual.yml
@@ -26,4 +26,4 @@ xPathScrapers:
                 with:
       Image: //video[@class="ampVideo"]/@poster
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -31,4 +31,4 @@ xPathScrapers:
               - regex: .+(http[^\)]+).+
                 with: $1
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -31,4 +31,4 @@ xPathScrapers:
             - regex: .+(http[^\)]+).+
               with: $1
 
-# Last Updated July 16, 2020
+# Last Updated November 4, 2020

--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -12,10 +12,11 @@ xPathScrapers:
       Title: $info//div[@class="video-group-left"]//h1[@class="title"]/text()
       Date:
         selector: $info//div[@class="video-group-left"]//div[@class="grid-one-date"]/span[@class="date-display-single"]/@content
-        replace:
-          - regex: (\d{4}-\d{2}-\d{2})T.+
-            with: $1
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: (\d{4}-\d{2}-\d{2})T.+
+              with: $1
+          - parseDate: 2006-01-02
       Details:
         selector: $info//div[@class="video-group-bottom"]//text()
         concat: " "
@@ -25,8 +26,9 @@ xPathScrapers:
         Name: $info//div[@class="video-group-left"]/div[@class="video-actress-name"]//a/text()
       Image:
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
-        replace:
-          - regex: .+(http[^\)]+).+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(http[^\)]+).+
+              with: $1
 
 # Last Updated July 16, 2020

--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -14,8 +14,8 @@ xPathScrapers:
         selector: $info//div[@class="video-group-left"]//div[@class="grid-one-date"]/span[@class="date-display-single"]/@content
         postProcess:
           - replace:
-            - regex: (\d{4}-\d{2}-\d{2})T.+
-              with: $1
+              - regex: (\d{4}-\d{2}-\d{2})T.+
+                with: $1
           - parseDate: 2006-01-02
       Details:
         selector: $info//div[@class="video-group-bottom"]//text()
@@ -28,7 +28,7 @@ xPathScrapers:
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
         postProcess:
           - replace:
-            - regex: .+(http[^\)]+).+
-              with: $1
+              - regex: .+(http[^\)]+).+
+                with: $1
 
 # Last Updated November 4, 2020

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: //div[@class="u-relative u-z--zero"]//h1/text()
       Date:
         selector: $info//time/@datetime
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Details:
         selector: $info//div[@class="u-mb--four u-lh--opt u-fs--fo u-fw--medium u-lw"]//text()
         concat: " "
@@ -24,8 +25,9 @@ xPathScrapers:
         Name: $info//div[@class="u-mt--three"]/div[@class="u-mb--three"]/a/text()
       Image:
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
-        replace:
-          - regex: .+(http[^\)]+).+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(http[^\)]+).+
+              with: $1
 
 # Last Updated May 25, 2020

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -30,4 +30,4 @@ xPathScrapers:
               - regex: .+(http[^\)]+).+
                 with: $1
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -27,7 +27,7 @@ xPathScrapers:
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
         postProcess:
           - replace:
-            - regex: .+(http[^\)]+).+
-              with: $1
+              - regex: .+(http[^\)]+).+
+                with: $1
 
 # Last Updated November 4, 2020

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -30,4 +30,4 @@ xPathScrapers:
             - regex: .+(http[^\)]+).+
               with: $1
 
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/SexVR.yml
+++ b/scrapers/SexVR.yml
@@ -85,4 +85,4 @@ xPathScrapers:
         Name: //span[@class="studio-name"]//text()
       Image: //dl8-video/@poster
 
-# Last Updated June 2, 2020
+# Last Updated November 4, 2020

--- a/scrapers/SexVR.yml
+++ b/scrapers/SexVR.yml
@@ -85,4 +85,4 @@ xPathScrapers:
         Name: //span[@class="studio-name"]//text()
       Image: //dl8-video/@poster
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/SexVR.yml
+++ b/scrapers/SexVR.yml
@@ -28,45 +28,45 @@ xPathScrapers:
         selector: //meta[@name="application-name"]/@content
         postProcess:
           - replace:
-            - regex: .+
-              with: female
+              - regex: .+
+                with: female
       Twitter: $info//li[span[@class="sub-label"]/text()="Twitter:"]/span[@class="sub-desc"]/a/@href
       Birthdate:
         selector: $info//li[@class="profile-field profile-field-fob"]/span[@class="sub-desc"]/text()
         postProcess:
           - replace:
-            - regex: \s\(\d+\s\w+\)
-              with:
+              - regex: \s\(\d+\s\w+\)
+                with:
           - parseDate: 2 Jan 2006
       Ethnicity:
         selector: $info//li[span[@class="sub-label"]/text()="Ethnicity:"]/span[@class="sub-desc"]/text()
         postProcess:
           - replace:
-            - regex: Latin
-              with: 'hispanic'
-            - regex: Caucasian
-              with: 'white'
-            - regex: Ebony
-              with: 'black'
-            - regex: Asian
-              with: 'asian'
+              - regex: Latin
+                with: 'hispanic'
+              - regex: Caucasian
+                with: 'white'
+              - regex: Ebony
+                with: 'black'
+              - regex: Asian
+                with: 'asian'
       Country: $info//li[span[@class="sub-label"]/text()="Country:"]/span[@class="sub-desc"]/text()
       EyeColor: $info//li[@class="profile-field profile-field-eyes"]/span[@class="sub-desc"]/text()
       Height:
         selector: $info//li[@class="profile-field profile-field-height"]/span[@class="sub-desc"]/text()
         postProcess:
           - replace:
-            - regex: (\d+)\scm.+
-              with: $1
+              - regex: (\d+)\scm.+
+                with: $1
       Measurements: $info//li[span[@class="sub-label"]/text()="Measurements:"]/span[@class="sub-desc"]/text()
       FakeTits:
         selector: $info//li[span[@class="sub-label"]/text()="Natural Tits:"]/span[@class="sub-desc"]/text()
         postProcess:
           - replace:
-            - regex: Yes
-              with: 'No'
-            - regex: No
-              with: 'Yes'
+              - regex: Yes
+                with: 'No'
+              - regex: No
+                with: 'Yes'
       Tattoos: $info//li[span[@class="sub-label"]/text()="Tattoo(s):"]/span[@class="sub-desc"]/text()
       Piercings: $info//li[span[@class="sub-label"]/text()="Piercing(s):"]/span[@class="sub-desc"]/text()
       Aliases: $info//li[@class="profile-field profile-field-ska"]/span[@class="sub-desc"]/text()

--- a/scrapers/SexVR.yml
+++ b/scrapers/SexVR.yml
@@ -26,42 +26,47 @@ xPathScrapers:
       URL: //link[@rel="canonical"]/@href
       Gender:
         selector: //meta[@name="application-name"]/@content
-        replace:
-          - regex: .+
-            with: female
+        postProcess:
+          - replace:
+            - regex: .+
+              with: female
       Twitter: $info//li[span[@class="sub-label"]/text()="Twitter:"]/span[@class="sub-desc"]/a/@href
       Birthdate:
         selector: $info//li[@class="profile-field profile-field-fob"]/span[@class="sub-desc"]/text()
-        replace:
-          - regex: \s\(\d+\s\w+\)
-            with:
-        parseDate: 2 Jan 2006
+        postProcess:
+          - replace:
+            - regex: \s\(\d+\s\w+\)
+              with:
+          - parseDate: 2 Jan 2006
       Ethnicity:
         selector: $info//li[span[@class="sub-label"]/text()="Ethnicity:"]/span[@class="sub-desc"]/text()
-        replace:
-          - regex: Latin
-            with: 'hispanic'
-          - regex: Caucasian
-            with: 'white'
-          - regex: Ebony
-            with: 'black'
-          - regex: Asian
-            with: 'asian'
+        postProcess:
+          - replace:
+            - regex: Latin
+              with: 'hispanic'
+            - regex: Caucasian
+              with: 'white'
+            - regex: Ebony
+              with: 'black'
+            - regex: Asian
+              with: 'asian'
       Country: $info//li[span[@class="sub-label"]/text()="Country:"]/span[@class="sub-desc"]/text()
       EyeColor: $info//li[@class="profile-field profile-field-eyes"]/span[@class="sub-desc"]/text()
       Height:
         selector: $info//li[@class="profile-field profile-field-height"]/span[@class="sub-desc"]/text()
-        replace:
-          - regex: (\d+)\scm.+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: (\d+)\scm.+
+              with: $1
       Measurements: $info//li[span[@class="sub-label"]/text()="Measurements:"]/span[@class="sub-desc"]/text()
       FakeTits:
         selector: $info//li[span[@class="sub-label"]/text()="Natural Tits:"]/span[@class="sub-desc"]/text()
-        replace:
-          - regex: Yes
-            with: 'No'
-          - regex: No
-            with: 'Yes'
+        postProcess:
+          - replace:
+            - regex: Yes
+              with: 'No'
+            - regex: No
+              with: 'Yes'
       Tattoos: $info//li[span[@class="sub-label"]/text()="Tattoo(s):"]/span[@class="sub-desc"]/text()
       Piercings: $info//li[span[@class="sub-label"]/text()="Piercing(s):"]/span[@class="sub-desc"]/text()
       Aliases: $info//li[@class="profile-field profile-field-ska"]/span[@class="sub-desc"]/text()

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -32,4 +32,4 @@ xPathScrapers:
       Image: //video[@id="trailervideo"]/@poster
 
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -17,14 +17,16 @@ xPathScrapers:
       Title: //h1
       Date:
         selector: //p[@class="date"]
-        parseDate: 2006-01-02
+        postProcess:
+          - parseDate: 2006-01-02
       Details: //p[@class="description"]
       Performers:
         Name:
           selector: //div[@class="col-3"]/a[@class="ampLink"]/text()
-          replace:
-            - regex: "\\.$"
-              with:
+          postProcess:
+            - replace:
+              - regex: "\\.$"
+                with:
       Tags:
         Name: //div[@class="col-12 col-md-6"]/div/div[@class="col-12"]/a/text()
       Image: //video[@id="trailervideo"]/@poster

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -32,4 +32,4 @@ xPathScrapers:
       Image: //video[@id="trailervideo"]/@poster
 
 
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -25,8 +25,8 @@ xPathScrapers:
           selector: //div[@class="col-3"]/a[@class="ampLink"]/text()
           postProcess:
             - replace:
-              - regex: "\\.$"
-                with:
+                - regex: "\\.$"
+                  with:
       Tags:
         Name: //div[@class="col-12 col-md-6"]/div/div[@class="col-12"]/a/text()
       Image: //video[@id="trailervideo"]/@poster

--- a/scrapers/TeamSkeet.yml
+++ b/scrapers/TeamSkeet.yml
@@ -23,4 +23,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/TeamSkeet.yml
+++ b/scrapers/TeamSkeet.yml
@@ -10,7 +10,8 @@ xPathScrapers:
       Title: //div[@class="col-12 sceneTitle"]/text()
       Date:
         selector: //div[@class="col-6 sceneDate"]/text()
-        parseDate: 01/02/2006
+        postProcess:
+          - parseDate: 01/02/2006
       Details: //div[@class="col-12 sceneDesc"]/text()
       Performers:
         Name: //div[@class="col-12 contentTitle"]/a

--- a/scrapers/TeamSkeet.yml
+++ b/scrapers/TeamSkeet.yml
@@ -23,4 +23,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated October 11, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Teencoreclub.yml
+++ b/scrapers/Teencoreclub.yml
@@ -45,16 +45,16 @@ xPathScrapers:
         selector: //div[@class="detail-hero-title"]//h1/text()
         postProcess:
           - replace:
-            - regex: \t+
-              with: ' '
+              - regex: \t+
+                with: ' '
       Details: //div[@class="detail-description"]/text()
       Performers:
         Name:
           selector: //div[@class="detail-hero-title"]//h1/text()
           postProcess:
             - replace:
-              - regex: \t+
-                with:
+                - regex: \t+
+                  with:
           split: ','
       Tags:
         Name:
@@ -64,14 +64,14 @@ xPathScrapers:
         selector: //div[@class="detail-hero"]/@style
         postProcess:
           - replace:
-            - regex: ^.*url.([^\)]+).*$
-              with: "$1"
+              - regex: ^.*url.([^\)]+).*$
+                with: "$1"
       Studio:
         Name:
           selector: //div[@class="flex-shrink-0 flex items-center"]//img[1]/@alt
           postProcess:
             - replace:
-              - regex: \.\w+
-                with:
+                - regex: \.\w+
+                  with:
 
 # Last Updated November 4, 2020

--- a/scrapers/Teencoreclub.yml
+++ b/scrapers/Teencoreclub.yml
@@ -43,16 +43,18 @@ xPathScrapers:
     scene:
       Title:
         selector: //div[@class="detail-hero-title"]//h1/text()
-        replace:
-          - regex: \t+
-            with: ' '
+        postProcess:
+          - replace:
+            - regex: \t+
+              with: ' '
       Details: //div[@class="detail-description"]/text()
       Performers:
         Name:
           selector: //div[@class="detail-hero-title"]//h1/text()
-          replace:
-            - regex: \t+
-              with:
+          postProcess:
+            - replace:
+              - regex: \t+
+                with:
           split: ','
       Tags:
         Name:
@@ -60,14 +62,16 @@ xPathScrapers:
           split: ','
       Image:
         selector: //div[@class="detail-hero"]/@style
-        replace:
-          - regex: ^.*url.([^\)]+).*$
-            with: "$1"
+        postProcess:
+          - replace:
+            - regex: ^.*url.([^\)]+).*$
+              with: "$1"
       Studio:
         Name:
           selector: //div[@class="flex-shrink-0 flex items-center"]//img[1]/@alt
-          replace:
-            - regex: \.\w+
-              with:
+          postProcess:
+            - replace:
+              - regex: \.\w+
+                with:
 
 # Last Updated June 22, 2020

--- a/scrapers/Teencoreclub.yml
+++ b/scrapers/Teencoreclub.yml
@@ -74,4 +74,4 @@ xPathScrapers:
                 - regex: \.\w+
                   with:
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Teencoreclub.yml
+++ b/scrapers/Teencoreclub.yml
@@ -74,4 +74,4 @@ xPathScrapers:
               - regex: \.\w+
                 with:
 
-# Last Updated June 22, 2020
+# Last Updated November 4, 2020

--- a/scrapers/TheNude.yml
+++ b/scrapers/TheNude.yml
@@ -17,8 +17,8 @@ xPathScrapers:
         selector: //figcaption/span
         postProcess:
           - replace:
-            - regex: "^AKA:"
-              with: ""
+              - regex: "^AKA:"
+                with: ""
       URL: //a[@class="model-name"]/@href
   performerScraper:
     performer:
@@ -34,39 +34,39 @@ xPathScrapers:
         selector: //li/span[@class="list-quest"][contains(text(),'Ethnicity')]/../text()
         postProcess:
           - replace:
-            - regex: Asian
-              with: "asian"
-            - regex: Caucasian
-              with: "white"
-            - regex: Black
-              with: "black"
-            - regex: Latin
-              with: "hispanic"
+              - regex: Asian
+                with: "asian"
+              - regex: Caucasian
+                with: "white"
+              - regex: Black
+                with: "black"
+              - regex: Latin
+                with: "hispanic"
       Country: 
         selector: //span[@itemprop="nationality"]/text()
         postProcess:
           - replace:
-            - regex: "United States of America"
-              with: "United States"
+              - regex: "United States of America"
+                with: "United States"
       #EyeColor: not listed
       Height:
         selector: //li/span[@class="list-quest"][contains(text(),'Height')]/../text()
         postProcess:
           - replace:
-            - regex: ^(\d+).+$
-              with: "$1 cm"
+              - regex: ^(\d+).+$
+                with: "$1 cm"
       Measurements:
         selector: //li/span[@class="list-quest"][contains(text(),'Measurements')]/../text()
       FakeTits:
         selector: //li/span[@class="list-quest"][contains(text(),'Breasts')]/../text()
         postProcess:
           - replace:
-            - regex: ^[^\(]+\(([^\)]+)\).*$
-              with: "$1"
-            - regex: Fake
-              with: "Yes"
-            - regex: Real
-              with: "No"
+              - regex: ^[^\(]+\(([^\)]+)\).*$
+                with: "$1"
+              - regex: Fake
+                with: "Yes"
+              - regex: Real
+                with: "No"
       CareerLength:
         selector: //li/span[@class="list-quest"][contains(text(),'Seen')]/../text()
         concat: "-"

--- a/scrapers/TheNude.yml
+++ b/scrapers/TheNude.yml
@@ -81,4 +81,4 @@ xPathScrapers:
         selector: (//meta[@itemprop="image"])[1]/@content
       Gender:
         selector: //meta[@itemprop="gender"]/@content
-# Last updated July 02, 2020
+# Last Updated November 4, 2020

--- a/scrapers/TheNude.yml
+++ b/scrapers/TheNude.yml
@@ -15,9 +15,10 @@ xPathScrapers:
 #      Name: //a[@class="model-name"]/../../a/@title       Version to get a little info on label/studio as well
       Name:
         selector: //figcaption/span
-        replace:
-          - regex: "^AKA:"
-            with: ""
+        postProcess:
+          - replace:
+            - regex: "^AKA:"
+              with: ""
       URL: //a[@class="model-name"]/@href
   performerScraper:
     performer:
@@ -27,40 +28,45 @@ xPathScrapers:
       Instagram: //a[text()="INSTAGRAM"]/@href
       Birthdate:
         selector: //li/span[@class="list-quest"][contains(text(),'Born')]/../text()
-        parseDate: 02-01-2006
+        postProcess:
+          - parseDate: 02-01-2006
       Ethnicity:
         selector: //li/span[@class="list-quest"][contains(text(),'Ethnicity')]/../text()
-        replace:
-          - regex: Asian
-            with: "asian"
-          - regex: Caucasian
-            with: "white"
-          - regex: Black
-            with: "black"
-          - regex: Latin
-            with: "hispanic"
+        postProcess:
+          - replace:
+            - regex: Asian
+              with: "asian"
+            - regex: Caucasian
+              with: "white"
+            - regex: Black
+              with: "black"
+            - regex: Latin
+              with: "hispanic"
       Country: 
         selector: //span[@itemprop="nationality"]/text()
-        replace:
-          - regex: "United States of America"
-            with: "United States"
+        postProcess:
+          - replace:
+            - regex: "United States of America"
+              with: "United States"
       #EyeColor: not listed
       Height:
         selector: //li/span[@class="list-quest"][contains(text(),'Height')]/../text()
-        replace:
-          - regex: ^(\d+).+$
-            with: "$1 cm"
+        postProcess:
+          - replace:
+            - regex: ^(\d+).+$
+              with: "$1 cm"
       Measurements:
         selector: //li/span[@class="list-quest"][contains(text(),'Measurements')]/../text()
       FakeTits:
         selector: //li/span[@class="list-quest"][contains(text(),'Breasts')]/../text()
-        replace:
-          - regex: ^[^\(]+\(([^\)]+)\).*$
-            with: "$1"
-          - regex: Fake
-            with: "Yes"
-          - regex: Real
-            with: "No"
+        postProcess:
+          - replace:
+            - regex: ^[^\(]+\(([^\)]+)\).*$
+              with: "$1"
+            - regex: Fake
+              with: "Yes"
+            - regex: Real
+              with: "No"
       CareerLength:
         selector: //li/span[@class="list-quest"][contains(text(),'Seen')]/../text()
         concat: "-"

--- a/scrapers/TheNude.yml
+++ b/scrapers/TheNude.yml
@@ -81,4 +81,4 @@ xPathScrapers:
         selector: (//meta[@itemprop="image"])[1]/@content
       Gender:
         selector: //meta[@itemprop="gender"]/@content
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -80,4 +80,4 @@ jsonScrapers:
         Name: $data.site.name
       Tags:
         Name: $data.tags.#.tag
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -25,8 +25,8 @@ jsonScrapers:
         selector: data.#.id
         postProcess:
           - replace:
-            - regex: ^
-              with: https://api.metadataapi.net/performers/
+              - regex: ^
+                with: https://api.metadataapi.net/performers/
 
   performerScraper:
     common:
@@ -40,8 +40,8 @@ jsonScrapers:
         selector: $extras.height
         postProcess:
           - replace:
-            - regex: cm
-              with:
+              - regex: cm
+                with:
       Measurements: $extras.measurements
       Tattoos: $extras.tattoos
       Piercings: $extras.piercings

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -23,9 +23,10 @@ jsonScrapers:
       Name: data.#.name
       URL:
         selector: data.#.id
-        replace:
-          - regex: ^
-            with: https://api.metadataapi.net/performers/
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://api.metadataapi.net/performers/
 
   performerScraper:
     common:
@@ -37,9 +38,10 @@ jsonScrapers:
       Ethnicity: $extras.ethnicity
       Height:
         selector: $extras.height
-        replace:
-          - regex: cm
-            with:
+        postProcess:
+          - replace:
+            - regex: cm
+              with:
       Measurements: $extras.measurements
       Tattoos: $extras.tattoos
       Piercings: $extras.piercings

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -80,4 +80,4 @@ jsonScrapers:
         Name: $data.site.name
       Tags:
         Name: $data.tags.#.tag
-#Last Updated September 6, 2020
+# Last Updated November 4, 2020

--- a/scrapers/TimTales.yml
+++ b/scrapers/TimTales.yml
@@ -69,4 +69,4 @@ xPathScrapers:
                 with: $1
       Image: //div[@class="model-details"]/img/@src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/TimTales.yml
+++ b/scrapers/TimTales.yml
@@ -69,4 +69,4 @@ xPathScrapers:
                 with: $1
       Image: //div[@class="model-details"]/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/TimTales.yml
+++ b/scrapers/TimTales.yml
@@ -21,8 +21,8 @@ xPathScrapers:
         selector: $info/p[@class="date"]/text()
         postProcess:
           - replace:
-            - regex: \s–\s.*$
-              with:
+              - regex: \s–\s.*$
+                with:
           - parseDate: January 02, 2006
       Details:
         selector: $info/p[@class="bodytext"]/text()
@@ -34,17 +34,17 @@ xPathScrapers:
           selector: $info/p[@class="categories" and contains(text(), "Men:")]
           postProcess:
             - replace:
-               - regex: "Men:"
-                 with:
-               - regex: (,)\s+
-                 with: $1
+                - regex: "Men:"
+                  with:
+                - regex: (,)\s+
+                  with: $1
           split: ","
       Image:
         selector: //div[@class="video player no-volume play-button"]/@style
         postProcess:
           - replace:
-            - regex: .+'(.+)'.+
-              with: $1
+              - regex: .+'(.+)'.+
+                with: $1
       Studio:
         Name:
           fixed: Timtales

--- a/scrapers/TimTales.yml
+++ b/scrapers/TimTales.yml
@@ -19,10 +19,11 @@ xPathScrapers:
       Title: $info/h1/text()
       Date:
         selector: $info/p[@class="date"]/text()
-        replace:
-          - regex: \s–\s.*$
-            with:
-        parseDate: January 02, 2006
+        postProcess:
+          - replace:
+            - regex: \s–\s.*$
+              with:
+          - parseDate: January 02, 2006
       Details:
         selector: $info/p[@class="bodytext"]/text()
         concat: "\n\n"
@@ -40,9 +41,10 @@ xPathScrapers:
           split: ","
       Image:
         selector: //div[@class="video player no-volume play-button"]/@style
-        replace:
-          - regex: .+'(.+)'.+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+'(.+)'.+
+              with: $1
       Studio:
         Name:
           fixed: Timtales

--- a/scrapers/Tokyohot.yml
+++ b/scrapers/Tokyohot.yml
@@ -20,4 +20,4 @@ xPathScrapers:
         Name: $movieinfo/dd[1]/a/text()
       Image: //li[@class="package"]/a[1]/@href
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Tokyohot.yml
+++ b/scrapers/Tokyohot.yml
@@ -20,4 +20,4 @@ xPathScrapers:
         Name: $movieinfo/dd[1]/a/text()
       Image: //li[@class="package"]/a[1]/@href
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Tokyohot.yml
+++ b/scrapers/Tokyohot.yml
@@ -14,7 +14,8 @@ xPathScrapers:
       Details: //div[@class="sentence"]//text()
       Date:
         selector: $movieinfo/dd[$tagexists+5]/text()
-        parseDate: 2006/01/02
+        postProcess:
+          - parseDate: 2006/01/02
       Performers:
         Name: $movieinfo/dd[1]/a/text()
       Image: //li[@class="package"]/a[1]/@href

--- a/scrapers/Tonightsgirlfriend.yml
+++ b/scrapers/Tonightsgirlfriend.yml
@@ -11,15 +11,17 @@ xPathScrapers:
     scene:
       Title:
         selector: //head/title/text()
-        replace:
-          - regex: \sHD\sPorn\s\|\sTonightsGirlfriend\.com
-            with:
+        postProcess:
+          - replace:
+            - regex: \sHD\sPorn\s\|\sTonightsGirlfriend\.com
+              with:
       Date:
         selector: $sceneinfo/p/span/text()
-        replace:
-          - regex: "Added: "
-            with:
-        parseDate: 01-02-06
+        postProcess:
+          - replace:
+            - regex: "Added: "
+              with:
+          - parseDate: 01-02-06
       Details: //div[@class="scenepage-description"]/p
       Performers:
         Name: $sceneinfo/p/a

--- a/scrapers/Tonightsgirlfriend.yml
+++ b/scrapers/Tonightsgirlfriend.yml
@@ -31,4 +31,4 @@ xPathScrapers:
           fixed: "Tonight's Girlfriend"
       URL: //link[@rel='canonical']/@href
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Tonightsgirlfriend.yml
+++ b/scrapers/Tonightsgirlfriend.yml
@@ -31,4 +31,4 @@ xPathScrapers:
           fixed: "Tonight's Girlfriend"
       URL: //link[@rel='canonical']/@href
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Tonightsgirlfriend.yml
+++ b/scrapers/Tonightsgirlfriend.yml
@@ -13,14 +13,14 @@ xPathScrapers:
         selector: //head/title/text()
         postProcess:
           - replace:
-            - regex: \sHD\sPorn\s\|\sTonightsGirlfriend\.com
-              with:
+              - regex: \sHD\sPorn\s\|\sTonightsGirlfriend\.com
+                with:
       Date:
         selector: $sceneinfo/p/span/text()
         postProcess:
           - replace:
-            - regex: "Added: "
-              with:
+              - regex: "Added: "
+                with:
           - parseDate: 01-02-06
       Details: //div[@class="scenepage-description"]/p
       Performers:

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -15,8 +15,8 @@ xPathScrapers:
         selector: //video[@id="my-video"]/@poster
         postProcess:
           - replace:
-            - regex: ^
-              with: "http://www.trans500.com"
+              - regex: ^
+                with: "http://www.trans500.com"
       Studio: 
         Name: //p[@class="pull-right"]/b/text()
 # Last Updated November 4, 2020

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -19,4 +19,4 @@ xPathScrapers:
                 with: "http://www.trans500.com"
       Studio: 
         Name: //p[@class="pull-right"]/b/text()
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -13,8 +13,9 @@ xPathScrapers:
       Details: //p[@class="description"]
       Image:
         selector: //video[@id="my-video"]/@poster
-        replace:
-          - regex: ^
-            with: "http://www.trans500.com"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "http://www.trans500.com"
       Studio: 
         Name: //p[@class="pull-right"]/b/text()

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -19,3 +19,4 @@ xPathScrapers:
               with: "http://www.trans500.com"
       Studio: 
         Name: //p[@class="pull-right"]/b/text()
+# Last Updated November 4, 2020

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -12,14 +12,14 @@ xPathScrapers:
         selector: //header[@id="scene-info"]/h1/text()[contains(., ":")]
         postProcess: 
           - replace: 
-            - regex: .*:.
-              with: 
+              - regex: .*:.
+                with: 
       Date:
         selector: //div[contains(text(), "Added:")]/text()  # or //div[@class="scene-infobrick"][contains(text(), "Added:")]/text()
         postProcess: 
           - replace: 
-            - regex: ".*:"
-              with: 
+              - regex: ".*:"
+                with: 
           - parseDate: 01/02/2006
       Performers: 
         Name: //div[@class="scene-infobrick"][contains(text(), "TSGirls:")]/a/text()
@@ -28,16 +28,16 @@ xPathScrapers:
         selector: //meta[@name="twitter:image0"]/@content
         postProcess:
           - replace: 
-            - regex: http
-              with: https
+              - regex: http
+                with: https
         # selector: //div[@class="vjs-poster"]/@style
         # postProcess:
-          # - replace:
-            # - regex: ^.+(http[^\&]+).+$
-              # with: $1
-          # - replace: 
-            # - regex: http 
-              # with: https
+            # - replace:
+              # - regex: ^.+(http[^\&]+).+$
+                # with: $1
+            # - replace: 
+              # - regex: http 
+                # with: https
       Studio:
         Name: 
           selector: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -26,16 +26,18 @@ xPathScrapers:
       Details: //section[@id="scene-desc"]/p/text()
       Image:
         selector: //meta[@name="twitter:image0"]/@content
-        replace: 
-          - regex: http
-            with: https
+        postProcess:
+          - replace: 
+            - regex: http
+              with: https
         # selector: //div[@class="vjs-poster"]/@style
-        # replace:
-          # - regex: ^.+(http[^\&]+).+$
-            # with: $1
-        # replace: 
-          # - regex: http 
-            # with: https
+        # postProcess:
+          # - replace:
+            # - regex: ^.+(http[^\&]+).+$
+              # with: $1
+          # - replace: 
+            # - regex: http 
+              # with: https
       Studio:
         Name: 
           selector: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -56,3 +56,4 @@ xPathScrapers:
                   with: "Behind Trans500" 
       Tags:  # Either //meta[@name="keywords"]/@content OR: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
         Name: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
+# Last Updated November 4, 2020

--- a/scrapers/Trans500espanol.yml
+++ b/scrapers/Trans500espanol.yml
@@ -56,4 +56,4 @@ xPathScrapers:
                   with: "Behind Trans500" 
       Tags:  # Either //meta[@name="keywords"]/@content OR: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
         Name: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -71,9 +71,10 @@ xPathScrapers:
                 with: https://www.$1/$2
       Date:
         selector: //div[@class='date-and-covers']/div[@class='date']/text()
-        replace:
-          - regex: (\d+)(st|nd|rd|th)
-            with: "$1"
-        parseDate: January 2 2006
+        postProcess:
+          - replace:
+            - regex: (\d+)(st|nd|rd|th)
+              with: "$1"
+          - parseDate: January 2 2006
 
 # Last Updated October 3, 2020

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -73,8 +73,8 @@ xPathScrapers:
         selector: //div[@class='date-and-covers']/div[@class='date']/text()
         postProcess:
           - replace:
-            - regex: (\d+)(st|nd|rd|th)
-              with: "$1"
+              - regex: (\d+)(st|nd|rd|th)
+                with: "$1"
           - parseDate: January 2 2006
 
 # Last Updated November 4, 2020

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -77,4 +77,4 @@ xPathScrapers:
               with: "$1"
           - parseDate: January 2 2006
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -77,4 +77,4 @@ xPathScrapers:
                 with: "$1"
           - parseDate: January 2 2006
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -33,4 +33,4 @@ xPathScrapers:
                   with: "https:"
       Image: //meta[@property="og:image"][1]/@content
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -14,7 +14,8 @@ xPathScrapers:
       Title: //h1[@class="video-content__title d-block"]/text()
       Date:
         selector: $info//div[@class="section__item-title-download-space"][2]/text()[2]
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details:
         selector: //div[@class="video-content__description"]//p//text()
         concat: " "
@@ -26,9 +27,10 @@ xPathScrapers:
         Name: //meta[@name="dl8-customization-brand-name"]/@content
         URL:
           selector: //meta[@name="dl8-customization-brand-url"]/@content
-          replace:
-            - regex: ^
-              with: "https:"
+          postProcess:
+            - replace:
+              - regex: ^
+                with: "https:"
       Image: //meta[@property="og:image"][1]/@content
 
 # Last Updated May 25, 2020

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -29,8 +29,8 @@ xPathScrapers:
           selector: //meta[@name="dl8-customization-brand-url"]/@content
           postProcess:
             - replace:
-              - regex: ^
-                with: "https:"
+                - regex: ^
+                  with: "https:"
       Image: //meta[@property="og:image"][1]/@content
 
 # Last Updated November 4, 2020

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -33,4 +33,4 @@ xPathScrapers:
                 with: "https:"
       Image: //meta[@property="og:image"][1]/@content
 
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/VRConk.yml
+++ b/scrapers/VRConk.yml
@@ -30,4 +30,4 @@ xPathScrapers:
           - replace:
               - regex: ^.*url.([^\)]+).*$
                 with: "$1"
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VRConk.yml
+++ b/scrapers/VRConk.yml
@@ -14,8 +14,8 @@ xPathScrapers:
         selector: $info//div[@class="stats-container"]/ul/li[3]/span[@class="sub-label"]/text()
         postProcess:
           - replace:
-            - regex: (\d{4}-\d{2}-\d{2})\s.+
-              with: $1
+              - regex: (\d{4}-\d{2}-\d{2})\s.+
+                with: $1
           - parseDate: 2006-01-02
       Details:
         selector: $info//div[@class="expand-block-more"]/div[@class="d-container"][3]/text()
@@ -28,6 +28,6 @@ xPathScrapers:
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
         postProcess:
           - replace:
-            - regex: ^.*url.([^\)]+).*$
-              with: "$1"
+              - regex: ^.*url.([^\)]+).*$
+                with: "$1"
 # Last Updated November 4, 2020

--- a/scrapers/VRConk.yml
+++ b/scrapers/VRConk.yml
@@ -30,4 +30,4 @@ xPathScrapers:
           - replace:
             - regex: ^.*url.([^\)]+).*$
               with: "$1"
-# Last Updated July 16, 2020
+# Last Updated November 4, 2020

--- a/scrapers/VRConk.yml
+++ b/scrapers/VRConk.yml
@@ -12,10 +12,11 @@ xPathScrapers:
       Title: $info//div[contains(@class, 'video-details')]//h1/text()
       Date:
         selector: $info//div[@class="stats-container"]/ul/li[3]/span[@class="sub-label"]/text()
-        replace:
-          - regex: (\d{4}-\d{2}-\d{2})\s.+
-            with: $1
-        parseDate: 2006-01-02
+        postProcess:
+          - replace:
+            - regex: (\d{4}-\d{2}-\d{2})\s.+
+              with: $1
+          - parseDate: 2006-01-02
       Details:
         selector: $info//div[@class="expand-block-more"]/div[@class="d-container"][3]/text()
         concat: " "
@@ -25,7 +26,8 @@ xPathScrapers:
         Name: $info//ul[@class="models-list"]//li/a/@title
       Image: 
         selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
-        replace:
-          - regex: ^.*url.([^\)]+).*$
-            with: "$1"
+        postProcess:
+          - replace:
+            - regex: ^.*url.([^\)]+).*$
+              with: "$1"
 # Last Updated July 16, 2020

--- a/scrapers/VRHush.yml
+++ b/scrapers/VRHush.yml
@@ -28,4 +28,4 @@ xPathScrapers:
             - regex: ^
               with: "https:"
 
-# Last Updated July 17, 2020
+# Last Updated November 4, 2020

--- a/scrapers/VRHush.yml
+++ b/scrapers/VRHush.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: $info//h1[@class="latest-scene-title"]/text()
       Date:
         selector: $info//div[@class="row latest-scene-meta-1"]/div[@class="col-xs-6 text-left"]/text()
-        parseDate: Jan 2, 2006
+        postProcess:
+          - parseDate: Jan 2, 2006
       Details:
         selector: $info//span[contains(@class, "full-description")]/text()
         concat: " "
@@ -22,8 +23,9 @@ xPathScrapers:
         Name: $info//h5[@class="latest-scene-subtitle"]//a/text()
       Image: 
         selector: $info//dl8-video/@poster
-        replace:
-          - regex: ^
-            with: "https:"
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https:"
 
 # Last Updated July 17, 2020

--- a/scrapers/VRHush.yml
+++ b/scrapers/VRHush.yml
@@ -28,4 +28,4 @@ xPathScrapers:
               - regex: ^
                 with: "https:"
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VRHush.yml
+++ b/scrapers/VRHush.yml
@@ -25,7 +25,7 @@ xPathScrapers:
         selector: $info//dl8-video/@poster
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+              - regex: ^
+                with: "https:"
 
 # Last Updated November 4, 2020

--- a/scrapers/VirtualTaboo.yml
+++ b/scrapers/VirtualTaboo.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: $info/div[@class="col-md-4 col right-info"]/h1
       Date:
         selector: $info/div[@class="col-md-4 col right-info"]/div[@class="info"]/span[@class="bullet"]/following-sibling::text()
-        parseDate: 02 January, 2006
+        postProcess:
+          - parseDate: 02 January, 2006
       Details:
         selector: $info//div[@class="description"]/span[@class="full hidden"]/text()
         concat: " "

--- a/scrapers/VirtualTaboo.yml
+++ b/scrapers/VirtualTaboo.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Performers:
         Name: $info//div[@class="info"]/a/text()
       Image: //meta[@property="og:image"]/@content
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/VirtualTaboo.yml
+++ b/scrapers/VirtualTaboo.yml
@@ -22,4 +22,4 @@ xPathScrapers:
       Performers:
         Name: $info//div[@class="info"]/a/text()
       Image: //meta[@property="og:image"]/@content
-# Last Updated July 12, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Vivid.yml
+++ b/scrapers/Vivid.yml
@@ -29,4 +29,4 @@ xPathScrapers:
               with: ""
           - parseDate: Jan 2, 2006
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Vivid.yml
+++ b/scrapers/Vivid.yml
@@ -29,4 +29,4 @@ xPathScrapers:
                 with: ""
           - parseDate: Jan 2, 2006
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/Vivid.yml
+++ b/scrapers/Vivid.yml
@@ -17,14 +17,16 @@ xPathScrapers:
         Name: $info/h4[contains(text(),'Starring:')]/a
       Image:
         selector: //script[contains(text(),'poster:')]|//img[@id="placard"]/@src
-        replace:
-          - regex: .+(https://content\.vivid\.com/.+\.jpg).+
-            with: $1
+        postProcess:
+          - replace:
+            - regex: .+(https://content\.vivid\.com/.+\.jpg).+
+              with: $1
       Date:
         selector: $info/h5[contains(text(),'Released:')]
-        replace:
-          - regex: "Released:"
-            with: ""
-        parseDate: Jan 2, 2006
+        postProcess:
+          - replace:
+            - regex: "Released:"
+              with: ""
+          - parseDate: Jan 2, 2006
 
 # Last Updated October 3, 2020

--- a/scrapers/Vivid.yml
+++ b/scrapers/Vivid.yml
@@ -19,14 +19,14 @@ xPathScrapers:
         selector: //script[contains(text(),'poster:')]|//img[@id="placard"]/@src
         postProcess:
           - replace:
-            - regex: .+(https://content\.vivid\.com/.+\.jpg).+
-              with: $1
+              - regex: .+(https://content\.vivid\.com/.+\.jpg).+
+                with: $1
       Date:
         selector: $info/h5[contains(text(),'Released:')]
         postProcess:
           - replace:
-            - regex: "Released:"
-              with: ""
+              - regex: "Released:"
+                with: ""
           - parseDate: Jan 2, 2006
 
 # Last Updated November 4, 2020

--- a/scrapers/WankzVR.yml
+++ b/scrapers/WankzVR.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: //div[@class="detail__header detail__header-lg"]/h1
       Date:
         selector: $info//span[@class="detail__date"]/text()
-        parseDate: 2 January, 2006
+        postProcess:
+          - parseDate: 2 January, 2006
       Details:
         selector: //div[@class="detail__txt detail__txt-show_lg"]/text()|//span[@class="more__body"]/text()
         concat: " "

--- a/scrapers/WankzVR.yml
+++ b/scrapers/WankzVR.yml
@@ -23,4 +23,4 @@ xPathScrapers:
         Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
       Image: //meta[@property="og:image"]/@content
 
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/WankzVR.yml
+++ b/scrapers/WankzVR.yml
@@ -23,4 +23,4 @@ xPathScrapers:
         Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
       Image: //meta[@property="og:image"]/@content
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/WickedMovies.yml
+++ b/scrapers/WickedMovies.yml
@@ -13,7 +13,8 @@ xPathScrapers:
         Name: //span[@class="slide-title"]/text()
       Date:
         selector: //ul[@class="dvdSpecs"]/li[@class="updatedOn"]/text()[1]
-        parseDate: "2006-01-02"
+        postProcess:
+          - parseDate: "2006-01-02"
       Image:
         selector: //a[@class="frontCoverImg"]/img/@src
       Tags:

--- a/scrapers/WickedMovies.yml
+++ b/scrapers/WickedMovies.yml
@@ -20,4 +20,4 @@ xPathScrapers:
       Tags:
         Name: //p[@class="dvdCol"]//a
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/WickedMovies.yml
+++ b/scrapers/WickedMovies.yml
@@ -20,4 +20,4 @@ xPathScrapers:
       Tags:
         Name: //p[@class="dvdCol"]//a
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -12,7 +12,8 @@ xPathScrapers:
       Title: //div[@class="row info"]/div[@class="small-12 medium-12 large-12 columns"]/h1
       Date:
         selector: $sceneinfo/h2[1]/text()
-        parseDate: Jan 02, 2006
+        postProcess:
+          - parseDate: Jan 02, 2006
       Details:
         selector: $sceneinfo/p
         concat: " "

--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -21,4 +21,4 @@ xPathScrapers:
         Name: $sceneinfo/h2/a/text()
       Image: //div[@class="flex-video widescreen"]/a/img/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -21,4 +21,4 @@ xPathScrapers:
         Name: $sceneinfo/h2/a/text()
       Image: //div[@class="flex-video widescreen"]/a/img/@src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/XXXPawn.yml
+++ b/scrapers/XXXPawn.yml
@@ -45,4 +45,4 @@ xPathScrapers:
           selector: //meta[@http-equiv="keywords"]/@content
           split: ', '
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/XXXPawn.yml
+++ b/scrapers/XXXPawn.yml
@@ -45,4 +45,4 @@ xPathScrapers:
           selector: //meta[@http-equiv="keywords"]/@content
           split: ', '
 
-# Last Updated June 24, 2020
+# Last Updated November 4, 2020

--- a/scrapers/XXXPawn.yml
+++ b/scrapers/XXXPawn.yml
@@ -13,14 +13,14 @@ xPathScrapers:
         selector: //link[@rel="canonical"]/@href
         postProcess:
           - replace:
-            - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
-              with: https://xxxpawn.xxx/$1
+              - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+                with: https://xxxpawn.xxx/$1
           - subScraper:
               selector: //div[@id="title-single"]/span/text()
               postProcess:
                 - replace:
-                  - regex: (\w+\s)(\d+)\w+,(\s\d{4})
-                    with: $1$2$3
+                    - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+                      with: $1$2$3
                 - parseDate: January 2 2006
       Details:
         selector: //p[@class="videoDetail"]/text()|//p[@class="more"]/text()|//span[@class="morecontent"]/span/text()
@@ -30,14 +30,14 @@ xPathScrapers:
           selector: //link[@rel="canonical"]/@href
           postProcess:
             - replace:
-              - regex: .+
-                with: 'XXXPawn'
+                - regex: .+
+                  with: 'XXXPawn'
       Image:
         selector: //link[@rel="canonical"]/@href
         postProcess:
           - replace:
-            - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
-              with: https://xxxpawn.xxx/$1
+              - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+                with: https://xxxpawn.xxx/$1
           - subScraper:
               selector: //video/@poster
       Tags:

--- a/scrapers/XXXPawn.yml
+++ b/scrapers/XXXPawn.yml
@@ -11,31 +11,35 @@ xPathScrapers:
       Title: //h1/text()|//div[@id="content"]//h2/text()
       Date:
         selector: //link[@rel="canonical"]/@href
-        replace:
-          - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
-            with: https://xxxpawn.xxx/$1
-        subScraper:
-          selector: //div[@id="title-single"]/span/text()
-          replace:
-            - regex: (\w+\s)(\d+)\w+,(\s\d{4})
-              with: $1$2$3
-        parseDate: January 2 2006
+        postProcess:
+          - replace:
+            - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+              with: https://xxxpawn.xxx/$1
+          - subScraper:
+              selector: //div[@id="title-single"]/span/text()
+              postProcess:
+                - replace:
+                  - regex: (\w+\s)(\d+)\w+,(\s\d{4})
+                    with: $1$2$3
+                - parseDate: January 2 2006
       Details:
         selector: //p[@class="videoDetail"]/text()|//p[@class="more"]/text()|//span[@class="morecontent"]/span/text()
         concat: ''
       Studio:
         Name:
           selector: //link[@rel="canonical"]/@href
-          replace:
-            - regex: .+
-              with: 'XXXPawn'
+          postProcess:
+            - replace:
+              - regex: .+
+                with: 'XXXPawn'
       Image:
         selector: //link[@rel="canonical"]/@href
-        replace:
-          - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
-            with: https://xxxpawn.xxx/$1
-        subScraper:
-          selector: //video/@poster
+        postProcess:
+          - replace:
+            - regex: .+(?:\.xxx|\.com\/video\d+)\/([\w-]+)(?:.+|)
+              with: https://xxxpawn.xxx/$1
+          - subScraper:
+              selector: //video/@poster
       Tags:
         Name:
           selector: //meta[@http-equiv="keywords"]/@content

--- a/scrapers/Xartxxx.yml
+++ b/scrapers/Xartxxx.yml
@@ -10,7 +10,8 @@ xPathScrapers:
       Title: //h1[@class="entry-title"]
       Date:
         selector: //div[@class="meta-item meta-date"]/span/text()
-        parseDate: January 2, 2006
+        postProcess:
+          - parseDate: January 2, 2006
       Details:
         selector: //div[@class="entry-content-single"]/p
         concat: " "

--- a/scrapers/Xartxxx.yml
+++ b/scrapers/Xartxxx.yml
@@ -19,4 +19,4 @@ xPathScrapers:
         Name: //div[@class="meta-tags"]/a/text()
       Image: //a[@class="vlog-cover"]/img/@data-lazy-src
 
-# Last Updated October 3, 2020
+# Last Updated November 4, 2020

--- a/scrapers/Xartxxx.yml
+++ b/scrapers/Xartxxx.yml
@@ -19,4 +19,4 @@ xPathScrapers:
         Name: //div[@class="meta-tags"]/a/text()
       Image: //a[@class="vlog-cover"]/img/@data-lazy-src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ZeroTolerance.yml
+++ b/scrapers/ZeroTolerance.yml
@@ -12,10 +12,11 @@ xPathScrapers:
       Title: //h1[@class="section-title text-white"]/text()
       Date:
         selector: $desc/ul/li[1]/text()
-        replace:
-          - regex: Released\son\s
-            with:
-        parseDate: Jan 02, 2006
+        postProcess:
+          - replace:
+            - regex: Released\son\s
+              with:
+          - parseDate: Jan 02, 2006
       Details: $desc//p/text()
       Tags:
         Name: $desc//a/text()

--- a/scrapers/ZeroTolerance.yml
+++ b/scrapers/ZeroTolerance.yml
@@ -26,4 +26,4 @@ xPathScrapers:
         Name: //a[@class="btn-link dvd-title"]/text()
       Image: //img[@class="player-image"]/@src
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/ZeroTolerance.yml
+++ b/scrapers/ZeroTolerance.yml
@@ -26,4 +26,4 @@ xPathScrapers:
         Name: //a[@class="btn-link dvd-title"]/text()
       Image: //img[@class="player-image"]/@src
 
-# Last Updated May 25, 2020
+# Last Updated November 4, 2020

--- a/scrapers/ZeroTolerance.yml
+++ b/scrapers/ZeroTolerance.yml
@@ -14,8 +14,8 @@ xPathScrapers:
         selector: $desc/ul/li[1]/text()
         postProcess:
           - replace:
-            - regex: Released\son\s
-              with:
+              - regex: Released\son\s
+                with:
           - parseDate: Jan 02, 2006
       Details: $desc//p/text()
       Tags:

--- a/scrapers/joymii.yml
+++ b/scrapers/joymii.yml
@@ -39,4 +39,4 @@ xPathScrapers:
       Performers:
         Name: $info//h2[@class="starring-models"]/a/text()
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/joymii.yml
+++ b/scrapers/joymii.yml
@@ -39,4 +39,4 @@ xPathScrapers:
       Performers:
         Name: $info//h2[@class="starring-models"]/a/text()
 
-# Last Updated June 22, 2020
+# Last Updated November 4, 2020

--- a/scrapers/joymii.yml
+++ b/scrapers/joymii.yml
@@ -15,16 +15,16 @@ xPathScrapers:
         concat: "\n"
         postProcess:
           - replace:
-            - regex: "\n"
-              with: "\n"
+              - regex: "\n"
+                with: "\n"
       Date:
         selector: $info//h1[@class="title"]/text()
         postProcess:
           - replace:
-            - regex: ^
-              with: "https://joymii.com/search?query="
-            - regex: \s
-              with: +
+              - regex: ^
+                with: "https://joymii.com/search?query="
+              - regex: \s
+                with: +
           - subScraper:
               selector: //div[@class="box-results row"]/div[1]//div[@class="box-release_date release_date"]/text()
           - parseDate: Jan 02, 2006
@@ -34,8 +34,8 @@ xPathScrapers:
           selector: //title/text()
           postProcess:
             - replace:
-              - regex: .+
-                with: "joymii"
+                - regex: .+
+                  with: "joymii"
       Performers:
         Name: $info//h2[@class="starring-models"]/a/text()
 

--- a/scrapers/joymii.yml
+++ b/scrapers/joymii.yml
@@ -13,26 +13,29 @@ xPathScrapers:
       Details:
         selector: $info//p/text()
         concat: "\n"
-        replace:
-          - regex: "\n"
-            with: "\n"
+        postProcess:
+          - replace:
+            - regex: "\n"
+              with: "\n"
       Date:
         selector: $info//h1[@class="title"]/text()
-        replace:
-          - regex: ^
-            with: "https://joymii.com/search?query="
-          - regex: \s
-            with: +
-        subScraper:
-          selector: //div[@class="box-results row"]/div[1]//div[@class="box-release_date release_date"]/text()
-        parseDate: Jan 02, 2006
+        postProcess:
+          - replace:
+            - regex: ^
+              with: "https://joymii.com/search?query="
+            - regex: \s
+              with: +
+          - subScraper:
+              selector: //div[@class="box-results row"]/div[1]//div[@class="box-release_date release_date"]/text()
+          - parseDate: Jan 02, 2006
       Image: //img[@class="cover"]/@src|//video/@poster
       Studio:
         Name:
           selector: //title/text()
-          replace:
-            - regex: .+
-              with: "joymii"
+          postProcess:
+            - replace:
+              - regex: .+
+                with: "joymii"
       Performers:
         Name: $info//h2[@class="starring-models"]/a/text()
 

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -16,9 +16,10 @@ xPathScrapers:
     scene:
       Title:
         selector: //h1[@class="trailer-block_title"]
-        replace:
-          - regex: "LIVE$"
-            with:
+        postProcess:
+          - replace:
+            - regex: "LIVE$"
+              with:
       Date:
         selector: //div[@class="info-block_data"]/p[@class="text"][1]/text()
         postProcess:

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -41,4 +41,4 @@ xPathScrapers:
             - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
               with: $2
 
-# Last Updated August 10, 2020
+# Last Updated November 4, 2020

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -41,4 +41,4 @@ xPathScrapers:
               - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
                 with: $2
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -18,14 +18,14 @@ xPathScrapers:
         selector: //h1[@class="trailer-block_title"]
         postProcess:
           - replace:
-            - regex: "LIVE$"
-              with:
+              - regex: "LIVE$"
+                with:
       Date:
         selector: //div[@class="info-block_data"]/p[@class="text"][1]/text()
         postProcess:
           - replace:
-            - regex: (\w+\s)(\w+)(\s)(\d{1,2})(.+)(\d{4})(.+)
-              with: $2 $4, $6
+              - regex: (\w+\s)(\w+)(\s)(\d{1,2})(.+)(\d{4})(.+)
+                with: $2 $4, $6
           - parseDate: January 2, 2006
       Details: $infoblock/p[@class="text"][1]/text()
       Tags:
@@ -38,7 +38,7 @@ xPathScrapers:
         selector: //script[contains(.,"contentthumbs")]/text()|//img[@class="lazyload update_thumb thumbs stdimage"]/@src
         postProcess:
           - replace:
-            - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
-              with: $2
+              - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
+                with: $2
 
 # Last Updated November 4, 2020

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -20,7 +20,8 @@ xPathScrapers:
       Details: //p[@data-test-component="VideoDescription"]|//div[@data-test-component="VideoDescription"]//p
       Date:
         selector: //span[@data-test-component="ReleaseDateFormatted"]
-        parseDate: "January 2, 2006"
+        postProcess:
+          - parseDate: "January 2, 2006"
       Image:
         selector: //div[contains(@class, "sc-13rgbhb-2")]//img[contains(@class, "sc-1egln9q-1")]/@src
         # Less precise option:
@@ -28,9 +29,10 @@ xPathScrapers:
       Studio:
         Name:
           selector: //link[@rel="canonical"]/@href
-          replace:
-          - regex: https\://www\.(.+)\.com/.+
-            with: $1
+          postProcess:
+            - replace:
+              - regex: https\://www\.(.+)\.com/.+
+                with: $1
 driver:
   useCDP: true
 

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -31,8 +31,8 @@ xPathScrapers:
           selector: //link[@rel="canonical"]/@href
           postProcess:
             - replace:
-              - regex: https\://www\.(.+)\.com/.+
-                with: $1
+                - regex: https\://www\.(.+)\.com/.+
+                  with: $1
 driver:
   useCDP: true
 

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -36,4 +36,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated November 4, 2020
+# Last Updated November 8, 2020

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -36,4 +36,4 @@ xPathScrapers:
 driver:
   useCDP: true
 
-# Last Updated November 2, 2020
+# Last Updated November 4, 2020


### PR DESCRIPTION
as per #114
feel free to reject if this is too big of a PR

I am working on a [scraper schema (+validator)](https://github.com/stashapp/CommunityScrapers/compare/master...peolic:scraper-schema) so spotting the deprecated attributes was rather easy

the changes were made manually and I kept the order of execution as defined in the docs:
- `concat`
- `replace`
- `subScraper`
- `parseDate`
- `split`