### PR TITLE
Update vixen scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -108,8 +108,8 @@ bigfatcreampie.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bignaturals.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 black-tgirls.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 blackambush.com|blackambush.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-blacked.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
-blackedraw.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+blacked.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
+blackedraw.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
 blackmarketxxx.com|CombatZone.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 blacktgirlshardcore.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 blackvalleygirls.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -197,7 +197,7 @@ data18.com|data18.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 daughterswap.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ddfbusty.com|DDFNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 deauxmalive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-deeper.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+deeper.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
 deeplush.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 deviante.com|deviante.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 defiled18.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -725,8 +725,8 @@ tryteens.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tsfactor.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tsplayground.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tspov.com|ChristianXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
-tushy.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
-tushyraw.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+tushy.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
+tushyraw.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
 twistedvisual.com|AnalizedNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 twistys.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 twistysnetwork.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
@@ -741,7 +741,7 @@ virtualrealporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 virtualtaboo.com|VirtualTaboo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 vivid.com|Vivid.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vivthomas.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
-vixen.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+vixen.com|vixenNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|Python >= 3.3|-
 vrbangers.com|VRBangers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 vrbgay.com|VRBangers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 vrbtrans.com|VRBangers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -35,12 +35,15 @@ def fetch_page_json(page_html):
     return None if len(matches) == 0 else json.loads(matches[0])
 
 
-def save_json(scraped_json, video_id):
+def save_json(scraped_json, video_id, save_location):
+    location = 'VixenNetwork_JSON'
+    if save_location != 'save':
+        location = save_location
     try:
-        os.makedirs('VixenNetwork_JSON')
+        os.makedirs(location)
     except FileExistsError:
         pass
-    filename = os.path.join('VixenNetwork_JSON', '%s.json' % video_id)
+    filename = os.path.join(location, '%s.json' % video_id)
     with open(filename, 'w', encoding='utf-8') as f:
         json.dump(scraped_json, f, ensure_ascii=False, indent=4)
 
@@ -83,7 +86,8 @@ def main():
         'tags': [{'name': x['name']} for x in scene['categories']],
         'image': scene['images']['poster'][len(scene['images']['poster']) - 1]['src'],
     }
-    save_json(j, scene['videoId'])
+    if len(sys.argv) > 1:
+        save_json(j, scene['videoId'], sys.argv[1])
     print(json.dumps(scrape))
 
 

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -61,7 +61,7 @@ def main():
     if site is None:
         log('The URL could not be parsed')
         sys.exit(1)
-    response = make_request(url, 'https://%s' % site)
+    response = make_request('https://%s/%s' % (site, slug), 'https://%s' % site)
     if response is None:
         log('Could not fetch page HTML')
         sys.exit(1)

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -10,7 +10,7 @@ def log(*s):
 
 
 def get_from_url(url_to_parse):
-    m = re.match(r'(?:https?://)?(?:www\.)?((\w+)\.com)/([a-z-]+)', url_to_parse)
+    m = re.match(r'(?:https?://)?(?:www\.)?((\w+)\.com)/([a-z0-9-]+)', url_to_parse)
     if m is None:
         return None, None, None
     return m.groups()

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -5,6 +5,10 @@ import requests
 import sys
 
 
+MINIMUM_VERSION_MAJOR = 3
+MINIMUM_VERSION_MINOR = 3
+
+
 def log(*s):
     print(*s, file=sys.stderr)
 
@@ -92,6 +96,9 @@ def main():
 
 
 if __name__ == '__main__':
