### PR TITLE
Update SARJ-LLC to pull wide scene covers and allow galleryByURL

### DIFF
--- a/scrapers/SARJ-LLC.yml
+++ b/scrapers/SARJ-LLC.yml
@@ -41,7 +41,12 @@ xPathScrapers:
         Name: $data//a[@href[contains(.,'/model/')]]/text()
       Tags:
         Name: //div[@class='tag-list']//a/text()
-      Image: //div[@class='img-container']/img/@src
+      Image:
+        selector: //div[@class='img-container']/img/@src
+        postProcess:
+          - replace:
+            - regex: cover
+              with: "wide"
       Studio:
         Name: //meta[@property='og:site_name']/@content
 

--- a/scrapers/SARJ-LLC.yml
+++ b/scrapers/SARJ-LLC.yml
@@ -60,16 +60,19 @@ xPathScrapers:
         Name: //div[@class='tag-list']//a/text()
       Image:
         selector: //div[@class='img-container']/img/@src
+        # if you prefer the portrait covers over the landscape ones, comment out the postProcess section
         postProcess:
           - replace:
-            - regex: cover
+            - regex: (cover|clean)
               with: "wide"
       Studio:
         Name: //meta[@property='og:site_name']/@content
   galleryScraper:
     gallery:
       Title: //div[@class='info-container']/h3/a/text()
-      Details: //div[@class='description-text']/p/text()
+      Details: 
+        selector: //div[@class='description-text']/p/text()
+        concat: "\n\n"
       Date:
         selector: //div[@class='info-container']/span[@class='timestamp']/text()
         postProcess:

--- a/scrapers/SARJ-LLC.yml
+++ b/scrapers/SARJ-LLC.yml
@@ -15,6 +15,23 @@ sceneByURL:
       - stunning18.com
       - lovehairy.com
     scraper: sceneScraper
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - metartnetwork.com
+      - metart.com
+      - sexart.com
+      - thelifeerotic.com
+      - errotica-archives.com
+      - alsscan.com
+      - vivthomas.com
+      - metartx.com
+      - rylskyart.com
+      - eternaldesire.com
+      - stunning18.com
+      - lovehairy.com
+    scraper: galleryScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -49,5 +66,23 @@ xPathScrapers:
               with: "wide"
       Studio:
         Name: //meta[@property='og:site_name']/@content
-
-# Last Updated October 9, 2020
+  galleryScraper:
+    gallery:
+      Title: //div[@class='info-container']/h3/a/text()
+      Details: //div[@class='description-text']/p/text()
+      Date:
+        selector: //div[@class='info-container']/span[@class='timestamp']/text()
+        postProcess:
+          - parseDate: Jan 02, 2006
+      Studio:
+        Name: //meta[@property='og:site_name']/@content
+      Tags:
+        Name: //div[@class='tag-list']//a/text()
+      Performers:
+        Name:
+          selector: //a[@type='model']/text()
+          postProcess:
+            - replace:
+              - regex: ^Cast:\s+
+                with: ""
+# Last Updated November 24, 2020


### PR DESCRIPTION
This pull request does the following two things:

1. Previously for scenes it pulled the portrait cover.  After talking to a few people in Discord it sounded like wide covers would be preferred.  The URL for the wide cover is embedded inside an attribute with other text, but if you take the 'cover' url and replace 'cover' with 'wide' it points to the same place.  So I just used a regex to do that.

2. With 0.4.0 galleryByURL was added.  I've tested this on several galleries both recent and from way back at the sites inception and it seems to work.  I've only tested it on one of the listed sites but it stands to reason that if the scene code works across sites the gallery likely will as well since it's all the same backend.

I did run the validator and it checked out as well.