### PR TITLE
Add Boobpedia xPath performer scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -172,6 +172,7 @@ blownbyrone.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 blowpass.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bobbiedenlive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bobstgirls.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+boobpedia.com|Boobpedia.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Database
 bootyclapxxx.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 bootysisters.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 boppingbabes.com|BoppingBabes.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Boobpedia.yml
+++ b/scrapers/Boobpedia.yml
@@ -28,7 +28,8 @@ xPathScrapers:
       Birthdate:
         selector: //table//tr/td//b[text()='Born:']/../following-sibling::td/a
         concat: " "
-        parseDate: January 2 2006
+        postProcess:
+          - parseDate: January 2 2006
       Ethnicity: //table//tr/td/b[text()='Ethnicity:']/../following-sibling::td/a
       Country: //table//tr/td/b[text()='Nationality:']/../following-sibling::td/a
       EyeColor: //table//tr/td/b[text()='Eye color:']/../following-sibling::td
@@ -82,4 +83,4 @@ xPathScrapers:
       Details:
         selector: //div[@class="mw-parser-output"]/p
         concat: "\n\n"
-# Last Updated 01 February, 2022
+# Last Updated February 01, 2022

--- a/scrapers/Boobpedia.yml
+++ b/scrapers/Boobpedia.yml
@@ -1,0 +1,85 @@
+name: Boobpedia
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - boobpedia.com/boobs/
+    scraper: performerScraper
+performerByName:
+  action: scrapeXPath
+  queryURL: "https://www.boobpedia.com/wiki/index.php?title=Special%3ASearch&search={}"
+  scraper: performerSearch
+xPathScrapers:
+  performerSearch:
+    common:
+      $sr: //div/h2[span[contains(text(),"title")]]/following-sibling::ul[1]//a
+    performer:
+      Name: $sr
+      URL:
+        selector: $sr/@href
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "https://www.boobpedia.com"
+  performerScraper:
+    performer:
+      Name: //h1
+      Twitter: //table//tr/td/b/a[text()='Twitter']/@href
+      Instagram: //table//tr/td/b/a[text()='Instagram']/@href
+      Birthdate:
+        selector: //table//tr/td//b[text()='Born:']/../following-sibling::td/a
+        concat: " "
+        parseDate: January 2 2006
+      Ethnicity: //table//tr/td/b[text()='Ethnicity:']/../following-sibling::td/a
+      Country: //table//tr/td/b[text()='Nationality:']/../following-sibling::td/a
+      EyeColor: //table//tr/td/b[text()='Eye color:']/../following-sibling::td
+      Height:
+        selector: //table//tr/td/b[text()='Height:']/../following-sibling::td
+        postProcess:
+          - replace:
+              - regex: (?:.+\D)?(\d+\.\d+)\Dm.+
+                with: $1
+              - regex: \.
+                with: ""
+      Weight:
+        selector: //table//tr/td/b[text()='Weight:']/../following-sibling::td
+        postProcess:
+          - replace:
+              - regex: (?:.+\D)?(\d+)\Dkg.+
+                with: $1
+      Measurements:
+        selector: //table//tr/td/b[text()='Measurements:']/../following-sibling::td|//table//tr/td[contains(b,'cup')]/following-sibling::td
+        concat: "|"
+        postProcess:
+          - replace:
+              - regex: (\d+)-(\d+)-(\d+)[^|]+\|(\S+).+ # get measurements + cup
+                with: $1$4-$2-$3
+              - regex: \|.+$ # fallback to clear non matching regexes
+                with: ""
+      FakeTits: //table//tr/td/b[text()='Boobs:']/../following-sibling::td/a
+      HairColor: //table//tr/td[contains(b,'Hair')]/following-sibling::td
+      # nbsp; screws up the parsing, so use contains instead
+      CareerLength: //table//tr/td/b[text()[contains(.,'active:')]]/../following-sibling::td
+      Aliases: //table//tr/td/b[text()[contains(.,'known')]]/../following-sibling::td
+      Image:
+        #selector: //table[@class="infobox"]//img/@src #alterntive image, no need for subScraper but gets lq image
+        selector: //table[@class="infobox"]//a[img[@src]]/@href
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://www.boobpedia.com
+          - subScraper:
+              selector: //div[@id="file"]/a/@href
+              postProcess:
+                - replace:
+                    - regex: ^
+                      with: https://www.boobpedia.com
+      URL:
+        selector: //script[contains(.,"wgPageName")]
+        postProcess:
+          - replace:
+              - regex: '.+wgPageName":"([^"]+)".+'
+                with: "https://www.boobpedia.com/boobs/$1"
+      Details:
+        selector: //div[@class="mw-parser-output"]/p
+        concat: "\n\n"
+# Last Updated 01 February, 2022


### PR DESCRIPTION
tweaked withoutpant's original scraper from a stash's pull request
requested in #73

- The search functionality is limited by the way the boobpedia api treats white spaces (we cant urlreplace in byName queries in stash so nothing can be done about it atm) and also some results may not be performers. Any search query that  has spaces needs them replaced with `+`. If for example you need to search for `First Last` then use `First+Last`
- boobpedia doesnt seem to have a fixed order for the meta that has to do with metric sizes eg kg/lb, m/feet. I adjusted the regexes to work despite that, let me know if it doesnt work in some cases
- details keeps just the `<p>` part of the descriptions(should be the first paragraph actually), again there are too many variations and i thought that was the safest to use