+    if sys.version_info.major != MINIMUM_VERSION_MAJOR or sys.version_info.minor < MINIMUM_VERSION_MINOR:
+        log('Invalid Python version. Version %s.%s or later required.' % (MINIMUM_VERSION_MAJOR, MINIMUM_VERSION_MINOR))
+        sys.exit(1)
     try:
         main()
     except Exception as e:

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -1,0 +1,87 @@
+import json
+import os
+import re
+import requests
+import sys
+from urllib.parse import urlparse
+
+
+def log(*s):
+    print(*s, file=sys.stderr)
+
+
+def get_from_url(url_to_parse):
+    p = urlparse(url_to_parse)
+    return p.netloc, p.netloc[4:-4], p.path[1:]
+
+
+def make_request(request_url, origin_site):
+    r = requests.get(request_url, headers={
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0',
+        'Origin': origin_site,
+        'Referer': request_url
+    })
+    if r.status_code == 200:
+        return r.text
+    return None
+
+
+def fetch_page_json(page_html):
+    matches = re.findall(r'window\.__APOLLO_STATE__ = (.+);$', page_html, re.MULTILINE)
+    return None if len(matches) == 0 else json.loads(matches[0])
+
+
+def save_json(scraped_json, video_id):
+    try:
+        os.makedirs('VixenNetwork_JSON')
+    except FileExistsError:
+        pass
+    filename = os.path.join('VixenNetwork_JSON', '%s.json' % video_id)
+    with open(filename, 'w', encoding='utf-8') as f:
+        json.dump(scraped_json, f, ensure_ascii=False, indent=4)
+
+
+def main():
+    stdin = sys.stdin.read()
+    log(stdin)
+    fragment = json.loads(stdin)
+    
+    if not fragment['url']:
+        log('No URL entered.')
+        sys.exit(1)
+    url = fragment['url']
+    site, studio, path = get_from_url(url)
+    response = make_request(url, 'https://%s' % site)
+    if response is None:
+        log('Could not fetch page HTML')
+        sys.exit(1)
+    j = fetch_page_json(response)
+    if j is None:
+        log('Could not find JSON on page')
+        sys.exit(1)
+    scene_id = 'Video:%s:%s' % (studio, path)
+    if scene_id not in j:
+        log('Could not locate scene within JSON')
+        sys.exit(1)
+    scene = j[scene_id]
+    scrape = {
+        'title': scene['title'],
+        'date': scene['releaseDate'][:10],
+        'details': scene['description'],
+        'url': 'https:%s' % scene['absoluteUrl'],
+        'studio': {
+            'name': studio
+        },
+        'performers': [{'name': x['name']} for x in scene['models']],
+        'tags': [{'name': x['name']} for x in scene['categories']],
+        'image': scene['images']['poster'][len(scene['images']['poster']) - 1]['src'],
+    }
+    save_json(j, scene['videoId'])
+    print(json.dumps(scrape))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        log(e)

--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -16,11 +16,14 @@ def get_from_url(url_to_parse):
 
 
 def make_request(request_url, origin_site):
-    r = requests.get(request_url, headers={
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0',
-        'Origin': origin_site,
-        'Referer': request_url
-    })
+    try:
+        r = requests.get(request_url, headers={
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0',
+            'Origin': origin_site,
+            'Referer': request_url
+        }, timeout=(3, 6))
+    except requests.exceptions.RequestException:
+        return None
     if r.status_code == 200:
         return r.text
     return None

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -1,12 +1,12 @@
 name: "Vixen Media Group"
 sceneByURL:
   - url:
-      - vixen.com/
-      - tushy.com/
-      - tushyraw.com/
-      - deeper.com/
       - blacked.com/
       - blackedraw.com/
+      - deeper.com/
+      - tushy.com/
+      - tushyraw.com/
+      - vixen.com/
     action: script
     script:
       - python

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -11,4 +11,5 @@ sceneByURL:
     script:
       - python
       - vixenNetwork.py
-# Last Updated February 8, 2021
+      # - "save" # replace "save" with absolute file path of a directory to change default location
+# Last Updated February 10, 2021

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -1,36 +1,14 @@
 name: "Vixen Media Group"
 sceneByURL:
-  - action: scrapeXPath
-    url:
-      - blacked.com/
-      - blackedraw.com/
-      - deeper.com/
+  - url:
+      - vixen.com/
       - tushy.com/
       - tushyraw.com/
-      - vixen.com/
-    scraper: sceneScraper
-xPathScrapers:
-  sceneScraper:
-    common:
-      $performer: //div[@data-test-component="VideoModels"]/a
-    scene:
-      Title: //h1[@data-test-component="VideoTitle"]
-      Performers:
-        Name: $performer
-      Details: //p[@data-test-component="VideoDescription"]|//div[@data-test-component="VideoDescription"]//p
-      Date:
-        selector: //span[@data-test-component="ReleaseDateFormatted"]
-        postProcess:
-          - parseDate: "January 2, 2006"
-      Image:
-        selector: //picture[@data-test-component="ProgressiveImageImage"]/img/@src
-      Studio:
-        Name:
-          selector: //link[@rel="canonical"]/@href
-          postProcess:
-            - replace:
-                - regex: https\://www\.(.+)\.com/.+
-                  with: $1
-driver:
-  useCDP: true
-# Last Updated February 3, 2021
+      - deeper.com/
+      - blacked.com/
+      - blackedraw.com/
+    action: script
+    script:
+      - python
+      - vixenNetwork.py
+# Last Updated February 8, 2021


### PR DESCRIPTION
This commit replaces the old XPath scraper with a new script scraper. This eliminates the need for the CDP.
The script performs faster than the existing scraper (due to no CDP) and even includes scene tags.

Python v3.3 or later is required.