### PR TITLE
Update SARJ-LLC scraper to use new logging

### DIFF
--- a/scrapers/SARJ-LLC.yml
+++ b/scrapers/SARJ-LLC.yml
@@ -70,4 +70,4 @@ performerByName:
     - SARJ-LLC.py
     - search
     - performer
-# Last Updated September 09, 2021
+# Last Updated September 18, 2021


### PR DESCRIPTION
Adds some logging using the new logging infrastructure of Stash.

(And secretly also fixes an issue which meant that fragment based scraping (based on name and date) didn't work unless a URL was set. Never noticed this issue as I was running a slightly modified version containing some logging and apparently this fix which I never made in the repository tracked version)