### PR TITLE
Remove Cloudflare errors from JAVLibrary

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -316,7 +316,7 @@ itscleolive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jamesdeen.com|AnalizedNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 japanhdv.com|JapanHDV.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 javhd.com|JavHD.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
-javlibrary.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|JAV
+javlibrary.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|CDP|JAV
 jaysinxxx.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jayspov.net|JaysPov.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jelenajensen.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -28,10 +28,10 @@ movieByURL:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: 
+      Title:
         selector: //div[@id="video_id"]/table/tbody/tr/td[@class="text"]/text()
       # Using URL to still get a URL with sceneByFragment if a duplicate exist.
-      URL: 
+      URL:
         selector: //div[@class="videos"]/div/a/@title[not(contains(.,"(Blu-ray"))]/../@href|//meta[@property="og:url"]/@content
         postProcess:
           - replace:
@@ -55,6 +55,8 @@ xPathScrapers:
         selector: //div[@id="video_jacket"]/img/@src
         postProcess:
           - replace:
+            - regex: (http:|https:)
+              with:
             - regex: ^
               with: "https:"
       Studio:
@@ -65,7 +67,7 @@ xPathScrapers:
       Director: //div[@id='video_director']/table/tbody/tr/td[@class="text"]/span/a/text()
       Duration: //div[@id="video_length"]/table/tbody/tr/td/span[@class="text"]/text()
       Date: //div[@id="video_date"]/table/tbody/tr/td[@class="text"]/text()
-      Synopsis: 
+      Synopsis:
         selector: //div[@id="video_title"]/h3/a/text()
         postProcess:
           - replace:
@@ -77,7 +79,19 @@ xPathScrapers:
         selector: //div[@id="video_jacket"]/img/@src
         postProcess:
           - replace:
+            - regex: (http:|https:)
+              with:
             - regex: ^
               with: "https:"
 
-# Last Updated October 22, 2020
+# Switched to CDP due to Cloudflare errors Javascript errors.
+# The 5 second sleep in combination with the CDP driver should prevent
+# Standard Cloudflare errors in regards to their Javascript check.
+# There is still the possibliy of getting a CAPTCHA block based on Cloudflare's
+# analasys of your traffic pattern. Nothing can be don't about that besides
+# waiting it out or using one of the mirrors.
+driver:
+  useCDP: true
+  sleep: 5
+
+# Last Updated November 8, 2020

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -88,7 +88,7 @@ xPathScrapers:
 # The 5 second sleep in combination with the CDP driver should prevent
 # Standard Cloudflare errors in regards to their Javascript check.
 # There is still the possibliy of getting a CAPTCHA block based on Cloudflare's
-# analasys of your traffic pattern. Nothing can be don't about that besides
+# analysis of your traffic pattern. Nothing can be done about that besides
 # waiting it out or using one of the mirrors.
 driver:
   useCDP: true

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -84,7 +84,7 @@ xPathScrapers:
             - regex: ^
               with: "https:"
 
-# Switched to CDP due to Cloudflare errors Javascript errors.
+# Switched to CDP due to Cloudflare and Javascript errors.
 # The 5 second sleep in combination with the CDP driver should prevent
 # Standard Cloudflare errors in regards to their Javascript check.
 # There is still the possibliy of getting a CAPTCHA block based on Cloudflare's

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -87,7 +87,7 @@ xPathScrapers:
 # Switched to CDP due to Cloudflare and Javascript errors.
 # The 5 second sleep in combination with the CDP driver should prevent
 # Standard Cloudflare errors in regards to their Javascript check.
-# There is still the possibliy of getting a CAPTCHA block based on Cloudflare's
+# There is still the possibility of getting a CAPTCHA block based on Cloudflare's
 # analysis of your traffic pattern. Nothing can be done about that besides
 # waiting it out or using one of the mirrors.
 driver:


### PR DESCRIPTION
Since more and more scrapers have been running into issues with Cloudflare I did some reading up on how their scraper protection actually functions.

You can see the sample error JAV was getting here: https://github.com/stashapp/CommunityScrapers/issues/123#issuecomment-706771764
Basically Cloudflare spends 5 seconds testing javascript to make sure it works as a scraper prevention method.

So anytime we get a response like this on a scraper:
![image](https://user-images.githubusercontent.com/1358708/98500566-da2fec80-221a-11eb-9263-caf48ff24fbd.png)

It can be fixed by adding CDP with a 5 second sleep to the scraper.

```YAML
driver:
  useCDP: true
  sleep: 5
```

If a CAPTCHA is hit, that is a whole other story, but this Javascript challenge page is apparently the most common Cloudflare page that scrapers run into. (Info source https://github.com/Anorov/cloudflare-scrape)