### PR TITLE
Add AdultFilmIndex parser

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -34,8 +34,8 @@ activeduty.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 addisonstreet.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 adultdvdempire.com|AdultEmpire.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adultdvdmarketplace.com|AdultDvdMarketPlace.yml|:x:|:x:|:heavy_check_mark:|:x:|-|-
-adultfilmindex.com|AdultFilmIndex.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adultempire.com|AdultEmpire.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
+adultfilmindex.com|AdultFilmIndex.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adulttime.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 aebn.com|AEBN.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Straight + Gay
 alettaoceanempire.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -34,6 +34,7 @@ activeduty.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 addisonstreet.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 adultdvdempire.com|AdultEmpire.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adultdvdmarketplace.com|AdultDvdMarketPlace.yml|:x:|:x:|:heavy_check_mark:|:x:|-|-
+adultfilmindex.com|AdultFilmIndex.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adultempire.com|AdultEmpire.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 adulttime.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 aebn.com|AEBN.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Straight + Gay

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -24,7 +24,7 @@ movieByURL:
     queryURL: https://adultfilmindex.com/api/v1/stash/movie/{url}
     queryURLReplace:
       url:
-        - regex: '.+/movie/(.*)/(.*).+'
+        - regex: '.+/movie/([^/]+)/.+$'
           with: "${1}"
 jsonScrapers:
   sceneSearch:
@@ -78,4 +78,4 @@ driver:
       Value: stashjson/1.0.0
     - Key: Authorization # Beta key, enabled and active for now
       Value: Bearer 4vY0iwSUVPH5cGAX1AUZarJ8pbuDUK53
-# Last Updated February 03, 2022
+# Last Updated February 04, 2022

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -30,7 +30,7 @@ jsonScrapers:
   sceneSearch:
     scene:
       Title: data.#.title
-      date: data.#.release_date
+      Date: data.#.release_date
       Image: data.#.thumbnail
       URL: data.#.url
       Details: data.#.description

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -1,0 +1,75 @@
+name: AdultFilmIndex
+sceneByURL:
+  - action: scrapeJson
+    url:
+      - https://adultfilmindex.com/api/v1/stash/scene/
+    scraper: sceneScraper
+sceneByName:
+  action: scrapeJson
+  queryURL: https://adultfilmindex.com/api/v1/stash/scene_search/{}
+  scraper: sceneSearch
+sceneByQueryFragment:
+  action: scrapeJson
+  queryURL: "{url}"
+  scraper: sceneScraper
+sceneByFragment:
+  action: scrapeJson
+  queryURL: https://adultfilmindex.com/api/v1/stash/scene_fragment_search/{filename}/{oshash}
+  scraper: sceneScraper
+movieByURL:
+  - action: scrapeJson
+    url:
+      - https://adultfilmindex.com/movie/
+    scraper: movieScraper
+    queryURL: https://adultfilmindex.com/api/v1/stash/movie/{url}
+    queryURLReplace:
+      url:
+        - regex: '.+/movie/(.*)/(.*).+'
+          with: "${1}"
+jsonScrapers:
+  sceneSearch:
+    scene:
+      Title: data.#.title
+      date: data.#.release_date
+      Image: data.#.thumbnail
+      URL: data.#.url
+      Details: data.#.description
+  sceneScraper:
+    scene:
+      Title: data.title
+      Details: data.description
+      URL: data.url
+      Image: data.thumbnail
+      Date:
+        selector: data.movie.release_date
+        postProcess:
+          - parseDate: 2006-01-02
+      Movies:
+        Name: data.movie.title
+      Performers:
+        Name: data.actors.#.name
+      Studio:
+        Name: data.movie.studio.name
+      Tags:
+        Name: data.tags.#.name
+  movieScraper:
+    movie:
+      Name: data.title
+      Synopsis: data.description
+      URL: data.url
+      Duration: data.runtime
+      Date:
+        selector: data.release_date
+        postProcess:
+          - parseDate: 2006-01-02
+      Studio:
+        Name: data.studio.name
+      FrontImage: data.front_cover
+      BackImage: data.back_cover
+driver:
+  headers:
+    - Key: User-Agent
+      Value: stashjson/1.0.0
+    - Key: Authorization # Beta key, enabled and active for now
+      Value: Bearer 4vY0iwSUVPH5cGAX1AUZarJ8pbuDUK53
+# Last Updated February 03, 2022

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -43,6 +43,9 @@ jsonScrapers:
       Date:
         selector: data.movie.release_date
         postProcess:
+          - replace:
+              - regex: T.*$
+                with: ""
           - parseDate: 2006-01-02
       Movies:
         Name: data.movie.title

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -64,6 +64,9 @@ jsonScrapers:
       Date:
         selector: data.release_date
         postProcess:
+          - replace:
+              - regex: T.*$
+                with: ""
           - parseDate: 2006-01-02
       Studio:
         Name: data.studio.name


### PR DESCRIPTION
Hello, we are building a new adult filmography database on AdultFilmIndex.com. We combine the metadata from multiple adult film sources to make a new, comprehensive adult DVD index and database.

We have made a stash-specific API endpoints for scraping the metadata for movies and scenes. The API is in beta, and we have included a key for accessing it, this key is available for all stash users.

This PR includes the parsers for scenes and movies using AdultFilmIndex API. We have tested the parser locally and have determined it working.