### PR TITLE
Adding initial support for a wikidata based scraper.

### DIFF
--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -1,7 +1,7 @@
 name: Wikidata
 performerByName:
   action: scrapeJson
-  queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20wd%3AQ488111%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).%0A%20%20FILTER(STRSTARTS(%3Flabel%2C%20%22{}%22)).%0A%7D%0A&format=json
+  queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20VALUES%20%3Fprofessions%20%7Bwd%3AQ488111%20wd%3AQ3286043%20wd%3AQ728711%20wd%3AQ1079215%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20%20%3Fprofessions.%0A%20%20%3Fpornographic_actor%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).0A%20%20FILTER(STRSTARTS(%3Flabel%2C%20%22{}%22)).%0A%7D%0A&format=json
   scraper: performerSearch
 performerByURL:
   - action: scrapeJson

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -43,6 +43,34 @@ jsonScrapers:
           - map:
               6581072: "FEMALE"
               6581097: "MALE"
+      HairColor:
+        selector: entities.*.claims.P1884.#.mainsnak.datavalue.value.numeric-id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.wikidata.org/wiki/Special:EntityData/Q"
+              - regex: $
+                with: .json
+          - subScraper:
+              selector: entities.*.labels.en.value
+      Country:
+        selector: entities.*.claims.P27.#.mainsnak.datavalue.value.numeric-id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.wikidata.org/wiki/Special:EntityData/Q"
+              - regex: $
+                with: .json
+          - subScraper:
+              selector: entities.*.labels.en.value
+      Twitter:
+        selector: entities.*.claims.P2002.#.mainsnak.datavalue.value
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://twitter.com/"
+
+
 
 
 #driver:

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -1,4 +1,4 @@
-name: wikidata
+name: Wikidata
 performerByName:
   action: scrapeJson
   queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20wd%3AQ488111%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).%0A%20%20FILTER(STRSTARTS(%3Flabel%2C%20%22{}%22)).%0A%7D%0A&format=json
@@ -40,9 +40,13 @@ jsonScrapers:
       Gender:
         selector: entities.*.claims.P21.#.mainsnak.datavalue.value.numeric-id
         postProcess:
-          - map:
-              6581072: "FEMALE"
-              6581097: "MALE"
+          - replace:
+              - regex: ^
+                with: "https://www.wikidata.org/wiki/Special:EntityData/Q"
+              - regex: $
+                with: .json
+          - subScraper:
+              selector: entities.*.labels.en.value
       HairColor:
         selector: entities.*.claims.P1884.#.mainsnak.datavalue.value.numeric-id
         postProcess:
@@ -69,8 +73,18 @@ jsonScrapers:
           - replace:
               - regex: ^
                 with: "https://twitter.com/"
-
-
+      Details:
+        selector: entities.*.sitelinks.enwiki.title
+        postProcess:
+          - replace:
+              - regex: " "
+                with:  "_"
+              - regex: ^
+                with: "https://en.wikipedia.org/w/api.php?action=query&origin=*&prop=extracts&explaintext&titles="
+              - regex: $
+                with: "&format=json"
+          - subScraper:
+              selector: query.pages.*.extract
 
 
 # Last Updated August 08, 2021

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -49,4 +49,4 @@ jsonScrapers:
 #  headers:
 #    - Key: User-Agent
 #      Value: stashjson/1.0.0
-# Last Updated August 1, 2021
+# Last Updated August 03, 2021

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -6,7 +6,14 @@ performerByName:
 performerByURL:
   - action: scrapeJson
     url:
-      - https://www.wikidata.org/wiki/Special:EntityData/
+      - https://www.wikidata.org/wiki/Q
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        - regex: https://www.wikidata.org/wiki/
+          with: https://www.wikidata.org/wiki/Special:EntityData/
+        - regex: $
+          with: .json
     scraper: performerScraper
 jsonScrapers:
   performerSearch:
@@ -17,12 +24,20 @@ jsonScrapers:
         postProcess:
           - replace:
               - regex: http:\/\/www.wikidata.org\/entity\/
-                with: https://www.wikidata.org/wiki/Special:EntityData/
-              - regex: $
-                with: .json
+                with: https://www.wikidata.org/wiki/
+#              - regex: $
+#        postProcess:
+#          - replace:
+#              - regex: http:\/\/www.wikidata.org\/entity\/
+#                with: https://www.wikidata.org/wiki/Special:EntityData/
+#              - regex: $
+#                with: .json
   performerScraper:
     performer:
       Name: entities.*.labels.en.value
