### PR TITLE
Add Jav.Land scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -535,6 +535,8 @@ japanhdv.com|JapanHDV.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 javdb.com|javdb.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|stash >= v0.9.0-21|Database
 javdb9.com|javdb.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Database
 javhd.com|JavHD.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
+jav.land|JavLand.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|JAV
+
 javlibrary.com|JavLibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|stash >= v0.9.0-21|JAV
 jaysinxxx.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jayspov.net|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/JavLand.yml
+++ b/scrapers/JavLand.yml
@@ -1,0 +1,54 @@
+name: "Jav.Land"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - jav.land
+    scraper: sceneScraper
+movieByURL:
+  - action: scrapeXPath
+    url:
+      - jav.land
+    scraper: movieScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $info: &infoSel //table[starts-with(@class,"videotextlist ")]
+    scene:
+      Title: &titleSel $info/tbody/tr[2]/td[2]/text()
+      Date: &dateAttr $info/tbody/tr[3]/td[2]/text()
+      Details: &detailsSel //div[@class="col-xs-12"]/strong/text()
+      Tags:
+        Name: $info/tbody/tr[9]/td[2]//a/text()
+      Performers:
+        Name: $info/tbody/tr[10]/td[2]//a[1]/text()
+      Studio: 
+        Name: &studioName $info/tbody/tr[7]/td[2]//a[1]/text()
+      Image: &imageSel //img[@class="img-responsive"]/@src
+      Movies:
+        Name: *titleSel
+        Date: *dateAttr
+        Director: $info/tbody/tr[5]/td[2]//a[1]/text()
+        Studio:
+          Name: *studioName
+        Synopsis: *detailsSel
+        FrontImage: *imageSel
+  movieScraper:
+    common:
+      $info: *infoSel
+    movie:
+      Name: *titleSel
+      Duration:
+        selector: $info/tbody/tr[4]/td[2]
+        postProcess:
+          - replace:
+              - regex: \(.+\)
+                with: ""
+              - regex: min
+                with: ":00"
+      Date: *dateAttr
+      Director: $info/tbody/tr[5]/td[2]//a[1]/text()
+      Studio:
+        Name: *studioName
+      Synopsis: *detailsSel
+      FrontImage: *imageSel
+# Last Updated September 25, 2021


### PR DESCRIPTION
Jav.Land is a comprehensive JAV collections website, which is easy to scrape.
Tested with many videos. It can create a movie while scraping a scene.
There might be a problem with duration and studio name occasionally.