### PR TITLE
Add AnimeCharactersDatabase

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -296,6 +296,7 @@ daddyslilangel.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 damnthatsbig.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 danejones.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 danni.com|Danni.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+darkroomvr.com|DarkRoomVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 darkx.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 data18.com|data18.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 daughterswap.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -80,6 +80,7 @@ angelasommers.com|angelasommers.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 angelawhite.com|AngelaWhite.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 angelinacastrolive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 anilos.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
+animecharactersdatabase.com|AnimeCharactersDatabase.yml|:x:|:x:|:x:|:heavy_check_mark:|Python|Database
 archangelvideo.com|ArchAngelVideo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ariellynn.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ashleyfires.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/AnimeCharactersDatabase.py
+++ b/scrapers/AnimeCharactersDatabase.py
@@ -1,0 +1,235 @@
+import json
+import re
+import sys
+from datetime import datetime
+
+import cloudscraper
+import requests
+from lxml import html
+
+#  --------------------------------------
+
+# This is a scraper for: animecharactersdatabase.com
+#
+# AnimeCharactersDatabase includes characters from:
+# Anime, Hentai, (Mobile) Games, Eroge, Virtual Idols/YouTubers, Vocaloid
+#
+# These fields will be populated if available:
+# Name, Gender, Birthdate, Country, Hair Color, Eye Color, Height, Measurements, URL, Details, Tags, Image
+#
+# Tags mostly include appearance indicators like: ahoge, dress, hat, twintails, etc.
+# A number of additional tags can be configured below.
+
+# ---------------------------------------
+# ---------- Tag Configuration ----------
+# ---------------------------------------
+
+# Maximum number of search results (between 1 and 30).
+# Search by name includes the franchise for each result to make it easier to choose the correct one.
+# Some (non ascii, very short) names require querying the API individually to get the franchise for each result.
+# This might get you banned, since the API is rate limited.
+# See: http://wiki.animecharactersdatabase.com/index.php?title=API_Access
+limit = 15
+
+# Prefix for performer tags.
+prefix = "performer:"
+
+# List of additional tags.
+additional_tags = [{"name": "fictional"}]  # []
+
+# Scrape the source material as tag (name of anime/game): Kantai Collection, Idolmaster: Cinderella Girls, etc.
+include_parody = True
+parody_prefix = "parody:"
+
+# Scrape Zodiac Sign as tag: Libra ♎, Sagittarius ♐, etc.
+include_sign = True
+sign_prefix = prefix + "sign:"
+
+# Scrape race of non-human characters as tag: Orc, Elf, etc.
+include_race = True
+race_prefix = prefix + "race:"
+
+# Scrape ship class of ship girls as tag (kancolle, etc.): Battleship, etc.
+include_ship_class = True
+ship_class_prefix = prefix + "ship:"
+
+# Scrape blood type as tag: A, B, etc.
+include_blood_type = True
+blood_type_prefix = prefix + "Blood Type "
+
+# Scrape apparent age as tag: Adult, Teen, etc.
+# Might differ from canonical age.
+# Canonical age will be ignored, since it would result in too many tags.
+# Birthdate is sometimes available, but the resulting calculated age represents neither canonical age nor apparent age.
+include_apparent_age = True
+apparent_age_prefix = prefix + "Apparent "
+
+# Scrape Hair Length as tag: To Shoulders, To Neck, Past Waist, etc.
+include_hair_length = True
+hair_length_prefix = prefix + "Hair "
+
+
+# ---------------------------------------
+# ---------------------------------------
+# ---------------------------------------
+
+
+def debug(t):
+    sys.stderr.write(str(t) + "\n")
+
+
+def readJSONInput():
+    input = sys.stdin.read()
+    return json.loads(input)
+
+
+def scrapeURL(url):
+    return html.fromstring(scrapeUrlToString(url))
+
+
+def scrapeUrlToString(url):
+    scraper = cloudscraper.create_scraper()
+    try:
+        scraped = scraper.get(url)
+    except:
+        debug("scrape error")
+        sys.exit(1)
+
+    if scraped.status_code >= 400:
+        debug('HTTP Error: %s' % scraped.status_code)
+        sys.exit(1)
+
+    return scraped.content
+
+
+def performerByName(query):
+    cleanedQuery = requests.utils.quote(query)
+    url = f"https://www.animecharactersdatabase.com/searchall.php?in=characters&sq={cleanedQuery}"
+    tree = scrapeURL(url)
+    names = tree.xpath("//li/div[@class='tile3top']/a/text()")
+    ids = tree.xpath("//li/div[@class='tile3top']/a/@href")
+
+    results = []
+    for name, id in zip(names, ids):
+        results.append({
+            "name": name,
+            "id": id.replace("characters.php?id=", ""),
+            "url": "https://www.animecharactersdatabase.com/" + id
+        })
+    debug(f"scraped {len(results)} results on: {url}")
+    return results
+
+
+def addFranchise(query, results):
+    cleanedQuery = requests.utils.quote(query)
+    url = f"https://www.animecharactersdatabase.com/api_series_characters.php?character_q={cleanedQuery}"
+    data = json.loads(scrapeUrlToString(url))
+    count1 = 0
+    count2 = 0
+    for result in results:
+        try:
+            # Try to find the franchise in API search results.
+            # These results are ordered by alphabet and limited to 100,
+            # so short queries might not include the correct result.
+            # The API query also does not seem to support any Kanji.
+            franchise = next(e["anime_name"] for e in data["search_results"] if str(e["id"]) == result["id"])
+            count1 += 1
+        except:
+            # Use separate API calls as a backup.
+            # This might get you banned, since the API is rate limited.
+            franchise = apiGetCharacter(result["id"])["origin"]
+            count2 += 1
+        # Append franchise to character name for easier differentiation.
+        result["name"] = f"{result['name']} ({franchise})"
+        result.pop("id")
+    debug(f"scraped {count1} franchises by single API call")
+    debug(f"scraped {count2} franchises by separate API calls")
+    return results
+
+
+def apiGetCharacter(id):
+    url = f"https://www.animecharactersdatabase.com/api_series_characters.php?character_id={id}"
+    return json.loads(scrapeUrlToString(url))
+
+
+def performerByURL(url, result={}):
+    debug("performerByURL: " + url)
+    tree = scrapeURL(url)
+    result["url"] = url
+    result["name"] = next(iter(tree.xpath(
+        "//h3[@id='section001_summary']/following-sibling::p/a[contains(@href,'character')]/text()")), "").strip()
+    result["details"] = "\n".join([s.strip() for s in tree.xpath(
+        "//div[@style='padding: 0 15px 15px 15px; text-align: left;']/text()")])
+    if not result["details"]:
+        result["details"] = re.sub(" .$", ".", " ".join([s.strip() for s in tree.xpath(
+            "//h3[@id='section001_summary']/following-sibling::p[contains(a/@href,'character')]//text()") if
+                                                         s.strip()]))
+    result["image"] = next(iter(tree.xpath("//meta[@property='og:image']/@content")), "")
+
+    # left table, works for link and plain text fields, return result list
+    def parse_left(field):
+        template = "//table//th[text()='{0}' or a/text()='{0}']/following-sibling::td/a/text()"
+        return tree.xpath(template.format(field))
+
+    result["tags"] = additional_tags
+    result["tags"] += [{"name": prefix + tag.strip()} for tag in parse_left("Tags ")]
+    if include_parody:
+        result["tags"] += [{"name": parody_prefix + tag.strip()} for tag in parse_left("From")]
+    if include_blood_type:
+        result["tags"] += [{"name": blood_type_prefix + tag.strip()} for tag in parse_left("Blood Type")]
+    if include_race:
+        result["tags"] += [{"name": race_prefix + tag.strip()} for tag in parse_left("Race")]
+    if include_sign:
+        result["tags"] += [{"name": sign_prefix + tag.strip()} for tag in parse_left("Sign")]
+    if include_ship_class:
+        result["tags"] += [{"name": ship_class_prefix + tag.strip()} for tag in parse_left("Ship Class")]
+    result["country"] = next(iter(parse_left("Nationality")), "")
+    birthday = parse_left("Birthday")
+    birthyear = parse_left("Birthyear")
+    if birthday and birthyear:
+        birthdate = datetime.strptime(birthday[0].strip(), "%B %d").replace(year=int(birthyear[0].strip()))
+        result["birthdate"] = birthdate.strftime("%Y-%m-%d")
+    bust = parse_left("Bust")
+    waist = parse_left("Waist")
+    hip = parse_left("Hip")
+    if bust and waist and hip:
+        bust = bust[0].strip().replace("cm", "")
+        waist = waist[0].strip().replace("cm", "")
+        hip = hip[0].strip().replace("cm", "")
+        result["measurements"] = "{}-{}-{}".format(bust, waist, hip)
+    result["height"] = next(iter(parse_left("Height")), "").strip().replace("cm", "")
+
+    # middle/right table, reverse result list to prefer official appearance, return result or empty string
+    def parse_right(field):
+        template = "//table//th[text()='{}']/following-sibling::td/text()"
+        return next(reversed(tree.xpath(template.format(field))), "").strip().replace("Unknown", "")
+
+    # should be tagged anyway if yes
+    # if parse_right("Animal Ears") == "Yes":
+    #     result["tags"] += [{"name": "performer:animal ears"}]
+    hair_length = parse_right("Hair Length")
+    if include_hair_length and hair_length:
+        result["tags"] += [{"name": hair_length_prefix + hair_length}]
+    apparent_age = parse_right("Apparent Age")
+    if include_apparent_age and apparent_age:
+        result["tags"] += [{"name": apparent_age_prefix + apparent_age}]
+    result["gender"] = parse_right("Gender")
+    result["eye_color"] = parse_right("Eye Color")
+    result["hair_color"] = parse_right("Hair Color")
+
+    return result
+
+
+# read the input
+i = readJSONInput()
+
+if sys.argv[1] == "performerByURL":
+    url = i["url"]
+    result = performerByURL(url)
+    print(json.dumps(result))
+elif sys.argv[1] == "performerByName":
+    name = i["name"]
+    debug(f"Searching for name: {name}")
+    results = performerByName(name, )[:limit]
+    results = addFranchise(name, results)
+    print(json.dumps(results))

