### PR TITLE
Fix LetsDoeIt Scraper

### DIFF
--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -33,9 +33,9 @@ xPathScrapers:
       Tags:
         Name: $details//div[@class="col"][4]//a/text()|$details//div[@class="col"][6]//a/text()
       Performers:
-        Name: $actors//h4/span/a//text()
+        Name: $actors//span/a//text()
       Studio:
-        Name: $actors/h4/a//text()
+        Name: $actors//a//text()
       Image: //picture[@class="poster"]/img/@src
 
-# Last Updated November 8, 2020
+# Last Updated December 11, 2020


### PR DESCRIPTION
The `h4` element was replaced with a semantic `h2` element. This broke the scraping of studio and performers. Because this could realistically be changed again and there are no other elements as children to `div.actors`, the logical solution is to remove it from the query altogether.