### PR TITLE
Add Fit18 xPath scene scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -348,6 +348,7 @@ fist4k.com|Vip4K.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fistertwister.com|Fistertwister.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fistflush.com|sapphix.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fistingcentral.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+fit18.com|Fit18.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fitting-room.com|FittingRoom.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 footsiebabes.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 forbiddenfruitsfilms.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-

--- a/scrapers/Fit18.yml
+++ b/scrapers/Fit18.yml
@@ -1,0 +1,23 @@
+name: Fit18
+sceneByURL:
+  #for URLs either search through google or use something like `https://www.fit18.com/models/performer-name/scene1`
+  - action: scrapeXPath
+    url:
+      - fit18.com/models
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $info: //div[contains(@class,"scene-info")]
+    scene:
+      Title: $info/h1
+      Details: $info/p
+      Performers:
+        Name:
+          selector: $info/h2/a
+      Image:
+        selector: //div[@class="video-box"]//a/img[@style]/@src
+      Studio:
+        Name:
+          fixed: Fit18
+# Last Updated May 16, 2021


### PR DESCRIPTION
Requested from #73 
Non members area is very limited. For the url of the scene search using google or try to use something like `https://www.fit18.com/models/performer-name/scene1` adjusting the performer-name and scene number.