--- a/scrapers/AnimeCharactersDatabase.py
+++ b/scrapers/AnimeCharactersDatabase.py
@@ -17,7 +17,6 @@ from lxml import html
 # These fields will be populated if available:
 # Name, Gender, Birthdate, Country, Hair Color, Eye Color, Height, Measurements, URL, Details, Tags, Image
 #
-# Tags mostly include appearance indicators like: ahoge, dress, hat, twintails, etc.
 # A number of additional tags can be configured below.
 
 # ---------------------------------------
@@ -37,6 +36,10 @@ prefix = "performer:"
 # List of additional tags.
 additional_tags = [{"name": "fictional"}]  # []
 
+# Tags mostly include appearance indicators like: ahoge, dress, hat, twintails, etc.
+include_tag = True
+tag_prefix = prefix
+
 # Scrape the source material as tag (name of anime/game): Kantai Collection, Idolmaster: Cinderella Girls, etc.
 include_parody = True
 parody_prefix = "parody:"
@@ -49,7 +52,7 @@ sign_prefix = prefix + "sign:"
 include_race = True
 race_prefix = prefix + "race:"
 
-# Scrape ship class of ship girls as tag (kancolle, etc.): Battleship, etc.
+# Scrape ship class of ship girls as tag (kancolle, etc.): Destroyer, etc.
 include_ship_class = True
 ship_class_prefix = prefix + "ship:"
 
