### PR TITLE
AMAMultimedia: Higher resolution images, sort URLs

### DIFF
--- a/scrapers/AMAMultimedia.yml
+++ b/scrapers/AMAMultimedia.yml
@@ -19,39 +19,42 @@ name: "AMA Multimedia"
 sceneByURL:
   - action: scrapeXPath
     url:
+      # Straight Porn
       - anal4k.com/video/
-      - passion-hd.com/video/
-      - lubed.com/video/
+      - baeb.com/video/
+      - bbcpie.com/video/
+      - castingcouch-x.com/video/
+      - cum4k.com/video/
+      - exotic4k.com/video/
+      - fantasyhd.com/video/
+      - girlcum.com/video/
       - holed.com/video/
+      - lubed.com/video/
+      - myveryfirsttime.com/video/
+      - nannyspy.com/video/
+      - passion-hd.com/video/
       - pornpros.com/video/
       - povd.com/video/
-      - tiny4k.com/video/
-      - castingcouch-x.com/video/
-      - exotic4k.com/video/
       - puremature.com/video/
-      - fantasyhd.com/video/
-      - cum4k.com/video/
-      - wetvr.com/video/
-      - myveryfirsttime.com/video/
-      - girlcum.com/video/
       - spyfam.com/video/
-      - baeb.com/video/
-      - nannyspy.com/video/
-      - bbcpie.com/video/
-      - gayroom.com/video/
-      - manroyale.com/video/
-      - gaycastings.com/video/
-      - damnthatsbig.com/video/
-      - gaycreeps.com/video/
-      - menpov.com/video/
-      - massagebait.com/video/
+      - tiny4k.com/video/
+      - wetvr.com/video/
+
+      # Gay Porn
       - bathhousebait.com/video/
       - boysdestroyed.com/video/
+      - damnthatsbig.com/video/
+      - gaycastings.com/video/
+      - gaycreeps.com/video/
+      - gayroom.com/video/
+      - gayviolations.com/video/
+      - manroyale.com/video/
+      - massagebait.com/video/
+      - menpov.com/video/
+      - officecock.com/video/
+      - outhim.com/video/
       - showerbait.com/video/
       - thickandbig.com/video/
-      - outhim.com/video/
-      - officecock.com/video/
-      - gayviolations.com/video/
 
     scraper: sceneScraper
 xPathScrapers:
@@ -61,7 +64,12 @@ xPathScrapers:
       Details: //div[@id="t2019-description"]/text()
       Performers:
         Name: //div[@id="t2019-models"]/a/text()
-      Image: //video[@id="player"]/@poster
+      Image:
+        selector: //video[@id="player"]/@poster
+        postProcess:
+          - replace:
+              - regex: ([?&]img[wh]=\d+)+$
+                with:
       Studio:
         Name: //title/text()
       Date:
@@ -69,4 +77,4 @@ xPathScrapers:
         postProcess:
           - parseDate: January 02, 2006
 
-# Last Updated February 25, 2021
+# Last Updated April 18, 2021


### PR DESCRIPTION
A higher resolution image is returned by removing the `?imgw=<number>&imgh=<number>` from the video poster URL.
In addition, sort the scraper URLs and split in two groups.