### PR TITLE
Add aziani and gloryholesecrets to gangbangcreampie xPath Scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -71,6 +71,7 @@ atkpremium.com|ATKHairy.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 aussieass.com|AussieAss.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 aussiefellatioqueens.com|AussieFelatioQueens.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 aussiepov.com|AussieAss.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+aziani.com|GangBangCreampie.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 b47w.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|CDP|JAV
 babepedia.com|Babepedia.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Database
 babes.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -295,6 +296,7 @@ girlsoutwest.com|GirlsOutWest.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 girlsrimming.com|GirlsRimming.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Rimjobs
 girlstryanal.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 girlsway.com|PureTaboo.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Lesbian
+gloryholesecrets.com|GangBangCreampie.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 gloryholeswallow.com|GloryHoleSwallow.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 grannyghetto.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Granny
 grooby-archives.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/GangBangCreampie.yml
+++ b/scrapers/GangBangCreampie.yml
@@ -1,31 +1,61 @@
-name: GangBangCreampie
+name: Aziani
 sceneByURL:
   - action: scrapeXPath
     url:
       - gangbangcreampie.com
+      - gloryholesecrets.com
     scraper: sceneScraper
+  - action: scrapeXPath
+  # This site differs from the other two in that it lacks the host part in the url,
+  # therefore there is a copy of the scraper with only one extra replace.
+  # It uses YAML anchors, so ideally only the first scraper needs to be changed
+    url:
+      - aziani.com
+    scraper: sceneScraperB
 xPathScrapers:
   sceneScraper:
     scene:
-      Studio:
+      Studio: &studio
         Name:
-          fixed: Gangbang Creampie
-      Performers:
+          selector: //base/@href
+          postProcess:
+            - replace:
+                - regex: ^.+(?:\.|/)(.+)\..+$
+                  with: $1
+            - map:
+                gloryholesecrets: Gloryhole Secrets
+                gangbangcreampie: Gangbang Creampie
+                aziani: Aziani
+      Performers: &performers
         Name: //div[@class="video_details mb mt0"]/h5[i[@class="icon-female"]]/a
-      Title:
+      Title: &title
         selector: //h2[@class="H_underline"]/text()
-      Details:
+      Details: &details
         selector: //div[@class="desc"]/p/text()
         concat: "\n\n"
-      Tags:
+      Tags: &tags
         Name: //h5[@class="video_categories"]/a
-      Image:
+      Image: &image
         selector: //img[@id="set-target-1_0"]/@src
-      Date:
+      Date: &date
         selector: //comment()[contains(.,"icon-calendar")]
         postProcess:
           - replace:
-              - regex: .*(\d{2}\/\d{2}\/\d{4}).*
+              - regex: ^.*(\d{2}\/\d{2}\/\d{4}).*$
                 with: $1
           - parseDate: 01/02/2006
-# Last Updated August 30, 2020
+  sceneScraperB:
+    scene:
+      Studio: *studio
+      Performers: *performers
+      Title: *title
+      Details: *details
+      Tags: *tags
+      Image:
+        <<: *image
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://www.aziani.com
+      Date: *date
+# Last Updated December 13, 2020


### PR DESCRIPTION
Gloryholesecrets was requested in #73 

All pages use the same layout, with the exception of aziani, where the host part is missing from the thumbnail urls.
Since, as far as I know, it is not possible to dynamically compose the URL, I used YAML anchors, which makes it faster, and in my opinion more readable, than a big replace. So in the best case you only have to change the xPath in one place if the layout changes.