### PR TITLE
Fix AdultFilmIndex direct scene urls

### DIFF
--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -2,8 +2,13 @@ name: AdultFilmIndex
 sceneByURL:
   - action: scrapeJson
     url:
-      - https://adultfilmindex.com/api/v1/stash/scene/
+      - https://adultfilmindex.com/movie/
     scraper: sceneScraper
+    queryURL: https://adultfilmindex.com/api/v1/stash/scene/{url}
+    queryURLReplace:
+      url:
+        - regex: '.+/movie/([^/]+)/([^/]+)/scene/([^/]+)$'
+          with: "${3}"
 sceneByName:
   action: scrapeJson
   queryURL: https://adultfilmindex.com/api/v1/stash/scene_search/{}

--- a/scrapers/AdultFilmIndex.yml
+++ b/scrapers/AdultFilmIndex.yml
@@ -83,4 +83,4 @@ driver:
       Value: stashjson/1.0.0
     - Key: Authorization # Beta key, enabled and active for now
       Value: Bearer 4vY0iwSUVPH5cGAX1AUZarJ8pbuDUK53
-# Last Updated February 04, 2022
+# Last Updated February 05, 2022


### PR DESCRIPTION
Direct scene urls are not picked up by stash parser, since `sceneByUrl` looks for `/api` urls. Updated so that a direct scene url can be used and parsed.