### PR TITLE
update image and tags for hucows scraper

### DIFF
--- a/scrapers/Hucows.yml
+++ b/scrapers/Hucows.yml
@@ -19,7 +19,7 @@ xPathScrapers:
               - regex: ^\s+
                 with:
           - parseDate: 2 Jan 2006
-      Image: //div[@class="imghoverclass postfeat post-single-img"]//img//@src
+      Image: //div[contains(@class,"post-single-img")]//img/@src
       Studio:
         Name:
           fixed: Hucows
@@ -27,4 +27,5 @@ xPathScrapers:
         Name: //a[@rel="category tag"]/text()
       Performers:
         Name: //span[@class="posttags"]/a/text()
-# Last Updated November 05, 2020
+
+# Last Updated November 08, 2020

--- a/scrapers/Hucows.yml
+++ b/scrapers/Hucows.yml
@@ -19,12 +19,12 @@ xPathScrapers:
               - regex: ^\s+
                 with:
           - parseDate: 2 Jan 2006
-      Image: //center/a[1]/img[@class="lightboxhover"]/@src
+      Image: //div[@class="imghoverclass postfeat post-single-img"]//img//@src
       Studio:
         Name:
           fixed: Hucows
       Tags:
-        Name: //section[@id="categories-2"]//a
+        Name: //a[@rel="category tag"]/text()
       Performers:
         Name: //span[@class="posttags"]/a/text()
-# Last Updated July 29, 2020
+# Last Updated November 05, 2020


### PR DESCRIPTION
Changes:
Images: Grab the banner image instead of the screenshot 
Tags: Grab relevant tags instead of all the tags