### PR TITLE
Update MindGeekAPI.py

### DIFF
--- a/scrapers/MindGeekAPI.py
+++ b/scrapers/MindGeekAPI.py
@@ -89,8 +89,7 @@ def check_config(url, date_today):
                 token = file_instance
                 #debug("Using token from {}".format(SET_FILE_URL))
             else:
-                debug("Token from the past, getting new one".format(
-                    SET_FILE_URL))
+                debug("Token from the past, getting new one".format(SET_FILE_URL))
         except NoSectionError:
             pass
     return token, found_scene_id
@@ -104,12 +103,9 @@ def write_config(url, token, date_today):
         config.get(my_domain, 'url')
     except NoSectionError:
         config.add_section(my_domain)
-    if url:
-        config.set(my_domain, 'url', url)
-    if token:
-        config.set(my_domain, 'instance', token)
-    if date_today:
-        config.set(my_domain, 'date', date_today)
+    config.set(my_domain, 'url', 'https://' + my_domain)
+    config.set(my_domain, 'instance', token)
+    config.set(my_domain, 'date', date_today)
     with open(SET_FILE_URL, 'w') as configfile:
         config.write(configfile)
     return
@@ -312,7 +308,6 @@ else:
         # Send to the API
         api_URL = 'https://site-api.project1service.com/v2/releases/{}'.format(scene_id)
         scene_api_json = send_request(api_URL, request_headers)
-        write_config(scene_url,"","")
     else:
         scene_api_json = use_local
     if scene_api_json.get('parent') is not None:

--- a/scrapers/MindGeekAPI.py
+++ b/scrapers/MindGeekAPI.py
@@ -226,12 +226,15 @@ def scraping_json(api_json, url=""):
     backup_image=None
     if type(api_json['images']['poster']) is list:
         for image_type in api_json['images']['poster']:
-            if '/poster_fallback/' in image_type['xx'].get('url') and backup_image is None:
-                backup_image = image_type['xx'].get('url')
-                continue
-            if '/poster/' in image_type['xx'].get('url'):
-                scrape['image'] = image_type['xx'].get('url')
-                break
+            try:
+                if '/poster_fallback/' in image_type['xx'].get('url') and backup_image is None:
+                    backup_image = image_type['xx'].get('url')
+                    continue
+                if '/poster/' in image_type['xx'].get('url'):
+                    scrape['image'] = image_type['xx'].get('url')
+                    break
+            except TypeError:
+                pass
     else:
         if type(api_json['images']['poster']) is dict:
             for _, img_value in api_json['images']['poster'].items():


### PR DESCRIPTION
- Fixed correct URL in the config file. Before it was possible to have a incorrect URL (Scene delete from network) in the `.ini` file, now it use the homepage so it's unlikely to be delete.
- Some network don't use poster (DeviantHardcore), use the `poster_fallback` if can't get `poster`
- Explain a little more for First Runner (You need to scrape 1 URL from the network, to be enable to search with your title on this network.)