### PR TITLE
Move VixenNetwork default JSON save location

### DIFF
--- a/scrapers/vixenNetwork.py
+++ b/scrapers/vixenNetwork.py
@@ -40,7 +40,7 @@ def fetch_page_json(page_html):
 
 
 def save_json(scraped_json, video_id, save_location):
-    location = 'VixenNetwork_JSON'
+    location = os.path.join('..', 'scraperJSON', 'VixenNetwork')
     if save_location != 'save':
         location = save_location
     try:

--- a/scrapers/vixenNetwork.yml
+++ b/scrapers/vixenNetwork.yml
@@ -12,4 +12,4 @@ sceneByURL:
       - python
       - vixenNetwork.py
       # - "save" # replace "save" with absolute file path of a directory to change default location
-# Last Updated February 10, 2021
+# Last Updated February 24, 2021


### PR DESCRIPTION
Moves the default JSON save location to outside of the scrapers directory.