### PR TITLE
Update R18 (sceneByFragment + censor)

### DIFF
--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -38,6 +38,28 @@ xPathScrapers:
       Details:
         selector: //div[@class="col01"]/h1/cite[@itemprop="name"]/text()|//div[contains(@class,"cmn-box-description")]/p
         concat: "\n\n"
+        postProcess:
+          - replace:
+            - regex: R\*{2}e
+              with: "Rape"
+            - regex: G\*{7}g
+              with: "Gangbang"
+            - regex: T\*{5}e
+              with: "Torture"
+            - regex: V\*{5}t
+              with: "Violent"
+            - regex: S\*{3}e
+              with: "Slave"
+            - regex: S\*{3}ery
+              with: "Slavery"
+            - regex: D\*{3}king
+              with: "Drinking"
+            - regex: S\*{5}t
+              with: "Student"
+            - regex: SK\*{2}ls
+              with: "Skills"
+            - regex: P\*{4}hed
+              with: "Punished"
       Tags:
         Name: //div[@class="product-categories-list product-box-list"]/div[@class="pop-list"]/a
       Performers:

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -18,7 +18,7 @@ xPathScrapers:
   sceneScraper:
     common:
       $sceneinfo: //section[@class="clearfix"]/div[@class="product-details"]
-      $searchinfo: //li[@class="item-list"]/a//img[string-length(@alt)=string-length(preceding::div[@class="genre01"]/span/text())]
+      $searchinfo: //li[contains(@class,"item-list")]/a//img[string-length(@alt)=string-length(preceding::div[@class="genre01"]/span/text())]
     scene:
       Title: $searchinfo/@alt|$sceneinfo/dl/dt[contains(.,"DVD ID")]/following-sibling::dd[1]/text()
       URL: $searchinfo/ancestor::a/@href|//link[@rel='canonical']/@href

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -11,9 +11,7 @@ sceneByFragment:
     filename:
       - regex: (.*[^a-zA-Z0-9])*([a-zA-Z-]+\d+)(.+)
         with: $2
-      - regex: "-"
-        with: ""
-      - regex: (\D+)(\d+)
+      - regex: ([a-zA-Z]+)(\d+)
         with: $1-$2
   scraper: sceneScraper
 xPathScrapers:
@@ -53,5 +51,5 @@ xPathScrapers:
       Studio:
         Name:
           selector: $sceneinfo/dl/dt[contains(.,"Studio")]/../dd[@itemprop="productionCompany"]/a/text()
-      Image: //meta[@itemprop="thumbnailUrl"]/@content
+      Image: $searchinfo/@data-original|//meta[@itemprop="thumbnailUrl"]/@content
 # Last Updated December 22, 2020

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -60,6 +60,8 @@ xPathScrapers:
               with: "Skills"
             - regex: P\*{4}hed
               with: "Punished"
+            - regex: D\*{2}gged
+              with: "Drugged"
       Tags:
         Name: //div[@class="product-categories-list product-box-list"]/div[@class="pop-list"]/a
       Performers:

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -1,4 +1,4 @@
-name: r18
+name: "R18 (JAV)"
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -54,4 +54,4 @@ xPathScrapers:
         Name:
           selector: $sceneinfo/dl/dt[contains(.,"Studio")]/../dd[@itemprop="productionCompany"]/a/text()
       Image: //meta[@itemprop="thumbnailUrl"]/@content
-# Last Updated October 11, 2020
+# Last Updated December 22, 2020

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -18,7 +18,7 @@ xPathScrapers:
   sceneScraper:
     common:
       $sceneinfo: //section[@class="clearfix"]/div[@class="product-details"]
-      $searchinfo: //li[@class="item-list"]/a//img[string(@alt)=string(preceding::div[@class="genre01"]/span/text())]
+      $searchinfo: //li[@class="item-list"]/a//img[string-length(@alt)=string-length(preceding::div[@class="genre01"]/span/text())]
     scene:
       Title: $searchinfo/@alt|$sceneinfo/dl/dt[contains(.,"DVD ID")]/following-sibling::dd[1]/text()
       URL: $searchinfo/ancestor::a/@href|//link[@rel='canonical']/@href

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -62,6 +62,16 @@ xPathScrapers:
               with: "Punished"
             - regex: D\*{2}gged
               with: "Drugged"
+            - regex: F\*{3}ed
+              with: "Fucked"
+            - regex: D\*{3}k
+              with: "Drunk"
+            - regex: S\*{8}l
+              with: "Schoolgirl"
+            - regex: R\*{4}g
+              with: "Raping"
+            - regex: P\*{4}hment
+              with: "Punishment"
       Tags:
         Name: //div[@class="product-categories-list product-box-list"]/div[@class="pop-list"]/a
       Performers:

--- a/scrapers/r18.yml
+++ b/scrapers/r18.yml
@@ -4,12 +4,26 @@ sceneByURL:
     url:
       - r18.com/videos
     scraper: sceneScraper
+sceneByFragment:
+  action: scrapeXPath
+  queryURL: https://www.r18.com/common/search/searchword={filename}
+  queryURLReplace:
+    filename:
+      - regex: (.*[^a-zA-Z0-9])*([a-zA-Z-]+\d+)(.+)
+        with: $2
+      - regex: "-"
+        with: ""
+      - regex: (\D+)(\d+)
+        with: $1-$2
+  scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
     common:
       $sceneinfo: //section[@class="clearfix"]/div[@class="product-details"]
+      $searchinfo: //li[@class="item-list"]/a//img[string(@alt)=string(preceding::div[@class="genre01"]/span/text())]
     scene:
-      Title: $sceneinfo/dl/dt[contains(.,"DVD ID")]/following-sibling::dd[1]/text()
+      Title: $searchinfo/@alt|$sceneinfo/dl/dt[contains(.,"DVD ID")]/following-sibling::dd[1]/text()
+      URL: $searchinfo/ancestor::a/@href|//link[@rel='canonical']/@href
       Date:
         selector: $sceneinfo/dl/dt[contains(.,"Release Date")]/../dd[@itemprop="dateCreated"]/text()
         postProcess:


### PR DESCRIPTION
Same regex as Javlibrary but added 1 more step because R18 search is worst than Javlibrary
- It doesn't know PPPD148 but PPPD-148.

For the xpath, it compare the search text to the name of the Movies to avoid mistake
-  HNDS-057 != HND-057 (https://www.r18.com/common/search/searchword=HND-057/)

Changed the name to warn people it's for JAV, because "R18" is not really explicit.