### PR TITLE
Update Nubiles scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -223,6 +223,7 @@ famedigital.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 family.xxx|trafficpimps.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 familyhookups.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 familystrokes.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+familyswap.xxx|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 familytherapyxxx.com|FamilyTherapyXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 familyxxx.com|FamilyXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fantasyhd.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -270,6 +271,7 @@ girlgirl.com|JulesJordan.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 girlgirlmania.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 girlsandstuds.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 girlsgotcream.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+girlsonlyporn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 girlsoutwest.com|GirlsOutWest.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 girlsrimming.com|GirlsRimming.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Rimjobs
 girlstryanal.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
@@ -295,6 +297,7 @@ homemadeanalwhores.com|AnalizedNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 hometowngirls.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 hometownhoneys.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 horrorporn.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+hotcrazymess.com|Nubiles.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 hothouse.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 hotlegsandfeet.com|DDFNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 hottiemoms.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -443,6 +446,7 @@ nubiles-casting.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|st
 nubiles-porn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|stash >= v0.3.0-42|-
 nubiles.net|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|stash >= v0.3.0-42|-
 nubileset.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|stash >= v0.3.0-42|-
+nubilesporn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 nubilesunscripted.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|stash >= v0.3.0-42|-
 nudefightclub.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nurumassage.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -113,8 +113,10 @@ xPathScrapers:
             - replace:
                 - regex: (.+?)\.(com|xxx)
                   with: $1
+                # 'StepSiblingsCaught' => 'Step Siblings Caught'
                 - regex: ([a-z])-?([A-Z])
                   with: $1 $2
+                # 'Petite HDPorn' => 'Petite HD Porn'
                 - regex: ([A-Z]+)(Porn)
                   with: $1 $2
             # Fix special cases

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -64,7 +64,7 @@ galleryByURL:
 xPathScrapers:
   sceneScraper:
     common:
-      $contentpane: //div[@class="col-12 col-md-7 col-lg-5 content-pane-title"]
+      $contentpane: //div[contains(@class, "content-pane-title")]
     scene:
       Title: //h2/text()
       Date:
@@ -72,7 +72,7 @@ xPathScrapers:
         postProcess:
           - parseDate: Jan 2, 2006
       Details:
-        selector: //div[@class="col-12 content-pane-column"]//p/text()|//div[@class="col-12 content-pane-column"]/div/text()
+        selector: //div[contains(@class, "content-pane-column")]//p/text()|//div[contains(@class, "content-pane-column")]/div/text()
         concat: " "
       Performers:
         Name: //div[@class="content-pane-performers"]/a/text()
@@ -93,17 +93,17 @@ xPathScrapers:
                 with: "https:"
   galleryScraper:
     common:
-      $contentpane: //div[@class="col-12 col-md-7 col-lg-5 content-pane-title"]
+      $contentpane: //div[contains(@class, "content-pane-title")]
     gallery:
       Title:
         selector: //h2
         postProcess:
           - replace:
               # Remove - S11:E11 part
-              - regex: ^(.+)(?:\s-\sS\d+:E\d+)$|^(.+)$
-                with: $1$2
+              - regex: \s-\sS\d+:E\d+$
+                with:
       Details:
-        selector: //div[@class="col-12 content-pane-column"]//p/text()[normalize-space(.)]|//div[@class="col-12 content-pane-column"]/div/text()[normalize-space(.)]
+        selector: //div[contains(@class, "content-pane-column")]//p/text()[normalize-space(.)]|//div[contains(@class, "content-pane-column")]/div/text()[normalize-space(.)]
         concat: "\n\n"
       Date:
         selector: $contentpane//span[@class="date"]/text()

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -2,63 +2,63 @@ name: "Nubiles"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - nubilefilms.com/
-      - nubiles.net/
-      - nubiles-porn.com/
-      - nubilesunscripted.com/
-      - nubiles-casting.com/
-      - nubileset.com/
-      - nfbusty.com/
       - anilos.com/
-      - deeplush.com/
-      - momsteachsex.com/
-      - petitehdporn.com/
-      - brattysis.com/
-      - thatsitcomshow.com/
       - badteenspunished.com/
-      - princesscum.com/
-      - myfamilypies.com/
-      - daddyslilangel.com/
-      - teacherfucksteens.com/
-      - stepsiblingscaught.com/
-      - petiteballerinasfucked.com/
-      - driverxxx.com/
       - bountyhunterporn.com/
