### PR TITLE
Update Legal Porno scraper to new domain

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -398,7 +398,7 @@ ladyboy-ladyboy.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|T
 ladyboy.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 lanesisters.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 latinoguysporn.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
-legalporno.com|LegalPorno.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python >= 3.6|-
+analvids.com|LegalPorno.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python >= 3.6|-
 legsex.com|TheScoreGroup.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lesbea.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
 lesbianass.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Lesbian

--- a/scrapers/LegalPorno.py
+++ b/scrapers/LegalPorno.py
@@ -7,7 +7,7 @@ def debug(t):
   sys.stderr.write(t + "\n")
 
 def query_url(query):
-  res = requests.get(f"https://www.legalporno.com/api/autocomplete/search?q={query}")
+  res = requests.get(f"https://www.analvids.com/api/autocomplete/search?q={query}")
   data = res.json()
   results = data['terms']
   if len(results) > 1:

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -2,12 +2,12 @@ name: "LegalPorno"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - legalporno.com/watch/
+      - analvids.com/watch/
     scraper: sceneScraper
 performerByURL:
   - action: scrapeXPath
     url:
-      - https://www.legalporno.com
+      - https://www.analvids.com
     scraper: performerScraper
 sceneByFragment:
     action: script
@@ -31,7 +31,7 @@ xPathScrapers:
           - parseDate: 2006-01-02
       Details: $description/div[3]/dd/text()
       Performers:
-        Name: $description/div[1]/dd/a[contains(@href,'legalporno.com/model')]/text()
+        Name: $description/div[1]/dd/a[contains(@href,'analvids.com/model')]/text()
       Studio:
         Name: //div[@class="col-md-4 col-lg-3 hide-mobile text-right"]/div[@class="studio-director"]//a/text()
       Tags:

--- a/scrapers/LegalPorno.yml
+++ b/scrapers/LegalPorno.yml
@@ -49,4 +49,4 @@ xPathScrapers:
       Country: //td[@class='text-danger']//a[contains(@href,'nationality')]/text()
       Image:
         selector: //div[@class='model--avatar']//img/@src
-# Last Updated November 8, 2020
+# Last Updated February 13, 2021


### PR DESCRIPTION
Legal Porno have moved to a new domain: analvids.com. Their branding is still as LegalPorno so I didn't see the need to change the name of the scraper or the file name, but the URLs needed to be updated.