### PR TITLE
multiscrape: pass url to scrape_performer

### DIFF
--- a/scrapers/multiscrape.py
+++ b/scrapers/multiscrape.py
@@ -203,7 +203,7 @@ class multiscrape:
                     if spl is not None:
                         for spli in spl:
                             if spli["name"].lower()==name.lower():
-                                r=self.scrape_performer(s, {"name":spli["name"]})
+                                r=self.scrape_performer(s, {"name":spli["name"], "url":spli["url"]})
                                 if r is not None:
                                     scraper_cache[s]=r
                                     found=True

--- a/scrapers/multiscrape.yml
+++ b/scrapers/multiscrape.yml
@@ -14,4 +14,4 @@ performerByName:
       - multiscrape.py
       - query
 
-# Last Updated June 09, 2021
+# Last Updated December 16, 2021


### PR DESCRIPTION
If I don't pass the URL I get an error about fragments not being supported instead of the results.

Example Query for the playground:
```query scrapePerformer($scraper_id: ID!, $performer: ScrapedPerformerInput!) {
  scrapePerformer(scraper_id: $scraper_id, scraped_performer: $performer) {
    name
    url
    gender
    twitter
    instagram
    birthdate
    ethnicity
    country
    eye_color
    height
    measurements
    fake_tits
    career_length
    tattoos
    piercings
    aliases
    images
  }
}
```

Variables: 
```
{
  "scraper_id": "Pornhub",
  "performer": {"name": "Riley Reid", 
   "url": "https://www.pornhub.com/pornstar/riley-reid"}
}
```

If you take the URL out it should fail.