### PR TITLE
Update WankzVR.yml

### DIFF
--- a/scrapers/WankzVR.yml
+++ b/scrapers/WankzVR.yml
@@ -26,7 +26,8 @@ xPathScrapers:
         Name: $info//div[@class="tag-list__body"]//a/text()
       Performers:
         Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
-      Image: &imageSel //meta[@property="og:image"]/@content
+#   Blocked by website's anti-scraping.
+#      Image: &imageSel //meta[@property="og:image"]/@content
   movieScraper:
     common:
       $info: *infoSel
@@ -48,5 +49,5 @@ xPathScrapers:
         Name:
           fixed: WankzVR
       Synopsis: *detailsAttr
-      FrontImage: *imageSel
-# Last Updated September 18, 2021
+#      FrontImage: *imageSel
+# Last Updated September 28, 2021


### PR DESCRIPTION
After more testing, it seems cdns-i.wankzvr.com is a website that can effectively block image scraping. I tried to use drivers: headers and CDP yet unsuccessful. So I have to quote them out, otherwise when saving the scraping result you will have 403 error and the data will not be saved.