### PR TITLE
Brazzers fix, now CDP is required

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -126,7 +126,7 @@ boxtrucksex.com|BoxTruckSex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boysdestroyed.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 brandibelle.com|brandibelle.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 brattysis.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
-brazzers.com|Brazzers.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
+brazzers.com|Brazzers.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|CDP|-
 bruceandmorgan.net|bruceandmorgan.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Amateur Fetish
 brutalinvasion.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bskow.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -440,7 +440,7 @@ massagebait.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 maxinex.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 meanawolf.com|MeanaWolf.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 meetsuckandfuck.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-men.com|Brazzers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+men.com|Brazzers.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 menpov.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 metadataapi.net (JSON API)|ThePornDB.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 metadataapi.net (URL)|PornDB.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
@@ -577,7 +577,7 @@ rawattack.com|RawAttack.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rawcouples.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 reaganfoxx.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
 realityjunkies.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-realitykings.com|Brazzers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+realitykings.com|Brazzers.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 realsensual.com|RealSensual.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realtimebondage.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realvr.com|BaDoink.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|VR

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -1,10 +1,11 @@
-name: 'Brazzers'
+name: "Brazzers"
 
 sceneByURL:
   - action: scrapeXPath
     url:
+      # for brazzers make sure the video URL has the title after the id otherwise we get redirected to the main page
+      # if you only have the  id add an extra part after it eg for https://www.brazzers.com/video/123456/ use https://www.brazzers.com/video/123456/a
       - brazzers.com/video
-      - brazzers.com/scene
       - men.com/sceneid/
       - realitykings.com/scene/
     scraper: sceneScraper
@@ -19,14 +20,14 @@ performerByName:
   action: scrapeXPath
   queryURL: https://www.brazzers.com/pornstars?q={}
   scraper: performerSearch
-  
+
 galleryByURL:
   - action: scrapeXPath
     url:
       - brazzers.com/video
       - brazzers.com/scene
     scraper: galleryScraper
-    
+
 xPathScrapers:
   performerSearch:
     common:
@@ -44,27 +45,51 @@ xPathScrapers:
   sceneScraper:
     common:
       $titlebar: //*[name()='path'][1]/../../../../h2/..
+      $script: //script[@type="application/ld+json"]
     scene:
-      Title: $titlebar/h2/text()
-      Studio:
-        Name: 
-          selector: //div[text()="Subsite"]/../a/text()
-# Remove '#' if you want get the studio without space.
-#          postProcess:
-#              - replace: 
-#                  - regex: " "
-#                    with: ""
-      Date:
-        selector: $titlebar/div/text()
+      Title:
+        selector: $script
         postProcess:
-          - parseDate: January 2, 2006
-      Details: //h2[translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description']/../div/p/text()
+          - replace:
+              - regex: '.+name":\s*"([^"]+)".+'
+                with: $1
+      Studio:
+        Name:
+          selector: //div[text()="Subsite"]/../a/text()|//meta[@name="dti.network"]/@content
+      # Remove '#' if you want get the studio without space.
+      #          postProcess:
+      #              - replace:
+      #                  - regex: " "
+      #                    with: ""
+      Date:
+        selector: $script
+        postProcess:
+          - replace:
+              - regex: '.+uploadDate":\s*"([^"]+)".+'
+                with: $1
+          - parseDate: 2006-01-02
+      Details:
+        selector: //h2[translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description']/../div/p/text() #|$script
+        postProcess:
+          - replace:
+              - regex: '.+description":\s*"(.+)",\s*"thumb.+'
+                with: $1
+              - regex: '\\"'
+                with: '"'
+
       Tags:
         Name: //div[text()="Tags"]/../div/a/text()
       Performers:
-        Name: $titlebar/div/span/a/text()
-      Image: //img[@alt=""][contains(@src,"poster")]/@src
-      
+        Name:
+          selector: $titlebar/div/span/a/text()|//h2/span/a[contains(@href,"/modelprofile/")]
+      Image:
+        selector: //img[@alt=""][contains(@src,"poster")]/@src|$script
+        postProcess:
+          - replace:
+              - regex: '.+thumbnailUrl":\s*"([^"]+)".+'
+                with: $1
+      URL: //link[@rel="canonical"]/@href
+
   galleryScraper:
     common:
       $titlebar: //*[name()='path'][1]/../../../../h2/..
@@ -77,14 +102,14 @@ xPathScrapers:
         selector: $titlebar/div/text()
         postProcess:
           - parseDate: January 2, 2006
-       
+
       Details: //h2[translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description']/../div/p/text()
       Performers:
         Name: $titlebar/div/span/a/text()
-          
+
       Tags:
         Name: //div[text()="Tags"]/../div/a/text()
-        
+
   performerScraper:
     performer:
       Name: //section/div/div/div[@font-size]/text() # //div[@font-size][number(translate(@font-size,"px",""))>=35]/text()
@@ -96,7 +121,7 @@ xPathScrapers:
                 with: ","
           - parseDate: January 2, 2006
       Measurements: //*[contains(.,"Measurements")]/following-sibling::span/text()[not(contains(.,"N/A"))]
-      Country: 
+      Country:
         selector: //*[contains(.,"Birth Place")]/following-sibling::span/text()[not(contains(.,"N/A"))]
         postProcess:
           - replace:
@@ -153,7 +178,7 @@ xPathScrapers:
               WA: "USA"
               WI: "USA"
               WV: "USA"
-              WY: "USA"              
+              WY: "USA"
               Alabama: "USA"
               Alaska: "USA"
               Arizona: "USA"
@@ -228,9 +253,10 @@ xPathScrapers:
         postProcess:
           - map:
               Piercing: "Yes"
-# There is no Xpath to know the gender.
-#      Gender: 
-#        fixed: "Female"
+      # There is no Xpath to know the gender.
+      #      Gender:
+      #        fixed: "Female"
       URL: //link[@rel="canonical"]/@href
-
-# Last Updated December 23, 2020
+driver:
+  useCDP: true
+# Last Updated February 19, 2021

--- a/scrapers/Brazzers.yml
+++ b/scrapers/Brazzers.yml
@@ -69,13 +69,7 @@ xPathScrapers:
                 with: $1
           - parseDate: 2006-01-02
       Details:
-        selector: //h2[translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description']/../div/p/text() #|$script
-        postProcess:
-          - replace:
-              - regex: '.+description":\s*"(.+)",\s*"thumb.+'
-                with: $1
-              - regex: '\\"'
-                with: '"'
+        selector: //h2[translate(text(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description']/../div/p/text()
 
       Tags:
         Name: //div[text()="Tags"]/../div/a/text()


### PR DESCRIPTION
Not fully tested yet
scene changes only
- uses CDP now to get performers 
- the title and date from men was messed up so i used a script selector instead
- added a fallback for the studio when no subsite is present (mainly brazzers)
- added a fallback for the image from a script selector ( mainly for men)
- added scene URL

Also very important
For `brazzers` users must make sure the video URL has the title after the id otherwise we get redirected to the main page
If the user only has till the id part  for the url he needs to add an extra char after it eg for `https://www.brazzers.com/video/123456/` -> `https://www.brazzers.com/video/123456/a` to get to the scene page and then scrape ( thats were the scraped URL is needed)