### PR TITLE
Fix tags for ThePornDB json scraper

### DIFF
--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -85,11 +85,20 @@ jsonScrapers:
       Studio:
         Name: $data.site.name
       Tags:
-        Name: $data.tags.#.tag
+        Name:
+          selector: $data.id
+          postProcess:
+            - replace:
+                - regex: ^
+                  with: "https://api.metadataapi.net/scenes/"
+            - subScraper:
+                selector: data.tags.#.tag
+                concat: "|"
+          split: "|"
 driver:
   headers:
     - Key: User-Agent
       Value: stashjson/1.0.0
     #- Key: Authorization # Uncomment and add a valid API Key after the `Bearer ` part
       #Value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
-# Last Updated April 14, 2021
+# Last Updated April 27, 2021


### PR DESCRIPTION
Fixes the tags when you use the scrape with (scene query functionality)
Tags were removed from the `parser` endpoint so we need to get them from the `scenes` endpoint instead
Uses a subscraper to get the tags from the scene api page
Concat and then Split is needed since `subScraper` returns only a single result