+      - brattysis.com/
+      - daddyslilangel.com/
+      - deeplush.com/
       - detentiongirls.com/
+      - driverxxx.com/
       - familyswap.xxx/
       - girlsonlyporn.com/
       - hotcrazymess.com/
+      - momsteachsex.com/
+      - myfamilypies.com/
+      - nfbusty.com/
+      - nubilefilms.com/
+      - nubiles-casting.com/
+      - nubiles-porn.com/
+      - nubiles.net/
+      - nubileset.com/
       - nubilesporn.com/
+      - nubilesunscripted.com/
+      - petiteballerinasfucked.com/
+      - petitehdporn.com/
+      - princesscum.com/
+      - stepsiblingscaught.com/
+      - teacherfucksteens.com/
+      - thatsitcomshow.com/
     scraper: sceneScraper
 galleryByURL:
   - action: scrapeXPath
     url:
-      - nubilefilms.com/photo/gallery/
-      - nubiles.net/photo/gallery/
-      - nubiles-porn.com/photo/gallery/
-      - nubilesunscripted.com/photo/gallery/
-      - nubiles-casting.com/photo/gallery/
-      - nubileset.com/photo/gallery/
-      - nfbusty.com/photo/gallery/
       - anilos.com/photo/gallery/
-      - deeplush.com/photo/gallery/
-      - momsteachsex.com/photo/gallery/
-      - petitehdporn.com/photo/gallery/
-      - brattysis.com/photo/gallery/
-      - thatsitcomshow.com/photo/gallery/
       - badteenspunished.com/photo/gallery/
-      - princesscum.com/photo/gallery/
-      - myfamilypies.com/photo/gallery/
-      - daddyslilangel.com/photo/gallery/
-      - teacherfucksteens.com/photo/gallery/
-      - stepsiblingscaught.com/photo/gallery/
-      - petiteballerinasfucked.com/photo/gallery/
-      - driverxxx.com/photo/gallery/
       - bountyhunterporn.com/photo/gallery/
+      - brattysis.com/photo/gallery/
+      - daddyslilangel.com/photo/gallery/
+      - deeplush.com/photo/gallery/
       - detentiongirls.com/photo/gallery/
+      - driverxxx.com/photo/gallery/
       - familyswap.xxx/photo/gallery/
       - girlsonlyporn.com/photo/gallery/
+      - momsteachsex.com/photo/gallery/
+      - myfamilypies.com/photo/gallery/
+      - nfbusty.com/photo/gallery/
+      - nubilefilms.com/photo/gallery/
+      - nubiles-casting.com/photo/gallery/
+      - nubiles-porn.com/photo/gallery/
+      - nubiles.net/photo/gallery/
+      - nubileset.com/photo/gallery/
       - nubilesporn.com/photo/gallery/
+      - nubilesunscripted.com/photo/gallery/
+      - petiteballerinasfucked.com/photo/gallery/
+      - petitehdporn.com/photo/gallery/
+      - princesscum.com/photo/gallery/
+      - stepsiblingscaught.com/photo/gallery/
+      - teacherfucksteens.com/photo/gallery/
+      - thatsitcomshow.com/photo/gallery/
     scraper: galleryScraper
 
 xPathScrapers:

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -1,25 +1,21 @@
 name: "Nubiles"
+# Sites from https://nubilescash.com/page/about
+
 sceneByURL:
+  # Nubiles-Porn network sites
   - action: scrapeXPath
+    scraper: nubilesPornMultiScraper
     url:
-      - anilos.com/
       - badteenspunished.com/
       - bountyhunterporn.com/
-      - brattysis.com/
       - daddyslilangel.com/
-      - deeplush.com/
       - detentiongirls.com/
       - driverxxx.com/
       - familyswap.xxx/
-      - girlsonlyporn.com/
-      - hotcrazymess.com/
       - momsteachsex.com/
       - myfamilypies.com/
-      - nfbusty.com/
-      - nubilefilms.com/
       - nubiles-casting.com/
       - nubiles-porn.com/
-      - nubiles.net/
       - nubileset.com/
       - nubilesporn.com/
       - nubilesunscripted.com/
@@ -28,28 +24,36 @@ sceneByURL:
       - princesscum.com/
       - stepsiblingscaught.com/
       - teacherfucksteens.com/
-      - thatsitcomshow.com/
-    scraper: sceneScraper
-galleryByURL:
+
+  # Other Nubiles sites
   - action: scrapeXPath
