### PR TITLE
Update ThePornDB to use the parent not the site name

### DIFF
--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -74,7 +74,7 @@ jsonScrapers:
               - regex: .+default\d+\.png$
                 with:
       Performers:
-        Name: data.performers.#.parent        Name: data.performers.#.name.name
+        Name: data.performers.#.parent
       Studio:
         Name: data.site.name
       Tags:

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -111,4 +111,4 @@ driver:
       Value: stashjson/1.0.0
     #- Key: Authorization # Uncomment and add a valid API Key after the `Bearer ` part
       #Value: Bearer zUotW1dT5ESmpIpMnccUNczf8q4C9Thzn07ZqygE
-# Last Updated April 28, 2021
+# Last Updated July 30, 2021

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -91,7 +91,7 @@ jsonScrapers:
       URL: $data.url
       Image: $data.background.small
       Performers:
-        Name: $data.performers.#.name
+        Name: $data.performers.#.parent.name
       Studio:
         Name: $data.site.name
       Tags:

--- a/scrapers/ThePornDB.yml
+++ b/scrapers/ThePornDB.yml
@@ -74,7 +74,7 @@ jsonScrapers:
               - regex: .+default\d+\.png$
                 with:
       Performers:
-        Name: data.performers.#.name
+        Name: data.performers.#.parent        Name: data.performers.#.name.name
       Studio:
         Name: data.site.name
       Tags:


### PR DESCRIPTION
Entries from theporndb use the parent not the site id.
Scenes have a site specific performer id and this is usually linked to a performer id.
These can be different when a performer uses different names over time or some sites use stupid alias's and only use the first name for example.
You should return the canonical name of that performer.