### PR TITLE
Add headers/authentication to ThePornDB JSON scraper

### DIFF
--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -89,7 +89,7 @@ jsonScrapers:
 driver:
   headers:
     - Key: User-Agent
-      Value: Stash JSON Scraper
+      Value: stashjson/1.0.0
     #- Key: Authorization # Uncomment and add a valid API Key after the `Bearer ` part
       #Value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
-# Last Updated April 7, 2021
+# Last Updated April 14, 2021

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -88,8 +88,8 @@ jsonScrapers:
         Name: $data.tags.#.tag
 driver:
   headers:
-    - key: User-Agent
-      value: Stash JSON Scraper
-    #- key: Authorization # Uncomment and add a valid API key after the `Bearer ` part
-      #value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
+    - Key: User-Agent
+      Value: Stash JSON Scraper
+    #- Key: Authorization # Uncomment and add a valid API Key after the `Bearer ` part
+      #Value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
 # Last Updated April 7, 2021

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -21,6 +21,8 @@ sceneByFragment:
     filename:
       - regex: "[^a-zA-Z\\d\\-._~]" # clean filename so that it can construct a valid url
         with: "." # "%20"
+      - regex: \.+
+        with: "."
 jsonScrapers:
   performerSearch:
     performer:
@@ -84,4 +86,10 @@ jsonScrapers:
         Name: $data.site.name
       Tags:
         Name: $data.tags.#.tag
-# Last Updated November 20, 2020
+driver:
+  headers:
+    - key: User-Agent
+      value: Stash JSON Scraper
+    #- key: Authorization # Uncomment and add a valid API key after the `Bearer ` part
+      #value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
+# Last Updated April 7, 2021

--- a/validator/scraper.schema.json
+++ b/validator/scraper.schema.json
@@ -229,13 +229,13 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["key", "value"],
+            "required": ["Key", "Value"],
             "properties": {
-              "key": {
+              "Key": {
                 "title": "Key",
                 "type": "string"
               },
-              "value": {
+              "Value": {
                 "title": "Value",
                 "type": "string"
               }

--- a/validator/scraper.schema.json
+++ b/validator/scraper.schema.json
@@ -220,6 +220,27 @@
               }
             }
           }
+        },
+        "headers": {
+          "title": "Headers",
+          "description": "Headers to add to scraper requests.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "value"],
+            "properties": {
+              "key": {
+                "title": "Key",
+                "type": "string"
+              },
+              "value": {
+                "title": "Value",
+                "type": "string"
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Adds authentication to ThePornDB scraper via http headers and an API key.
Make sure to uncomment the `Authorization` header and replace the placeholder `zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE` key with a valid one.
Needs a specific stash version https://github.com/stashapp/stash/pull/1273