+    scraper: otherNubilesMultiScraper
     url:
-      - anilos.com/photo/gallery/
+      - anilos.com/
+      - brattysis.com/
+      - deeplush.com/
+      - girlsonlyporn.com/
+      - hotcrazymess.com/
+      - nfbusty.com/
+      - nubilefilms.com/
+      - nubiles.net/
+      - thatsitcomshow.com/
+
+galleryByURL:
+  # Nubiles-Porn network sites
+  - action: scrapeXPath
+    scraper: nubilesPornMultiScraper
+    url:
       - badteenspunished.com/photo/gallery/
       - bountyhunterporn.com/photo/gallery/
-      - brattysis.com/photo/gallery/
       - daddyslilangel.com/photo/gallery/
-      - deeplush.com/photo/gallery/
       - detentiongirls.com/photo/gallery/
       - driverxxx.com/photo/gallery/
       - familyswap.xxx/photo/gallery/
-      - girlsonlyporn.com/photo/gallery/
       - momsteachsex.com/photo/gallery/
       - myfamilypies.com/photo/gallery/
-      - nfbusty.com/photo/gallery/
-      - nubilefilms.com/photo/gallery/
       - nubiles-casting.com/photo/gallery/
       - nubiles-porn.com/photo/gallery/
-      - nubiles.net/photo/gallery/
       - nubileset.com/photo/gallery/
       - nubilesporn.com/photo/gallery/
       - nubilesunscripted.com/photo/gallery/
@@ -58,23 +62,35 @@ galleryByURL:
       - princesscum.com/photo/gallery/
       - stepsiblingscaught.com/photo/gallery/
       - teacherfucksteens.com/photo/gallery/
+
+  # Other Nubiles sites
+  - action: scrapeXPath
+    scraper: otherNubilesMultiScraper
+    url:
+      - anilos.com/photo/gallery/
+      - brattysis.com/photo/gallery/
+      - deeplush.com/photo/gallery/
+      - girlsonlyporn.com/photo/gallery/
+      - nfbusty.com/photo/gallery/
+      - nubilefilms.com/photo/gallery/
+      - nubiles.net/photo/gallery/
       - thatsitcomshow.com/photo/gallery/
-    scraper: galleryScraper
 
 xPathScrapers:
-  sceneScraper:
-    common:
+  nubilesPornMultiScraper:
+    common: &commonSelectors
       $contentpane: //div[contains(@class, "content-pane-title")]
+
     scene:
-      Title: //h2/text()
-      Date:
+      Title: &titleSelector //h2/text()
+      Date: &dateAttr
         selector: $contentpane//span[@class="date"]/text()
         postProcess:
           - parseDate: Jan 2, 2006
-      Details:
+      Details: &sceneDetailsAttr
         selector: //div[contains(@class, "content-pane-column")]//p/text()|//div[contains(@class, "content-pane-column")]/div/text()
         concat: " "
-      Performers:
+      Performers: &performersAttr
         Name: //div[@class="content-pane-performers"]/a/text()
       Studio:
         Name:
@@ -83,20 +99,18 @@ xPathScrapers:
             - replace:
               - regex: (.+?)\.(com|xxx)
                 with: $1
-      Tags:
+      Tags: &tagsAttr
         Name: //div[@class="categories"]/a/text()
-      Image:
+      Image: &imageAttr
         selector: //img[@class="fake-video-player-cover"]/@src
         postProcess:
           - replace:
               - regex: ^
                 with: "https:"
-  galleryScraper:
-    common:
-      $contentpane: //div[contains(@class, "content-pane-title")]
-    gallery:
+
+    gallery: &galleryScraper
       Title:
-        selector: //h2
+        selector: *titleSelector
         postProcess:
           - replace:
               # Remove - S11:E11 part
@@ -105,20 +119,29 @@ xPathScrapers:
       Details:
         selector: //div[contains(@class, "content-pane-column")]//p/text()[normalize-space(.)]|//div[contains(@class, "content-pane-column")]/div/text()[normalize-space(.)]
         concat: "\n\n"
-      Date:
-        selector: $contentpane//span[@class="date"]/text()
-        postProcess:
-          - parseDate: Jan 2, 2006
-      Performers:
-        Name: //div[@class="content-pane-performers"]/a/text()
-      Tags:
-        Name: //div[@class="categories"]/a/text()
-      Studio:
+      Date: *dateAttr
+      Performers: *performersAttr
+      Tags: *tagsAttr
+      Studio: &studioFromTitleAttr
         Name:
           selector: //title/text()
           postProcess:
             - replace:
               - regex: ^(.+?)\s-.+$
                 with: $1
