### PR TITLE
Update DDFNetwork.yml

### DIFF
--- a/scrapers/DDFNetwork.yml
+++ b/scrapers/DDFNetwork.yml
@@ -2,8 +2,8 @@ name: DDFNetwork
 sceneByURL:
   - action: scrapeXPath
     url:
-      - ddfbusty.com/videos/
       - 1by-day.com/videos/
+      - ddfbusty.com/videos/
       - eurogirlsongirls.com/videos/
       - euroteenerotica.com/videos/
       - handsonhardcore.com/videos/
@@ -25,5 +25,4 @@ xPathScrapers:
       Performers:
         Name: //h5[@class="card-title mb-0"]/a/text()
       Image: //meta[@itemprop="thumbnailUrl"]/@content
-
 # Last Updated May 17, 2021

--- a/scrapers/DDFNetwork.yml
+++ b/scrapers/DDFNetwork.yml
@@ -15,7 +15,10 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //meta[@itemprop="name"]/@content
-      Date: //meta[@itemprop="uploadDate"]/@content
+      Date:
+        selector: //div[@class='title-border d-inline-flex pr-3 flex-sm-fill justify-content-sm-center pr-sm-0']/p[@class='m-0 text-center']
+        postProcess:
+          - parseDate: 01.02.2006
       Details: //div[@class="descr-box"]/p
       Tags:
         Name: //ul[@class="tags pl-0"]/li/a/text()
@@ -23,4 +26,4 @@ xPathScrapers:
         Name: //h5[@class="card-title mb-0"]/a/text()
       Image: //meta[@itemprop="thumbnailUrl"]/@content
 
-# Last Updated July 31, 2020
+# Last Updated May 17, 2021


### PR DESCRIPTION
`Date: //meta[@itemprop="uploadDate"]/@content`

This is no longer any good as half the sites have changed this to a different date layout.

The fix gets it from a different location now which is the same across all sites.

