### PR TITLE
Unset birthdate if it can't be parsed to YYYY-MM-DD

### DIFF
--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -462,6 +462,12 @@ def performer_from_tree(tree):
             p.birthdate = datetime.datetime.strptime(p.birthdate, iafd_date).strftime(stash_date)
         except:
             p.birthdate = None
+            if performer_birthdate[0].lower() != "no data":
+                dob =  f'D.O.B. : {performer_birthdate[0]}\n'
+                try:
+                    p.details = p.details + dob
+                except:
+                    p.details = dob
             pass
 
     performer_deathdate = tree.xpath('(//p[@class="bioheading"][text()="Date of Death"]/following-sibling::p)[1]//text()')
@@ -471,6 +477,13 @@ def performer_from_tree(tree):
         try:
             p.death_date = datetime.datetime.strptime(p.death_date, iafd_date).strftime(stash_date)
         except:
+            p.death_date = None
+            if performer_deathdate[0].lower() != "no data":
+                dod = f'D.O.D. : {performer_deathdate[0]}\n'
+                try:
+                    p.details = p.details + dod
+                except:
+                    p.details = dod
             pass
 
     performer_ethnicity = tree.xpath('//div[p[text()="Ethnicity"]]/p[@class="biodata"][1]//text()')
@@ -617,5 +630,3 @@ if mode == "scene":
 
 #by default performer scraper
 performer_from_tree(tree)
-
-#Last Updated November 5, 2021

--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -461,6 +461,7 @@ def performer_from_tree(tree):
         try:
             p.birthdate = datetime.datetime.strptime(p.birthdate, iafd_date).strftime(stash_date)
         except:
+            p.birthdate = None
             pass
 
     performer_deathdate = tree.xpath('(//p[@class="bioheading"][text()="Date of Death"]/following-sibling::p)[1]//text()')

--- a/scrapers/IAFD.yml
+++ b/scrapers/IAFD.yml
@@ -28,4 +28,4 @@ movieByURL:
       - python3
       - IAFD.py
       - movie
-# Last Updated May 08, 2021
+# Last Updated December 19, 2021


### PR DESCRIPTION
I found an IAFD profile that had a birthdate value of `??/??/2000` which is the value the scraper returned. If a valid YYYY-MM-DD birthdate can't be scraped, then it should not be returned since stash won't let you save invalid date values.