+
+  otherNubilesMultiScraper:
+    common: *commonSelectors
+
+    scene:
+      Title: *titleSelector
+      Date: *dateAttr
+      Details: *sceneDetailsAttr
+      Performers: *performersAttr
+      Studio: *studioFromTitleAttr
+      Tags: *tagsAttr
+      Image: *imageAttr
+
+    gallery: *galleryScraper
 
 # Last Updated November 17, 2020

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -25,6 +25,10 @@ sceneByURL:
       - driverxxx.com/
       - bountyhunterporn.com/
       - detentiongirls.com/
+      - familyswap.xxx/
+      - girlsonlyporn.com/
+      - hotcrazymess.com/
+      - nubilesporn.com/
     scraper: sceneScraper
 galleryByURL:
   - action: scrapeXPath
@@ -52,6 +56,9 @@ galleryByURL:
       - driverxxx.com/photo/gallery/
       - bountyhunterporn.com/photo/gallery/
       - detentiongirls.com/photo/gallery/
+      - familyswap.xxx/photo/gallery/
+      - girlsonlyporn.com/photo/gallery/
+      - nubilesporn.com/photo/gallery/
     scraper: galleryScraper
 
 xPathScrapers:
@@ -74,7 +81,7 @@ xPathScrapers:
           selector: $contentpane//a[@class="site-link"]/text()
           postProcess:
             - replace:
-              - regex: (.+?)\.com
+              - regex: (.+?)\.(com|xxx)
                 with: $1
       Tags:
         Name: //div[@class="categories"]/a/text()
@@ -114,4 +121,4 @@ xPathScrapers:
               - regex: ^(.+?)\s-.+$
                 with: $1
 
-# Last Updated October 28, 2020
+# Last Updated November 17, 2020

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -1,8 +1,11 @@
 name: "Nubiles"
-# Sites from https://nubilescash.com/page/about
+
+# Nubiles Porn sites: https://nubilesporn.com/page/series
+# Nubile Films sites: https://nubilefilms.com/page/series
+# Standalone sites: https://nubilescash.com/page/about (contains all network sites)
 
 sceneByURL:
-  # Nubiles-Porn network sites
+  # Nubiles Porn sites
   - action: scrapeXPath
     scraper: nubilesPornMultiScraper
     url:
@@ -25,22 +28,27 @@ sceneByURL:
       - stepsiblingscaught.com/video/watch/
       - teacherfucksteens.com/video/watch/
 
-  # Other Nubiles sites
+  # Nubile Films sites
   - action: scrapeXPath
-    scraper: otherNubilesMultiScraper
+    scraper: nubileFilmsMultiScraper
+    url:
+      - girlsonlyporn.com/video/watch/
+      - hotcrazymess.com/video/watch/
+      - nubilefilms.com/video/watch/
+      - thatsitcomshow.com/video/watch/
+
+  # Standalone sites
+  - action: scrapeXPath
+    scraper: standaloneMultiScraper
     url:
       - anilos.com/video/watch/
       - brattysis.com/video/watch/
       - deeplush.com/video/watch/
-      - girlsonlyporn.com/video/watch/
-      - hotcrazymess.com/video/watch/
       - nfbusty.com/video/watch/
-      - nubilefilms.com/video/watch/
       - nubiles.net/video/watch/
-      - thatsitcomshow.com/video/watch/
 
 galleryByURL:
-  # Nubiles-Porn network sites
+  # Nubiles Porn sites
   - action: scrapeXPath
     scraper: nubilesPornMultiScraper
     url:
@@ -63,20 +71,26 @@ galleryByURL:
       - stepsiblingscaught.com/photo/gallery/
       - teacherfucksteens.com/photo/gallery/
 
-  # Other Nubiles sites
+  # Nubile Films sites
   - action: scrapeXPath
-    scraper: otherNubilesMultiScraper
+    scraper: nubileFilmsMultiScraper
+    url:
+      - girlsonlyporn.com/photo/gallery/
+      - nubilefilms.com/photo/gallery/
+      - thatsitcomshow.com/photo/gallery/
+
+  # Standalone sites
+  - action: scrapeXPath
+    scraper: standaloneMultiScraper
     url:
       - anilos.com/photo/gallery/
       - brattysis.com/photo/gallery/
       - deeplush.com/photo/gallery/