@@ -172,7 +175,8 @@ def performerByURL(url, result={}):
         return tree.xpath(template.format(field))
 
     result["tags"] = additional_tags
-    result["tags"] += [{"name": prefix + tag.strip()} for tag in parse_left("Tags ")]
+    if include_tag:
+        result["tags"] += [{"name": tag_prefix + tag.strip()} for tag in parse_left("Tags ")]
     if include_parody:
         result["tags"] += [{"name": parody_prefix + tag.strip()} for tag in parse_left("From")]
     if include_blood_type:
@@ -230,6 +234,6 @@ if sys.argv[1] == "performerByURL":
 elif sys.argv[1] == "performerByName":
     name = i["name"]
     debug(f"Searching for name: {name}")
-    results = performerByName(name, )[:limit]
+    results = performerByName(name)[:limit]
     results = addFranchise(name, results)
     print(json.dumps(results))

--- a/scrapers/AnimeCharactersDatabase.py
+++ b/scrapers/AnimeCharactersDatabase.py
@@ -7,6 +7,14 @@ import cloudscraper
 import requests
 from lxml import html
 
+try:
+    import py_common.log as log
+except ModuleNotFoundError:
+    print(
+        "You need to download the folder 'py_common' from the community repo (CommunityScrapers/tree/master/scrapers/py_common)",
+        file=sys.stderr)
+    sys.exit(1)
+
 #  --------------------------------------
 
 # This is a scraper for: animecharactersdatabase.com
@@ -76,11 +84,6 @@ hair_length_prefix = prefix + "Hair "
 # ---------------------------------------
 # ---------------------------------------
 
-
-def debug(t):
-    sys.stderr.write(str(t) + "\n")
-
-
 def readJSONInput():
     input = sys.stdin.read()
     return json.loads(input)
@@ -95,11 +98,11 @@ def scrapeUrlToString(url):
     try:
         scraped = scraper.get(url)
     except:
-        debug("scrape error")
+        log.error("scrape error")
         sys.exit(1)
 
     if scraped.status_code >= 400:
