### PR TITLE
PornDB (URL): Remove CDP

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -606,7 +606,7 @@ men.com|Brazzers.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 menpov.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 messyxxx.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 metadataapi.net (JSON API)|ThePornDB.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
-metadataapi.net (URL)|PornDB.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+metadataapi.net (URL)|PornDB.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 metart.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|python|-
 metartnetwork.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|python|-
 metartx.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|python|-

--- a/scrapers/PornDB.yml
+++ b/scrapers/PornDB.yml
@@ -47,10 +47,13 @@ xPathScrapers:
         #      with: "1000x1000"
 driver:
   useCDP: true
-  sleep: 5
+  clicks:
+    - # Click through Age Verification
+      xpath: //form[@action="https://metadataapi.net/age-verification"]//button[@type="submit"]
+      sleep: 5
   headers:
     - Key: User-Agent
       Value: stash/1.0.0
     #- Key: Authorization  # Uncomment and provide a valid API Key instead of the  XXXXX
     #  Value: Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXX
-# Last Updated May 23, 2021
+# Last Updated June 22, 2021

--- a/scrapers/PornDB.yml
+++ b/scrapers/PornDB.yml
@@ -46,14 +46,9 @@ xPathScrapers:
         #    - regex: "3000x3000"
         #      with: "1000x1000"
 driver:
-  useCDP: true
-  clicks:
-    - # Click through Age Verification
-      xpath: //form[@action="https://metadataapi.net/age-verification"]//button[@type="submit"]
-      sleep: 5
   headers:
     - Key: User-Agent
       Value: stash/1.0.0
     #- Key: Authorization  # Uncomment and provide a valid API Key instead of the  XXXXX
     #  Value: Bearer XXXXXXXXXXXXXXXXXXXXXXXXXXXX
-# Last Updated June 22, 2021
+# Last Updated June 23, 2021


### PR DESCRIPTION
Update: Thanks to the PornDB team CDP is no longer needed.

~~It _sometimes_ panics on the first scrape with `Could not find node with given id (-32000)`,
and sometimes does not panic, just fails to scrape anything.
But in any case, it seems that consistently the first scrape does not work.
The panic issue might be a race condition in the way clicks are coded in, @bnkai, this might be more up your alley?
`https://github.com/chromedp/chromedp/issues/762#issuecomment-788836126`~~

~~\!\[image](https://user-images.githubusercontent.com/66393006/122960418-0d7b5200-d38c-11eb-894e-0cdd38da9235.png)~~