+      Aliases:
+        selector: entities.*.aliases.en.#.value
+        concat: ", "
       Image:
         selector: entities.*.claims.P18.#.mainsnak.datavalue.value
         postProcess:
@@ -31,12 +46,34 @@ jsonScrapers:
                 with: "https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/"
       Weight:
         selector: entities.*.claims.P2067.#.mainsnak.datavalue.value.amount
+        postProcess:
+          - replace:
+              - regex: \+
+                with:
       Birthdate:
         selector: entities.*.claims.P569.#.mainsnak.datavalue.value.time
+        postProcess:
+          - replace:
+              - regex: .*(\d{4}-\d{1,2}-\d{1,2}).*
+                with: $1
+      DeathDate:
+        selector: entities.*.claims.P570.#.mainsnak.datavalue.value.time
+        postProcess:
+          - replace:
+              - regex: .*(\d{4}-\d{1,2}-\d{1,2}).*
+                with: $1
       Height:
         selector: entities.*.claims.P2048.#.mainsnak.datavalue.value.amount
+        postProcess:
+          - replace:
+              - regex: \+
+                with:
       CareerLength:
         selector: entities.*.claims.P2031.#.mainsnak.datavalue.value.time
+        postProcess:
+          - replace:
+              - regex: .*(\d{4}).*
+                with: $1
       Gender:
         selector: entities.*.claims.P21.#.mainsnak.datavalue.value.numeric-id
         postProcess:
@@ -57,6 +94,26 @@ jsonScrapers:
                 with: .json
           - subScraper:
               selector: entities.*.labels.en.value
+      EyeColor:
+        selector: entities.*.claims.P1340.#.mainsnak.datavalue.value.numeric-id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.wikidata.org/wiki/Special:EntityData/Q"
+              - regex: $
+                with: .json
+          - subScraper:
+              selector: entities.*.labels.en.value
+      Ethnicity:
+        selector: entities.*.claims.P172.#.mainsnak.datavalue.value.numeric-id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.wikidata.org/wiki/Special:EntityData/Q"
+              - regex: $
+                with: .json
+          - subScraper:
+              selector: entities.*.labels.en.value
       Country:
         selector: entities.*.claims.P27.#.mainsnak.datavalue.value.numeric-id
         postProcess:
@@ -67,12 +124,21 @@ jsonScrapers:
                 with: .json
           - subScraper:
               selector: entities.*.labels.en.value
+# Personal preference, keep the wikidata url instead of the official website of the performer
+#      URL:
+#        selector: entities.*.claims.P856.#.mainsnak.datavalue.value
       Twitter:
         selector: entities.*.claims.P2002.#.mainsnak.datavalue.value
         postProcess:
           - replace:
               - regex: ^
                 with: "https://twitter.com/"
+      Instagram:
+        selector: entities.*.claims.P2003.#.mainsnak.datavalue.value
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.instagram.com/"
       Details:
         selector: entities.*.sitelinks.enwiki.title
         postProcess:
@@ -87,4 +153,4 @@ jsonScrapers:
               selector: query.pages.*.extract
 
 
-# Last Updated August 08, 2021
+# Last Updated August 29, 2021

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -23,14 +23,14 @@ jsonScrapers:
   performerScraper:
     performer:
       Name: entities.*.labels.en.value
-#      Image:
-#        selector: entities.*.claims.P18.#.mainsnak.datavalue.value
-#        postProcess:
-#          - replace:
-#              - regex: ^
-#                with: "https://commons.wikimedia.org/wiki/File:"
-#      Weight:
-#        selector: entities.*.claims.P2067.#.mainsnak.datavalue.value.amount
+      Image:
+        selector: entities.*.claims.P18.#.mainsnak.datavalue.value
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/"
+      Weight:
+        selector: entities.*.claims.P2067.#.mainsnak.datavalue.value.amount
       Birthdate:
         selector: entities.*.claims.P569.#.mainsnak.datavalue.value.time
       Height:
@@ -73,8 +73,4 @@ jsonScrapers:
 
 
 
-#driver:
-#  headers:
-#    - Key: User-Agent
-#      Value: stashjson/1.0.0
-# Last Updated August 03, 2021
+# Last Updated August 08, 2021

--- a/scrapers/WikiData.yml
+++ b/scrapers/WikiData.yml
@@ -1,7 +1,7 @@
 name: Wikidata
 performerByName:
   action: scrapeJson
