### PR TITLE
Adding an onlyfans scraper using the DIGITALCRIMINAL onlyfans tool

### DIFF
--- a/scrapers/dc-onlyfans.py
+++ b/scrapers/dc-onlyfans.py
@@ -39,7 +39,13 @@ def lookup_scene(file,db,parent):
     res['studio']={'name':'OnlyFans','url':'https://www.onlyfans.com/'}
     res['url']='https://www.onlyfans.com/'+str(row[0])+'/'+parent.name
     res['date']=row[3].strftime('%Y-%m-%d')
-    res['performers']=[{"name":parent.name}]
+    performer={"name":parent.name}
+    image=findPerformerImage(parent)
+    if image is not None:
+        performer['images']=make_image_data_url(image)
+    res['performers']=[performer]
+
+
     return res
 
 def findFilePath(id):
@@ -69,6 +75,16 @@ def findFilePath(id):
     print(f"Error connecting to api",file=sys.stderr)
     print("{}")
     sys.exit()
+
+def findPerformerImage(path):
+    for c in path.iterdir():
+        if c.is_file() and c.name.endswith('.jpg'):
+            return c
+        elif c.is_dir():
+            r=findPerformerImage(c)
+            if r is not None:
+                return r
+    return None
 
 def make_image_data_url(image_path):
     # type: (str,) -> str

--- a/scrapers/dc-onlyfans.py
+++ b/scrapers/dc-onlyfans.py
@@ -1,0 +1,93 @@
+import json
+import sys
+import sqlite3
+import requests
+from os import path
+from pathlib import Path
+
+
+''' This script is a companion to the onlyfans data scraper by DIGITALCRIMINAL
+    https://github.com/DIGITALCRIMINAL/OnlyFans
+    This tool allows you to download data from onlyfans and saves some metadata on what it downloads.
+    
+    This script needs python3 and requests and sqlite3 
+    If you have a password on your instance you need to specify the api key below by removing the # and adding the key.
+   '''
+
+
+headers = {
+    "Accept-Encoding": "gzip, deflate, br",
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "Connection": "keep-alive",
+#   "ApiKey":"xxxxxxxxxx",
+    "DNT": "1"
+}
+graphql_api='http://localhost:9999/graphql'
+
+
+
+def lookup_scene(file,db,parent):
+    print(f"using database: {db.name}  {file.name}", file=sys.stderr)
+    conn = sqlite3.connect(db, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
+    c=conn.cursor()
+    c.execute('select posts.post_id,posts.text,medias.link,posts.created_at from posts,medias where posts.post_id=medias.post_id and medias.filename=?',(file.name,))
+    row=c.fetchone()
+    res={}
+    res['title']=str(parent.name)+ ' - '+row[3].strftime('%Y-%m-%d')
+    res['details']=row[1]
+    res['url']=row[2]
+    res['date']=row[3].strftime('%Y-%m-%d')
+    res['performers']=[{"name":parent.name}]
+    return res
+
+def findFilePath(id):
+    json = {}
+    json['query'] = """query FindScene($id: ID!, $checksum: String) {
+  findScene(id: $id, checksum: $checksum) {
+      id
+      path
+  }
+}"""
+    json['variables'] = {"id":id}
+
+    # handle cookies
+    response = requests.post(graphql_api, json=json, headers=headers)
+
+    if response.status_code == 200:
+        result = response.json()
+        if result.get("error", None):
+            for error in result["error"]["errors"]:
+                print("GraphQL error: {}".format(error),file=sys.stderr)
+                print("{}")
+                sys.exit()
+        if result.get("data", None):
+            data=result.get("data")
+            if "findScene" in data:
+                return data["findScene"]["path"]
+    print(f"Error connecting to api",file=sys.stderr)
+    print("{}")
+    sys.exit()
+
+if sys.argv[1] == "query":
+    fragment = json.loads(sys.stdin.read())
+    print(json.dumps(fragment),file=sys.stderr)
+    id=fragment['id']
+    file=Path(findFilePath(id))
+
+    p=file.parent
+    while not (Path(p.root)==p):
+        p=p.parent
+        for child in p.iterdir():
+            if child.is_dir():
+                for c in child.iterdir():
+                    if c.name== "user_data.db":
+                        scene=lookup_scene(file,c,p)
+                        print(json.dumps(scene))
+                        sys.exit()
+            if child.name=="user_data.db":
+                scene = lookup_scene(file, child, p)
+                print(json.dumps(scene))
+                sys.exit()
+    # not found return an empty map
+    print("{}")

--- a/scrapers/dc-onlyfans.py
+++ b/scrapers/dc-onlyfans.py
@@ -42,7 +42,7 @@ def lookup_scene(file,db,parent):
     performer={"name":parent.name}
     image=findPerformerImage(parent)
     if image is not None:
-        performer['images']=make_image_data_url(image)
+        performer['image']=make_image_data_url(image)
     res['performers']=[performer]
 
 

--- a/scrapers/dc-onlyfans.py
+++ b/scrapers/dc-onlyfans.py
@@ -2,9 +2,9 @@ import json
 import sys
 import sqlite3
 import requests
-from os import path
 from pathlib import Path
-
+import base64
+import mimetypes
 
 ''' This script is a companion to the onlyfans data scraper by DIGITALCRIMINAL
     https://github.com/DIGITALCRIMINAL/OnlyFans
@@ -36,7 +36,8 @@ def lookup_scene(file,db,parent):
     res={}
     res['title']=str(parent.name)+ ' - '+row[3].strftime('%Y-%m-%d')
     res['details']=row[1]
-    res['url']=row[2]
+    res['studio']={'name':'OnlyFans','url':'https://www.onlyfans.com/'}
+    res['url']='https://www.onlyfans.com/'+str(row[0])+'/'+parent.name
     res['date']=row[3].strftime('%Y-%m-%d')
     res['performers']=[{"name":parent.name}]
     return res
@@ -68,6 +69,14 @@ def findFilePath(id):
     print(f"Error connecting to api",file=sys.stderr)
     print("{}")
     sys.exit()
+
+def make_image_data_url(image_path):
+    # type: (str,) -> str
+    mime, _ = mimetypes.guess_type(image_path)
+    with open(image_path, 'rb') as img:
+        encoded = base64.b64encode(img.read()).decode()
+    return 'data:{0};base64,{1}'.format(mime, encoded)
+
 
 if sys.argv[1] == "query":
     fragment = json.loads(sys.stdin.read())

--- a/scrapers/dc-onlyfans.yml
+++ b/scrapers/dc-onlyfans.yml
@@ -1,0 +1,9 @@
+name: "DC Onlyfans"
+sceneByFragment:
+    action: script
+    script:
+      - python
+      # use python3 instead if needed
+      - dc-onlyfans.py
+      - query
+# Last Updated January 3, 2021

--- a/scrapers/dc-onlyfans.yml
+++ b/scrapers/dc-onlyfans.yml
@@ -6,4 +6,4 @@ sceneByFragment:
       # use python3 instead if needed
       - dc-onlyfans.py
       - query
-# Last Updated January 3, 2021
+# Last Updated January 17, 2022


### PR DESCRIPTION
This is a fragment based scraper that uses sqlite databases left behind after running the DIGITALCRIMINAL onlyfans scraper https://github.com/DIGITALCRIMINAL/OnlyFans

This script needs python and requests.

This script connects back to stash to find the current path of the video.
If your instance has a password you need to edit the script to include the api key by removing the # and adding it there.
#   "ApiKey":"xxxxxxxxxx",

Once it has the path it looks for user_data.db and returns the metadata from there.