-      - girlsonlyporn.com/photo/gallery/
       - nfbusty.com/photo/gallery/
-      - nubilefilms.com/photo/gallery/
       - nubiles.net/photo/gallery/
-      - thatsitcomshow.com/photo/gallery/
 
 xPathScrapers:
+  # Nubiles Porn sites
   nubilesPornMultiScraper:
     common: &commonSelectors
       $contentpane: //div[contains(@class, "content-pane-title")]
@@ -87,18 +101,26 @@ xPathScrapers:
         selector: $contentpane//span[@class="date"]/text()
         postProcess:
           - parseDate: Jan 2, 2006
-      Details: &sceneDetailsAttr
+      Details: &detailsAttr
         selector: //div[contains(@class, "content-pane-column")]//p/text()|//div[contains(@class, "content-pane-column")]/div/text()
-        concat: " "
+        concat: "\n\n"
       Performers: &performersAttr
         Name: //div[@class="content-pane-performers"]/a/text()
-      Studio:
+      Studio: &studioFromSiteLinkAttr
         Name:
           selector: $contentpane//a[@class="site-link"]/text()
           postProcess:
             - replace:
-              - regex: (.+?)\.(com|xxx)
-                with: $1
+                - regex: (.+?)\.(com|xxx)
+                  with: $1
+                - regex: ([a-z])-?([A-Z])
+                  with: $1 $2
+                - regex: ([A-Z]+)(Porn)
+                  with: $1 $2
+            # Fix special cases
+            - map:
+                Daddys Lil Angel: Daddy's Lil Angel
+                Nubiles ET: NubilesET
       Tags: &tagsAttr
         Name: //div[@class="categories"]/a/text()
       Image: &imageAttr
@@ -108,20 +130,61 @@ xPathScrapers:
               - regex: ^
                 with: "https:"
 
-    gallery: &galleryScraper
-      Title:
+    gallery:
+      Title: &galleryTitleAttr
         selector: *titleSelector
         postProcess:
           - replace:
               # Remove - S11:E11 part
               - regex: \s-\sS\d+:E\d+$
                 with:
-      Details:
-        selector: //div[contains(@class, "content-pane-column")]//p/text()[normalize-space(.)]|//div[contains(@class, "content-pane-column")]/div/text()[normalize-space(.)]
-        concat: "\n\n"
+      Details: *detailsAttr
       Date: *dateAttr
       Performers: *performersAttr
       Tags: *tagsAttr
+      Studio: *studioFromSiteLinkAttr
+
+  # Nubile Films sites
+  nubileFilmsMultiScraper:
+    common: *commonSelectors
+
+    scene:
+      Title: *titleSelector
+      Date: *dateAttr
+      Details: *detailsAttr
+      Performers: *performersAttr
+      Studio: &nubileFilmsStudioAttr
+        Name:
+          selector: //link[@rel="canonical"]/@href
+          postProcess:
+            - replace:
+                - regex: ^.*//(?:www\.)?(.+?)/.+$
+                  with: $1
+            - map:
+                girlsonlyporn.com: Girls Only Porn
+                hotcrazymess.com: Hot Crazy Mess
+                nubilefilms.com: Nubile Films
+                thatsitcomshow.com: That Sitcom Show
+      Tags: *tagsAttr
+      Image: *imageAttr
+
+    gallery:
+      Title: *galleryTitleAttr
+      Details: *detailsAttr
+      Date: *dateAttr
+      Performers: *performersAttr
+      Tags: *tagsAttr
+      Studio: *nubileFilmsStudioAttr
+
+  # Standalone sites
+  standaloneMultiScraper:
+    common: *commonSelectors
+
+    scene:
+      Title: *titleSelector
+      Date: *dateAttr
+      Details: *detailsAttr
+      Performers: *performersAttr
       Studio: &studioFromTitleAttr
         Name:
           selector: //title/text()
@@ -129,19 +192,15 @@ xPathScrapers:
             - replace:
               - regex: ^(.+?)\s-.+$
                 with: $1
-
-  otherNubilesMultiScraper:
-    common: *commonSelectors
-
-    scene:
-      Title: *titleSelector
-      Date: *dateAttr
-      Details: *sceneDetailsAttr
-      Performers: *performersAttr
-      Studio: *studioFromTitleAttr
       Tags: *tagsAttr
       Image: *imageAttr
 
