### PR TITLE
Update javlibrary mirror

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -73,6 +73,7 @@ aussiefellatioqueens.com|AussieFelatioQueens.yml|:heavy_check_mark:|:x:|:x:|:x:|
 aussiepov.com|AussieAss.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 aziani.com|GangBangCreampie.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 b47w.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|CDP|JAV
+b49t.com|javlibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|CDP|JAV
 babepedia.com|Babepedia.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Database
 babes.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 babesnetwork.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -13,15 +13,19 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - javlibrary.com/
-      - b49t.com/
+      - m45e.com/
+      - g46e.com/
       - b47w.com/
+      - b49t.com/
     scraper: sceneScraper
 movieByURL:
   - action: scrapeXPath
     url:
       - javlibrary.com/
-      - b49t.com/
+      - m45e.com/
+      - g46e.com/
       - b47w.com/
+      - b49t.com/
     scraper: movieScraper
 xPathScrapers:
   sceneScraper:

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -96,4 +96,4 @@ driver:
   useCDP: true
   sleep: 5
 
-# Last Updated November 8, 2020
+# Last Updated December 28, 2020

--- a/scrapers/javlibrary.yml
+++ b/scrapers/javlibrary.yml
@@ -13,16 +13,14 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - javlibrary.com/
-      - m45e.com/
-      - g46e.com/
+      - b49t.com/
       - b47w.com/
     scraper: sceneScraper
 movieByURL:
   - action: scrapeXPath
     url:
       - javlibrary.com/
-      - m45e.com/
-      - g46e.com/
+      - b49t.com/
       - b47w.com/
     scraper: movieScraper
 xPathScrapers:


### PR DESCRIPTION
Got blocked by Cloudflare, so time to update the mirror list. 😋 

```      
      - m45e.com/
      - g46e.com/
```
No longer exist but redirect to a other mirror (b49t) so if you have old mirror URL in stash, it will still work.
But normally the scraper replace the URL with javlibray.com so you shoudn't have URL with.
Then should i remove these sites ?