### PR TITLE
add shagmag gallery scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -547,6 +547,7 @@ sexsee.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 sexuallybroken.com|sexuallybroken.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 sexvr.com|SexVR.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|VR
 sexyhub.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+shagmag.com|shagmag.yml|:x:|:heavy_check_mark:|:x:|:x:|-|Magazines
 shandafay.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shanedieselsbanginbabes.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 share.myfreecams.com|MFC.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/shagmag.yml
+++ b/scrapers/shagmag.yml
@@ -1,0 +1,33 @@
+name: 'SHAGMAG'
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - shagmag.com/issues/
+    scraper: galleryScraper
+
+xPathScrapers:
+  galleryScraper:
+    gallery:
+      Title: //h1[@class="t-Page-Heading-1"]/text()
+      URL: //link[@rel="canonical"]/@href
+      Studio:
+        Name:
+          fixed: 'SHAGMAG'
+      Date:
+        selector: //h1[@class="t-Page-Heading-1"]/text()
+        postProcess:
+          - replace:
+            # There's one post per month so just assume the 1st so we can get a usable date
+            - regex: ^
+              with: '1 '
+          - parseDate: 2 January 2006
+      Performers:
+        Name:
+          selector: //small[1]/text()
+          postProcess:
+            - replace:
+              - regex: '^Feat. '
+                with: ''
+              - regex: $
+                with: ' and Julia Rose'
+          split: ' and '


### PR DESCRIPTION
Some things to note for this one.

 - The title is always a date in the format of `MMMM YYYY` (eg. `January 2020`)
 - There is only one upload per month, so we assume the first of the month so we can get a usable date (in reality it can come at any point in the month)
 - "Julia Rose" is present on all uploads however her name is not listed on any except the very first so we manually add her
   - This causes a small problem where she gets added twice to that very first one but it doesn't break anything
 - None of the other content on this site has dedicated pages so none of the videos are scrape-able.