### PR TITLE
Enable merge key support in validator

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -345,13 +345,13 @@ iknowthatgirl.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 immorallive.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 infernalrestraints.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 innocenthigh.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-intimatelesbians.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 insex.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+intimatelesbians.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 isthisreal.com|IsThisReal.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 itscleolive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jamesdeen.com|AnalizedNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 japanhdv.com|JapanHDV.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
-javdb.com|javdb.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|stash >= v0.4.0-14|Database
+javdb.com|javdb.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|stash >= v0.4.0-14|Database
 javhd.com|JavHD.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 javlibrary.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|CDP|JAV
 jaysinxxx.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/validator/index.js
+++ b/validator/index.js
@@ -92,6 +92,7 @@ class Validator {
     const yamlLoadOptions = {
       prettyErrors: true,
       version: '1.2',
+      merge: true,
     };
 
     let result = true;


### PR DESCRIPTION
It seems merge keys do work as long as the map key is unique
(see `GangBangCreampie.yml`)
https://github.com/stashapp/CommunityScrapers/blob/d5fe4e6d2cc884d260ec00dfa323bc1d4f9275f4/scrapers/GangBangCreampie.yml#L54-L59

What I tried to do with `Nubiles.yml` (#288) still produces an error:
```
Error loading scraper CommunityScrapers\\scrapers\\Nubiles.yml: yaml: unmarshal errors:
  line 187: key "Studio" already set in map
```

```yml
xPathScrapers:
  nubileFilmsMultiScraper:
    scene:
      <<: *sceneScraper
      Studio:
        Name: //div[@class="studio"]  # example
```