### PR TITLE
Add automatic scrape retrying to IAFD scraper

### DIFF
--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -516,7 +516,7 @@ def performer_from_tree(tree):
     if performer_image_url:
         try:
             debug_print("downloading image from %s" % performer_image_url[0] )
-            p.image = scrape_image(performer_image_url[0])
+            p.images = [scrape_image(performer_image_url[0])]
         except Exception as e:
             debug_print("error downloading image %s" %e)
 


### PR DESCRIPTION
The IAFD scrape often fails, returning an HTTP 403 error, and requires multiple attempts until it succeeds. This PR automates the retry process and makes the scrape request again until it succeeds with a max of 10 attempts and a 2 second delay between each one.

In my experience it always works after it retries a few times. It may be the case for some people that no amount of retrying will work, so I'm not sure if this retry behavior would be harmful to them.