### PR TITLE
Velvetveronica

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -958,7 +958,7 @@ unrealporn.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 upherasshole.com|PervCity.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 valentina.passionepiedi.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vcaxxx.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
-velvetveronica.com|velvetveronica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+velvetveronica.com|VelvetVeronica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vickyathome.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vinaskyxxx.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 vipissy.com|Vipissy.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -958,6 +958,7 @@ unrealporn.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 upherasshole.com|PervCity.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 valentina.passionepiedi.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vcaxxx.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+velvetveronica.com|velvetveronica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vickyathome.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vinaskyxxx.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 vipissy.com|Vipissy.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/VelvetVeronica.yml
+++ b/scrapers/VelvetVeronica.yml
@@ -1,4 +1,4 @@
-name: velvetveronica
+name: VelvetVeronica
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -11,27 +11,26 @@ xPathScrapers:
         selector: //h1[@class="product_title entry-title"]/text()
         postProcess:
           - replace:
-            - regex: Video \| (.*) (\[|\().*(\]|\))
-              with: $1
+              - regex: Video \| (.*) (\[|\().*(\]|\))
+                with: $1
       Date:
-        selector: //meta[@property="og:image"][1]/@content
+        selector: //meta[@name="twitter:image"]/@content
         postProcess:
           - replace:
-            - regex: .*/uploads/([0-9]{4})/([0-9]{2})/.*
-              with: $1-$2-01
-          #- parseDate: "January 2, 2006"
+              - regex: .*/uploads/([0-9]{4})/([0-9]{2})/.*
+                with: $1-$2-01
+          - parseDate: 2006-01-02
       Details:
         selector: //div[@id="x-legacy-panel-1"]/p or //div[@id="x-legacy-panel-1"]//li
         concat: "\n\n"
-      Performers: 
+      Performers:
         Name:
           fixed: Veronica Dyer
       Tags:
         Name:
           selector: //span[@class="tagged_as"]/a/text()
       Studio:
-        Name: 
+        Name:
           selector: //meta[@property="og:site_name"]/@content
       Image: //meta[@name="twitter:image"]/@content
-
 # Last Updated June 06, 2021

--- a/scrapers/velvetveronica.yml
+++ b/scrapers/velvetveronica.yml
@@ -32,6 +32,6 @@ xPathScrapers:
       Studio:
         Name: 
           selector: //meta[@property="og:site_name"]/@content
-      Image: //meta[@property="og:image"]/@content
+      Image: //meta[@name="twitter:image"]/@content
 
 # Last Updated June 06, 2021

--- a/scrapers/velvetveronica.yml
+++ b/scrapers/velvetveronica.yml
@@ -1,0 +1,34 @@
+name: velvetveronica
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - velvetveronica.com/product
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //h1[@class="product_title entry-title"]/text()
+        postProcess:
+          - replace:
+            - regex: Video \| (.*) (\[|\().*(\]|\))
+              with: $1
+      Date:
+        selector: //meta[@property="og:image"][1]/@content
+        postProcess:
+          - replace:
+            - regex: .*/uploads/([0-9]{4})/([0-9]{2})/.*
+              with: $1-$2-01
+          #- parseDate: "January 2, 2006"
+      Details:
+        selector: //div[@id="x-legacy-panel-1"]/p or //div[@id="x-legacy-panel-1"]//li
+        concat: "\n\n"
+      Tags:
+        Name:
+          selector: //span[@class="tagged_as"]/a/text()
+      Studio:
+        Name: 
+          selector: //meta[@property="og:site_name"]/@content
+      Image: //meta[@property="og:image"]/@content
+
+# Last Updated June 06, 2021

--- a/scrapers/velvetveronica.yml
+++ b/scrapers/velvetveronica.yml
@@ -23,6 +23,9 @@ xPathScrapers:
       Details:
         selector: //div[@id="x-legacy-panel-1"]/p or //div[@id="x-legacy-panel-1"]//li
         concat: "\n\n"
+      Performers: 
+        Name:
+          fixed: Veronica Dyer
       Tags:
         Name:
           selector: //span[@class="tagged_as"]/a/text()


### PR DESCRIPTION
Xpath scraper for velvetveronica.com

Date scraping is a bit iffy. For most videos the year and month of upload can be retrieved from image filename, but not the day. This PR therefore uses 1 for the day.
There are a limited number of old videos on the site that do have full date information in the image filename, but I don't see how to retrieve both forms in an xpath scraper.