-        debug('HTTP Error: %s' % scraped.status_code)
+        log.error('HTTP Error: %s' % scraped.status_code)
         sys.exit(1)
 
     return scraped.content
@@ -119,7 +122,7 @@ def performerByName(query):
             "id": id.replace("characters.php?id=", ""),
             "url": "https://www.animecharactersdatabase.com/" + id
         })
-    debug(f"scraped {len(results)} results on: {url}")
+    log.info(f"scraped {len(results)} results on: {url}")
     return results
 
 
@@ -145,8 +148,8 @@ def addFranchise(query, results):
         # Append franchise to character name for easier differentiation.
         result["name"] = f"{result['name']} ({franchise})"
         result.pop("id")
-    debug(f"scraped {count1} franchises by single API call")
-    debug(f"scraped {count2} franchises by separate API calls")
+    log.debug(f"scraped {count1} franchises by single API call")
+    log.debug(f"scraped {count2} franchises by separate API calls")
     return results
 
 
@@ -156,7 +159,7 @@ def apiGetCharacter(id):
 
 
 def performerByURL(url, result={}):
-    debug("performerByURL: " + url)
+    log.debug("performerByURL: " + url)
     tree = scrapeURL(url)
     result["url"] = url
     result["name"] = next(iter(tree.xpath(
@@ -233,7 +236,7 @@ if sys.argv[1] == "performerByURL":
     print(json.dumps(result))
 elif sys.argv[1] == "performerByName":
     name = i["name"]
-    debug(f"Searching for name: {name}")
+    log.info(f"Searching for name: {name}")
     results = performerByName(name)[:limit]
     results = addFranchise(name, results)
     print(json.dumps(results))

--- a/scrapers/AnimeCharactersDatabase.yml
+++ b/scrapers/AnimeCharactersDatabase.yml
@@ -3,7 +3,7 @@ name: AnimeCharactersDatabase
 performerByURL:
 - action: script
   url:
-    - animecharactersdatabase.com
+    - animecharactersdatabase.com/characters.php
   script:
     - python
     - AnimeCharactersDatabase.py
@@ -16,4 +16,4 @@ performerByName:
     - AnimeCharactersDatabase.py
     - performerByName
 
-# Last Updated January 20, 2022
+# Last Updated January 21, 2022

--- a/scrapers/AnimeCharactersDatabase.yml
+++ b/scrapers/AnimeCharactersDatabase.yml
@@ -1,0 +1,19 @@
+name: AnimeCharactersDatabase
+
+performerByURL:
+- action: script
+  url:
+    - animecharactersdatabase.com
+  script:
+    - python
+    - AnimeCharactersDatabase.py
+    - performerByURL
+
+performerByName:
+  action: script
+  script:
+    - python
+    - AnimeCharactersDatabase.py
+    - performerByName
+
+# Last Updated January 20, 2022

--- a/scrapers/AnimeCharactersDatabase.yml
+++ b/scrapers/AnimeCharactersDatabase.yml
@@ -16,4 +16,4 @@ performerByName:
     - AnimeCharactersDatabase.py
     - performerByName
 
-# Last Updated January 21, 2022
+# Last Updated January 23, 2022

--- a/scrapers/DarkRoomVR.yml
+++ b/scrapers/DarkRoomVR.yml
@@ -1,0 +1,29 @@
+name: "DarkRoomVR"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - darkroomvr.com
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $info: //div[@class="container"]
+    scene:
+      Title: $info//h1[@class="video-detail__title"]
+      Studio:
+        Name:
+          fixed: DarkRoomVR
+      Date:
+        selector: $info//div[@class="video-info__text"]/div[@class="video-info__time"]/text()
+        postProcess:
+          - replace:
+              - regex: ".+ • (.*)"
+                with: $1
+          - parseDate: 2 January, 2006
+      Details: $info//div[@data-id="description"][span[text()="Read less"]]/text()
+      Tags:
+        Name: $info//div[@class="tags__container"]//a/text()
+      Performers:
+        Name: $info//div[@class="video-info__text"]//a/text()
+      Image: $info//div[@class="image-container"]//dl8-video/@poster
+# Last Updated January 15, 2022


### PR DESCRIPTION
This seems to be the first Anime focused performer scraper. It uses Python.

AnimeCharactersDatabase includes characters from:
Anime, Hentai, (Mobile) Games, Eroge, Virtual Idols/YouTubers, Vocaloid

These fields will be populated if available:
Name, Gender, Birthdate, Country, Hair Color, Eye Color, Height, Measurements, URL, Details, Tags, Image

A bunch of additional details and tags can be configured in the .py