### PR TITLE
Update IAFD performer image xpath

### DIFF
--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -512,7 +512,7 @@ def performer_from_tree(tree):
     performer_piercings = tree.xpath('//div/p[text()="Piercings"]/following-sibling::p[1]//text()')
     p.piercings = p.set_value(performer_piercings)
 
-    performer_image_url = tree.xpath('//div[@id="headshot"]/img/@src')
+    performer_image_url = tree.xpath('//div[@id="headshot"]//img/@src')
     if performer_image_url:
         try:
             debug_print("downloading image from %s" % performer_image_url[0] )
@@ -617,4 +617,4 @@ if mode == "scene":
 #by default performer scraper
 performer_from_tree(tree)
 
-#Last Updated October 16, 2021
+#Last Updated November 5, 2021


### PR DESCRIPTION
Currently the IAFD scraper inconsistently scrapes the performer image, because sometimes the scraped page content around the performer headshot image looks like:
```<div id="headshot"><img title="Photo of ***" alt="Photo of *** data-cfsrc="https://www.iafd.com/graphics/headshots/***.jpg" style="display:none;visibility:hidden;"><noscript><img title="Photo of ***" alt="Photo of ***" src="https://www.iafd.com/graphics/headshots/***.jpg"></noscript></div>```
instead of the expected:
```<div id="headshot"><img title="Photo of ***" alt="Photo of ***" src="https://www.iafd.com/graphics/headshots/***.jpg"></div>```
This results in the image url not getting selected by the current xpath. This PR updates the xpath so it extracts the image url regardless of which html structure is returned which allows for consistent performer image scrapes.