### PR TITLE
Update stash-sqlite scraper to use data image URLs

### DIFF
--- a/scrapers/stash-sqlite.yml
+++ b/scrapers/stash-sqlite.yml
@@ -1,10 +1,12 @@
-name: "stash sqlite"
+name: stash sqlite
+
 performerByFragment:
     action: script
     script:
       - python
       - stash-sqlite.py
       - fetch
+
 performerByName:
     action: script
     script:
@@ -12,4 +14,4 @@ performerByName:
       - stash-sqlite.py
       - query
 
-# Last Updated August 12, 2020
+# Last Updated March 31, 2021


### PR DESCRIPTION
Same concept as #453:
Use `data:image/<type>;base64,<data>` URLs instead of `custom_served_folders` for the performer images.
(slightly different method of obtaining the type of the image)