### PR TITLE
Update Clips4Sale image and details selectors

### DIFF
--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -37,11 +37,11 @@ xPathScrapers:
       Performers:
         Name: $clipInfo//a/text()
       Image:
-        selector: //div[@class="clipImage"]/img/@src
+        selector: //div[contains(@class, "clipImage")]/img/@src
         postProcess:
           - replace:
-              - regex: ^\/\/
-                with: "https://"
-      URL: //meta[@property='og:url']/@content
+              - regex: ^//
+                with: https://
+      URL: //meta[@property="og:url"]/@content
 
-# Last Updated November 11, 2020
+# Last Updated December 14, 2020

--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -12,11 +12,11 @@ xPathScrapers:
     scene:
       Title: //div[@class="clipTitle"]/h3/text()
       Details:
-        selector: //div[@class="clip"]/div/p//text()
+        selector: //div[@class="clip"]/div[1]/*|//div[@class="clip"]/div[1]/text()
         concat: "\n\n"
         postProcess:
           - replace:
-              - regex: "Description:"
+              - regex: ^Description:\s*
                 with:
       Studio:
         Name: $studio


### PR DESCRIPTION
I've tested the details selector for over two weeks. It seems better than it was, but there is no magic/catch-all solution for Clips4Sale. Descriptions are user-generated content and Clips4Sale allow their users to use HTML as they please within that `//div[@class="clip"]/div[1]` element, so one clip's description markup can be wildly different than the next one.
This selector will probably scrape more text than it does currently (as opposed to less 😉)
but it should keep the line breaks for most of it, which will help make the text more readable and easier to trim down when scraping.

The image selector is just a simple fix.