### PR TITLE
AdultEmpire fixes

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -376,7 +376,7 @@ filf.com|FILF.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fillyfilms.com|CombatZone.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 filthflix.com|FilthFlix.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 filthyfamily.com|FilthyFamily.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-filthykings.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
+filthykings.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 finishesthejob.com|FinishesTheJob.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 firstanalquest.com|Firstanalquest.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 firstbgg.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -703,7 +703,7 @@ mylfdom.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mylifeinmiami.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 mylked.com|Mylked.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mypervmom.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-mypervyfamily.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
+mypervyfamily.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 myracequeens.com|karatmedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 mysislovesme.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 myteenoasis.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1055,7 +1055,7 @@ tonightsgirlfriend.com|Tonightsgirlfriend.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 toomanytrannies.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Trans
 topgrl.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 toticos.com|VegasDreamworks.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-touchmywife.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
+touchmywife.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 toughlovex.com|toughlovex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tour.purgatoryx.com|purgatoryx.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 trans500.com/tour/|Trans500.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -376,8 +376,7 @@ filf.com|FILF.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fillyfilms.com|CombatZone.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 filthflix.com|FilthFlix.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 filthyfamily.com|FilthyFamily.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-filthykings.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
-filthypov.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
+filthykings.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
 finishesthejob.com|FinishesTheJob.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 firstanalquest.com|Firstanalquest.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 firstbgg.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -638,7 +637,6 @@ maketeengape.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 maledigital.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 mamacitaz.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mandyflores.com|Mandyflores.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-manipulativemedia.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 manojob.com|FinishesTheJob.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 manroyale.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 manuelferrara.com|JulesJordan.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -705,7 +703,7 @@ mylfdom.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mylifeinmiami.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 mylked.com|Mylked.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mypervmom.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-mypervyfamily.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+mypervyfamily.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
 myracequeens.com|karatmedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 mysislovesme.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 myteenoasis.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1057,7 +1055,7 @@ tonightsgirlfriend.com|Tonightsgirlfriend.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 toomanytrannies.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Trans
 topgrl.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 toticos.com|VegasDreamworks.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-touchmywife.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+touchmywife.com|AdultEmpireNew.yml|:heavy_check_mark:|:x:|:x:|:x:|-|CDP
 toughlovex.com|toughlovex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tour.purgatoryx.com|purgatoryx.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 trans500.com/tour/|Trans500.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans

--- a/scrapers/AdultEmpireCash.yml
+++ b/scrapers/AdultEmpireCash.yml
@@ -6,8 +6,6 @@ sceneByURL:
     url:
       - concoxxxion.com/
       - elegantangel.com/
-      - filthykings.com/
-      - filthypov.com/
       - forbiddenfruitsfilms.com/
       - hornyhousehold.com/
       - jayspov.net/
@@ -15,13 +13,10 @@ sceneByURL:
       - kingsoffetish.com/
       - latinoguysporn.com/
       - lethalhardcore.com/
-      - manipulativemedia.com/
-      - mypervyfamily.com/
       - pornstarstroker.com/ # aggregator site?
       - reaganfoxx.com/
       - severesexfilms.com/
       - thirdworldxxx.com/
-      - touchmywife.com/
       - westcoastproductions.com/
 
   # VR Sites
@@ -40,10 +35,8 @@ movieByURL:
       - concoxxxion.com/
       - elegantangel.com/
       - filthykings.com/
-      - filthypov.com/
       - forbiddenfruitsfilms.com/
       - lethalhardcore.com/
-      - manipulativemedia.com/
       - severesexfilms.com/
       # - shemalestrokers.com/ # Scenes published as movies?
       - thirdworldxxx.com/
@@ -132,4 +125,4 @@ xPathScrapers:
                 with: https://imgs1cdn.adultempire.com/product/${1}_lg.jpg
       Studio:
         Name: //meta[@name="og:site_name"]/@content
-# Last Updated May 03, 2021
+# Last Updated November 20, 2021

--- a/scrapers/AdultEmpireNew.yml
+++ b/scrapers/AdultEmpireNew.yml
@@ -1,0 +1,28 @@
+name: AdultEmpireNew
+sceneByURL:
+  - action: scrapeXPath
+    scraper: sceneScraper
+    url:
+      - filthykings.com/
+      - mypervyfamily.com/
+      - touchmywife.com/
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h1[starts-with(@class,"Title")]
+      Date:
+        selector: //span[contains(@class,"Date-Text")]/text()
+        postProcess:
+          - parseDate: 2006-01-02
+      Details:
+        selector: //div/h2[text()="Description"]/following-sibling::div
+      Tags:
+        Name: //div/h2[text()="Categories"]/following-sibling::div/a
+      Performers:
+        Name: //a[contains(@class,"ActorThumb-Name-Link")]
+      Studio:
+        Name:
+          selector: //div[contains(@class,"Header-Freetour-Logo-Wrapper")]/a/@title
+driver:
+  useCDP: true
+# Last Updated November 20, 2021


### PR DESCRIPTION
fixes adultempire sites from #123
Removes filthykings, mypervyfamily and touchmywife from AdultEmpireCash and uses a new scraper for them with CDP
myfilthypov and manipulativemedia were removed altogether as they now redirect to other sites