-  queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20VALUES%20%3Fprofessions%20%7Bwd%3AQ488111%20wd%3AQ3286043%20wd%3AQ728711%20wd%3AQ1079215%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20%20%3Fprofessions.%0A%20%20%3Fpornographic_actor%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).0A%20%20FILTER(STRSTARTS(%3Flabel%2C%20%22{}%22)).%0A%7D%0A&format=json
+  queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20wd%3AQ488111%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).%0A%20%20FILTER(STRSTARTS(lcase(%3Flabel)%2C%20lcase(%22{}%22)))%7D&format=json
   scraper: performerSearch
 performerByURL:
   - action: scrapeJson
@@ -25,13 +25,6 @@ jsonScrapers:
           - replace:
               - regex: http:\/\/www.wikidata.org\/entity\/
                 with: https://www.wikidata.org/wiki/
-#              - regex: $
-#        postProcess:
-#          - replace:
-#              - regex: http:\/\/www.wikidata.org\/entity\/
-#                with: https://www.wikidata.org/wiki/Special:EntityData/
-#              - regex: $
-#                with: .json
   performerScraper:
     performer:
       Name: entities.*.labels.en.value
@@ -42,6 +35,8 @@ jsonScrapers:
         selector: entities.*.claims.P18.#.mainsnak.datavalue.value
         postProcess:
           - replace:
+              - regex: \s
+                with: "%20" # spaces cause 400 error
               - regex: ^
                 with: "https://commons.wikimedia.org/w/index.php?title=Special:Redirect/file/"
       Weight:
@@ -67,6 +62,8 @@ jsonScrapers:
         postProcess:
           - replace:
               - regex: \+
+                with:
+              - regex: \.
                 with:
       CareerLength:
         selector: entities.*.claims.P2031.#.mainsnak.datavalue.value.time

--- a/scrapers/wikidata.yml
+++ b/scrapers/wikidata.yml
@@ -1,0 +1,52 @@
+name: wikidata
+performerByName:
+  action: scrapeJson
+  queryURL: https://query.wikidata.org/sparql?query=SELECT%20%3Fpornographic_actor%20%3Fpornographic_actorLabel%20WHERE%20%7B%0A%20%20SERVICE%20wikibase%3Alabel%20%7B%20bd%3AserviceParam%20wikibase%3Alanguage%20%22en%22.%20%7D%0A%20%20%3Fpornographic_actor%20wdt%3AP106%20wd%3AQ488111%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20rdfs%3Alabel%20%3Flabel.%0A%20%20FILTER(LANG(%3Flabel)%20%3D%20%22en%22).%0A%20%20FILTER(STRSTARTS(%3Flabel%2C%20%22{}%22)).%0A%7D%0A&format=json
+  scraper: performerSearch
+performerByURL:
+  - action: scrapeJson
+    url:
+      - https://www.wikidata.org/wiki/Special:EntityData/
+    scraper: performerScraper
+jsonScrapers:
+  performerSearch:
+    performer:
+      Name: results.bindings.#.pornographic_actorLabel.value
+      URL:
+        selector: results.bindings.#.pornographic_actor.value
+        postProcess:
+          - replace:
+              - regex: http:\/\/www.wikidata.org\/entity\/
+                with: https://www.wikidata.org/wiki/Special:EntityData/
+              - regex: $
+                with: .json
+  performerScraper:
+    performer:
+      Name: entities.*.labels.en.value
+#      Image:
+#        selector: entities.*.claims.P18.#.mainsnak.datavalue.value
+#        postProcess:
+#          - replace:
+#              - regex: ^
+#                with: "https://commons.wikimedia.org/wiki/File:"
+#      Weight:
+#        selector: entities.*.claims.P2067.#.mainsnak.datavalue.value.amount
+      Birthdate:
+        selector: entities.*.claims.P569.#.mainsnak.datavalue.value.time
+      Height:
+        selector: entities.*.claims.P2048.#.mainsnak.datavalue.value.amount
+      CareerLength:
+        selector: entities.*.claims.P2031.#.mainsnak.datavalue.value.time
+      Gender:
+        selector: entities.*.claims.P21.#.mainsnak.datavalue.value.numeric-id
+        postProcess:
+          - map:
+              6581072: "FEMALE"
+              6581097: "MALE"
+
+
+#driver:
+#  headers:
+#    - Key: User-Agent
+#      Value: stashjson/1.0.0
+# Last Updated August 1, 2021


### PR DESCRIPTION
wikidata is the database behind wikipedia and can be used to power info boxes on wikipedia pages. Fixes #103
This database can have a lot of useful info such as height, weight, country, twitter handles etc.

Currently this is a WIP.
I might rewrite the processing performer with a python script as entries are easier to process.