### PR TITLE
Fix TrafficPimps Scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -234,7 +234,6 @@ fakehub.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 faketaxi.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 falconstudios.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 famedigital.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-family.xxx|trafficpimps.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 familyhookups.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 familystrokes.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 familyswap.xxx|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
@@ -506,11 +505,9 @@ perversefamily.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 pervertgallery.com|AnalizedNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 pervmom.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 peternorth.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-petite.xxx|trafficpimps.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 petiteballerinasfucked.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 petitehdporn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 pickupfuck.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-pimp.xxx|trafficpimps.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 playboy.tv|PlayboyTV.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 plumperpass.com|PlumperPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 pornfidelity.com|KellyMadisonMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|stash >= v0.4.0-14|-

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -2,43 +2,30 @@ name: trafficpimps
 sceneByURL:
   - action: scrapeXPath
     url:
-      - pimp.xxx/trailers/
-      - family.xxx/trailers/
-      - petite.xxx/trailers/
       - cherrypimps.com/
-      - wildoncam.com/
+      # - wildoncam.com/
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
-    common:
-      $infoblock: //div[@class="info-block"]
-      $infodata: //div[@class="info-block_data"]
     scene:
       Title:
-        selector: //h1[@class="trailer-block_title"]
-        postProcess:
-          - replace:
-              - regex: "LIVE$"
-                with:
+        selector: //div[@class="item-title"]/h1/text()
       Date:
-        selector: //div[@class="info-block_data"]/p[@class="text"][1]/text()
+        selector: //div[@class="update-info-row"][1]
         postProcess:
           - replace:
-              - regex: (\w+\s)(\w+)(\s)(\d{1,2})(.+)(\d{4})(.+)
-                with: $2 $4, $6
+              - regex: \s*Added:\s
+                with: ""
           - parseDate: January 2, 2006
-      Details: $infoblock/p[@class="text"][1]/text()
+      Details: //div[@class="update-info-block"][1]/p/text()
       Tags:
-        Name: $infoblock/p[contains(text(),'Categories:')]/a
+        Name: //ul[@class="tags"]/li/a/text()
       Performers:
-        Name: $infodata/p[contains(text(),'Featuring:')]/a
+        Name: //div[contains(@class, "model-list-item")]/a/span/text()
       Studio:
-        Name: //div[@class="container"]/a[@class="logo"]/@title
-      Image: 
-        selector: //script[contains(.,"contentthumbs")]/text()|//img[@class="lazyload update_thumb thumbs stdimage"]/@src
-        postProcess:
-          - replace:
-              - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
-                with: $2
+        Name: //a[@class="series-item-logo"]/img/@alt
+      Image: //div[@class="player-thumb"]/img/@src
+driver:
+  useCDP: true
 
-# Last Updated November 8, 2020
+# Last Updated December 11, 2020

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -24,8 +24,6 @@ xPathScrapers:
         Name: //div[contains(@class, "model-list-item")]/a/span/text()
       Studio:
         Name: //a[@class="series-item-logo"]/img/@alt
-      Image: //div[@class="player-thumb"]/img/@src
-driver:
-  useCDP: true
+      Image: //div[@class="player-thumb"]/img/@src0_1x
 
-# Last Updated December 11, 2020
+# Last Updated December 12, 2020

--- a/scrapers/trafficpimps.yml
+++ b/scrapers/trafficpimps.yml
@@ -3,10 +3,13 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - cherrypimps.com/
-      # - wildoncam.com/
-    scraper: sceneScraper
+    scraper: cherryPimpsScraper
+  - action: scrapeXPath
+    url:
+      - wildoncam.com/
+    scraper: wildOnCamsScraper
 xPathScrapers:
-  sceneScraper:
+  cherryPimpsScraper:
     scene:
       Title:
         selector: //div[@class="item-title"]/h1/text()
@@ -25,5 +28,36 @@ xPathScrapers:
       Studio:
         Name: //a[@class="series-item-logo"]/img/@alt
       Image: //div[@class="player-thumb"]/img/@src0_1x
+  wildOnCamsScraper:
+    common:
+      $infoblock: //div[@class="info-block"]
+      $infodata: //div[@class="info-block_data"]
+    scene:
+      Title:
+        selector: //h1[@class="trailer-block_title"]
+        postProcess:
+          - replace:
+            - regex: "LIVE$"
+              with: ""
+      Date:
+        selector: $infodata/p[@class="text"][1]/text()
+        postProcess:
+          - replace:
+            - regex: (\w+\s)(\w+)(\s)(\d{1,2})(.+)(\d{4})(.+)
+              with: $2 $4 $6
+          - parseDate: January 2 2006
+      Details: $infoblock/p[@class="text"][1]/text()
+      Tags:
+        Name: $infoblock/p[contains(text(), 'Categories:')]/a
+      Performers:
+        Name: $infodata/p[contains(text(), 'Featuring:')]/a
+      Studio:
+        Name: //div[@class="container"]/a[@class="logo"]/@title
+      Image:
+        selector: //script[contains(., "contentthumbs")]/text()|//img[@class="lazyload update_thumb thumbs stdimage"]/@src
+        postProcess:
+          - replace:
+            - regex: (.+)(https.+contentthumbs.+)(" width="100%)(.+)
+              with: $2
 
-# Last Updated December 12, 2020
+# Last Updated December 14, 2020


### PR DESCRIPTION
There are quite a few changes here. CDP is required to get the cover image.

Just a couple notes regarding the URL changes:

 - The pimp.xxx, family.xxx, and petite.xxx URLs redirect to cherrypimps.com and are thus pointless.
 - The wildoncam.com URL got commented out as the site has not updated to the new layout that is present on cherrypimps.com and thus none of the selectors will work. Wild On Cam scenes _are_ present on cherrypimps.com however so if they need to be scraped, use the CherryPimps site.

