### PR TITLE
Fix R18 search in JavLibrary_python fragment scraper

### DIFF
--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -552,6 +552,7 @@ if jav_main_html:
         # R18
         if jav_result.get("r18"):
             r18_search_url = re.sub(r".+\/\/", "https://", jav_result["r18"][0])
+            r18_search_url += '/'
             r18_search_html = sendRequest(r18_search_url, R18_HEADERS)
             r18_main_html = r18_search(r18_search_html, r18_xPath_search)
 

--- a/scrapers/JavLibrary_python.yml
+++ b/scrapers/JavLibrary_python.yml
@@ -16,4 +16,4 @@ sceneByQueryFragment:
       - python
       - JavLibrary_python.py
       - validSearch
-# Last Updated November 13, 2021
+# Last Updated January 17, 2022


### PR DESCRIPTION
R18 now return 404s for `/searchword={code}` and require search URLs to be formatted as `/searchword={code}/`.