### PR TITLE
Fix validator error

### DIFF
--- a/validator/index.js
+++ b/validator/index.js
@@ -334,7 +334,7 @@ class Validator {
   _collectCookieErrors(data) {
     const errors = [];
 
-    const cookies = data && data.driver.cookies;
+    const cookies = data.driver && data.driver.cookies;
     if (cookies) {
       const usesCDP = Boolean(data.driver && data.driver.useCDP);
       cookies.forEach((cookieItem, idx) => {


### PR DESCRIPTION
I don't know how I managed to miss this.
```
~\.stash\CommunityScrapers\validator\index.js:337
    const cookies = data && data.driver.cookies;
                                        ^
TypeError: Cannot read property 'cookies' of undefined
```