-    gallery: *galleryScraper
+    gallery:
+      Title: *galleryTitleAttr
+      Details: *detailsAttr
+      Date: *dateAttr
+      Performers: *performersAttr
+      Tags: *tagsAttr
+      Studio: *studioFromTitleAttr
 
-# Last Updated November 17, 2020
+# Last Updated November 25, 2020

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -6,38 +6,38 @@ sceneByURL:
   - action: scrapeXPath
     scraper: nubilesPornMultiScraper
     url:
-      - badteenspunished.com/
-      - bountyhunterporn.com/
-      - daddyslilangel.com/
-      - detentiongirls.com/
-      - driverxxx.com/
-      - familyswap.xxx/
-      - momsteachsex.com/
-      - myfamilypies.com/
-      - nubiles-casting.com/
-      - nubiles-porn.com/
-      - nubileset.com/
-      - nubilesporn.com/
-      - nubilesunscripted.com/
-      - petiteballerinasfucked.com/
-      - petitehdporn.com/
-      - princesscum.com/
-      - stepsiblingscaught.com/
-      - teacherfucksteens.com/
+      - badteenspunished.com/video/watch/
+      - bountyhunterporn.com/video/watch/
+      - daddyslilangel.com/video/watch/
+      - detentiongirls.com/video/watch/
+      - driverxxx.com/video/watch/
+      - familyswap.xxx/video/watch/
+      - momsteachsex.com/video/watch/
+      - myfamilypies.com/video/watch/
+      - nubiles-casting.com/video/watch/
+      - nubiles-porn.com/video/watch/
+      - nubileset.com/video/watch/
+      - nubilesporn.com/video/watch/
+      - nubilesunscripted.com/video/watch/
+      - petiteballerinasfucked.com/video/watch/
+      - petitehdporn.com/video/watch/
+      - princesscum.com/video/watch/
+      - stepsiblingscaught.com/video/watch/
+      - teacherfucksteens.com/video/watch/
 
   # Other Nubiles sites
   - action: scrapeXPath
     scraper: otherNubilesMultiScraper
     url:
-      - anilos.com/
-      - brattysis.com/
-      - deeplush.com/
-      - girlsonlyporn.com/
-      - hotcrazymess.com/
-      - nfbusty.com/
-      - nubilefilms.com/
-      - nubiles.net/
-      - thatsitcomshow.com/
+      - anilos.com/video/watch/
+      - brattysis.com/video/watch/
+      - deeplush.com/video/watch/
+      - girlsonlyporn.com/video/watch/
+      - hotcrazymess.com/video/watch/
+      - nfbusty.com/video/watch/
+      - nubilefilms.com/video/watch/
+      - nubiles.net/video/watch/
+      - thatsitcomshow.com/video/watch/
 
 galleryByURL:
   # Nubiles-Porn network sites


### PR DESCRIPTION
Add missing sites + sort:
- `familyswap.xxx` (scene + gallery) - Closes #287 
- `girlsonlyporn.com` (scene + gallery)
- `hotcrazymess.com` (scene) - Supersedes #128
- `nubilesporn.com` (scene + gallery)

### Nubiles-Porn network sites vs 'other' Nubiles sites
The latter need slightly different Studio Name selectors,
because the non Nubiles-Porn network sites don't have the site name below the video / gallery
and the page title selector can be incorrect for Nubiles-Porn.
I think the same selector for scenes needs to be used for galleries on the Nubiles-Porn but I haven't tested it yet.

### DRY scraper
The "DRY" (Don't Repeat Yourself) scraper is **an idea**.
I asked for objections on Discord and got none, but I do feel like this **might be** a bit too complex.
The idea behind it is to have less duplicate selectors for sites that are close enough but not exactly the same, which makes updating it easier, IMO.

YAML also supports merging (using `<<` keys), however, while working on this scraper I encountered errors in Stash and it only partially worked, as I noticed Tags and Performers did not scrape.
I suspect deep merging is not fully supported in the Go YAML implementation.
(Should be able to use `<<` without quotes, but it's not supported either)

```yml
xPathScrapers:
  nubileFilmsMultiScraper:
    scene:
      "<<": *sceneScraper
      Studio:
        Name: //div[@class="studio"]  # example
```

### Tests
https://pastebin.com/hxNThKxy
