### PR TITLE
Scrapper to copy scene data to gallery

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1243,8 +1243,8 @@ For each scraper a short description, an optional comment with the usage and the
 
 Scraper | Description | Comments | PR
 --------|-------------|----------|:--:
-CopyToGallery.yml| A scene to gallery scraper | A python scene scraper that copies metadata from a scene to the associated galleries. Can optionally (check .py file) associate and copy meta to all galleries in the same folder as the scene| [#895](https://github.com/stashapp/CommunityScrapers/pull/895)
 ComicInfoXML.yml| A ComixInfo XML gallery scraper | A python scraper that looks for ComicInfo xml compatible  files in the gallery's folder/filename and parses them | [#827](https://github.com/stashapp/CommunityScrapers/pull/827)
+CopyToGallery.yml| A scene to gallery scraper | A python scene scraper that copies metadata from a scene to the associated galleries. Can optionally (check .py file) associate and copy meta to all galleries in the same folder as the scene| [#895](https://github.com/stashapp/CommunityScrapers/pull/895)
 dc-onlyfans.yml| An Onlyfans DB scene scraper | A python scraper that scrapes Only Fans scenes using the DB file (user_data.db) created from DIGITALCRIMINAL's tool | [#847](https://github.com/stashapp/CommunityScrapers/pull/847)
 jellyfin.yml| A Jellyfin/Emby scraper | A python scraper that uses the Jellyfin/Emby API to look for Scenes, Performers and Movies via URL, Query or Fragments. Needs the URL, API-Key and User from Jellyfin set in jellyfin.py and the URLs in jellyfin.yml adopted to your local Jelly/Emby Instance | 
 MindGeekAPI.yml| A sceneBy(Name\|Fragment) scraper for MindGeek network| A python scraper that queries directly the MindGeek API. For further **needed** instructions refer to the relevant PRs and have a look in the `MindGeekApi.py` file | [#711](https://github.com/stashapp/CommunityScrapers/pull/711) [#738](https://github.com/stashapp/CommunityScrapers/pull/738) [#411](https://github.com/stashapp/CommunityScrapers/pull/411)

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1243,6 +1243,7 @@ For each scraper a short description, an optional comment with the usage and the
 
 Scraper | Description | Comments | PR
 --------|-------------|----------|:--:
+CopyToGallery.yml| A scene to gallery scraper | A python scene scraper that copies metadata from a scene to the associated galleries. Can optionally (check .py file) associate and copy meta to all galleries in the same folder as the scene| [#895](https://github.com/stashapp/CommunityScrapers/pull/895)
 ComicInfoXML.yml| A ComixInfo XML gallery scraper | A python scraper that looks for ComicInfo xml compatible  files in the gallery's folder/filename and parses them | [#827](https://github.com/stashapp/CommunityScrapers/pull/827)
 dc-onlyfans.yml| An Onlyfans DB scene scraper | A python scraper that scrapes Only Fans scenes using the DB file (user_data.db) created from DIGITALCRIMINAL's tool | [#847](https://github.com/stashapp/CommunityScrapers/pull/847)
 jellyfin.yml| A Jellyfin/Emby scraper | A python scraper that uses the Jellyfin/Emby API to look for Scenes, Performers and Movies via URL, Query or Fragments. Needs the URL, API-Key and User from Jellyfin set in jellyfin.py and the URLs in jellyfin.yml adopted to your local Jelly/Emby Instance | 

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -5,11 +5,6 @@ import os
 import py_common.graphql as graphql
 import py_common.log as log
 
-SERVER_IP = "http://localhost:9999"
-# API key (Settings > Configuration > Authentication)
-STASH_API = ""
-SERVER_URL = SERVER_IP + "/graphql"
-
 find_gallery = False
 
 def call_graphql(query, variables=None):

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -1,7 +1,6 @@
 import json
 import sys
 import os
-import requests
 
 import py_common.graphql as graphql
 import py_common.log as log

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -1,0 +1,146 @@
+import json
+import sys
+import os
+import requests
+
+import py_common.graphql as graphql
+import py_common.log as log
+
+SERVER_IP = "http://localhost:9999"
+# API key (Settings > Configuration > Authentication)
+STASH_API = ""
+SERVER_URL = SERVER_IP + "/graphql"
+
+def call_graphql(query, variables=None):
+    headers = {
+        "Accept-Encoding": "gzip, deflate, br",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Connection": "keep-alive",
+        "DNT": "1",
+        "ApiKey": STASH_API
+    }
+    json = {'query': query}
+    if variables is not None:
+        json['variables'] = variables
+    try:
+        response = requests.post(SERVER_URL, json=json, headers=headers)
+        if response.status_code == 200:
+            result = response.json()
+            if result.get("error"):
+                for error in result["error"]["errors"]:
+                    raise Exception("GraphQL error: {}".format(error))
+            if result.get("data"):
+                return result.get("data")
+        elif response.status_code == 401:
+            log.debug("401 returned from callGraphQL")
+            # debug("[ERROR][GraphQL] HTTP Error 401, Unauthorised.")
+            return None
+        else:
+            raise ConnectionError("GraphQL query failed:{} - {}".format(response.status_code, response.content))
+    except Exception as err:
+        log.error(err)
+        # debug(err)
+        return None
+
+def get_gallery_id_by_path(gallery_path):
+    log.debug("get_gallery_by_path gallery_path " + str(gallery_path))
+    query = """
+            query FindGalleries($galleries_filter: GalleryFilterType) {
+              findGalleries(gallery_filter: $galleries_filter filter: {per_page: -1}) {
+                count
+                    galleries {
+                        id
+                    }
+              }
+            }
+            """
+    variables = {"galleries_filter": {"path": {'value': gallery_path, "modifier": "INCLUDES_ALL"}}}
+    result = call_graphql(query, variables)
+    log.debug("get_gallery_by_path callGraphQL result " + str(result))
+    return result['findGalleries']['galleries'][0]['id']
+
+def update_gallery(input):
+    log.debug("gallery input " + str(input))
+    query = """
+                mutation GalleryUpdate($input : GalleryUpdateInput!) {
+                  galleryUpdate(input: $input) {
+                    id
+                    title
+                  }
+                }
+                """
+    variables = {
+        "input": input
+    }
+    result = call_graphql(query, variables)
+    log.debug("updateGallery callGraphQL result " + str(result))
+    return result
+
+def get_id(obj):
+    ids = []
+    for item in obj:
+        ids.append(item['id'])
+    return ids
+
+def find_galleries(scene_id, scene_path):
+    ids = []
+    directory_path = os.path.dirname(scene_path)
+    for (cur, dirs, files) in os.walk(directory_path):
+
+        for file in files:
+            if file.endswith('.zip'):
+                gallery_path = os.path.join(cur, file)
+                id = get_gallery_id_by_path(gallery_path)
+                updateScene_with_gallery(scene_id, id)
+                ids.append(id)
+        break
+    log.debug("find_galleries ids' found " + str(ids))
+    return ids
+
+def updateScene_with_gallery(scene_id, gallery_id):
+    data = {'id': scene_id, 'gallery_ids': [gallery_id]}
+    log.debug("data " + str(data))
+    query = """
+                mutation SceneUpdate($input : SceneUpdateInput!) {
+                  sceneUpdate(input: $input) {
+                    id
+                    title
+                  }
+                }
+                """
+    variables = {
+        "input": data
+    }
+    result = call_graphql(query, variables)
+    log.debug("graphql_updateGallery callGraphQL result " + str(result))
+
+FRAGMENT = json.loads(sys.stdin.read())
+SCENE_ID = FRAGMENT.get("id")
+
+scene = graphql.getScene(SCENE_ID)
+if scene:
+    scene_galleries = scene['galleries']
+    log.debug("scene_galleries " + str(scene_galleries))
+    gallery_ids = []
+    if len(scene_galleries) > 0:
+        for gallery_obj in scene_galleries:
+            gallery_ids.append(gallery_obj['id'])
+    else:
+        # if no galleries are associated see if any gallery zips exist in directory
+        gallery_ids = find_galleries(SCENE_ID, scene["path"])
+    log.debug("gallery_ids " + str(gallery_ids))
+
+    for gallery_id in gallery_ids:
+        gallery_input = {'id': gallery_id,
+                         'url': scene['url'],
+                         'title': scene['title'],
+                         'date': scene["date"],
+                         'details': scene['details'],
+                         'studio_id': scene['studio']['id'],
+                         'tag_ids': get_id(scene['tags']),
+                         'performer_ids': get_id(scene['performers'])}
+        update_gallery(gallery_input)
+
+    print(json.dumps({}))
+

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -14,36 +14,7 @@ SERVER_URL = SERVER_IP + "/graphql"
 find_gallery = False
 
 def call_graphql(query, variables=None):
-    headers = {
-        "Accept-Encoding": "gzip, deflate, br",
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "Connection": "keep-alive",
-        "DNT": "1",
-        "ApiKey": STASH_API
-    }
-    json = {'query': query}
-    if variables is not None:
-        json['variables'] = variables
-    try:
-        response = requests.post(SERVER_URL, json=json, headers=headers)
-        if response.status_code == 200:
-            result = response.json()
-            if result.get("error"):
-                for error in result["error"]["errors"]:
-                    raise Exception("GraphQL error: {}".format(error))
-            if result.get("data"):
-                return result.get("data")
-        elif response.status_code == 401:
-            log.debug("401 returned from callGraphQL")
-            # debug("[ERROR][GraphQL] HTTP Error 401, Unauthorised.")
-            return None
-        else:
-            raise ConnectionError("GraphQL query failed:{} - {}".format(response.status_code, response.content))
-    except Exception as err:
-        log.error(err)
-        # debug(err)
-        return None
+    return graphql.callGraphQL(query, variables)
 
 def get_gallery_id_by_path(gallery_path):
     log.debug("get_gallery_by_path gallery_path " + str(gallery_path))
@@ -76,7 +47,10 @@ def update_gallery(input):
         "input": input
     }
     result = call_graphql(query, variables)
-    log.debug("updateGallery callGraphQL result " + str(result))
+    if result:
+        g_id = result['galleryUpdate'].get('id')
+        g_title = result['galleryUpdate'].get('title')
+        log.info(f"updated Gallery ({g_id}): {g_title}")
     return result
 
 def get_id(obj):

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -11,6 +11,8 @@ SERVER_IP = "http://localhost:9999"
 STASH_API = ""
 SERVER_URL = SERVER_IP + "/graphql"
 
+find_gallery = False
+
 def call_graphql(query, variables=None):
     headers = {
         "Accept-Encoding": "gzip, deflate, br",
@@ -126,7 +128,7 @@ if scene:
     if len(scene_galleries) > 0:
         for gallery_obj in scene_galleries:
             gallery_ids.append(gallery_obj['id'])
-    else:
+    elif find_gallery:
         # if no galleries are associated see if any gallery zips exist in directory
         gallery_ids = find_galleries(SCENE_ID, scene["path"])
     log.debug("gallery_ids " + str(gallery_ids))

--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -134,12 +134,15 @@ if scene:
     log.debug("gallery_ids " + str(gallery_ids))
 
     for gallery_id in gallery_ids:
+        studio = None
+        if scene['studio']:
+            studio = scene['studio']['id']
         gallery_input = {'id': gallery_id,
                          'url': scene['url'],
                          'title': scene['title'],
                          'date': scene["date"],
                          'details': scene['details'],
-                         'studio_id': scene['studio']['id'],
+                         'studio_id': studio,
                          'tag_ids': get_id(scene['tags']),
                          'performer_ids': get_id(scene['performers'])}
         update_gallery(gallery_input)

--- a/scrapers/CopyToGallery.yml
+++ b/scrapers/CopyToGallery.yml
@@ -4,4 +4,4 @@ sceneByFragment:
   script:
     - python3
     - CopyToGallery.py
-# Last Updated February 5, 2022
+# Last Updated February 05, 2022

--- a/scrapers/CopyToGallery.yml
+++ b/scrapers/CopyToGallery.yml
@@ -1,0 +1,7 @@
+name: "Copy to Gallery"
+sceneByFragment:
+  action: script
+  script:
+    - python3
+    - CopyToGallery.py
+# Last Updated February 5, 2022


### PR DESCRIPTION
For anyone looking for an easier way to tag their galleries. Here is a scrapper I wrote to copy scene metadata to associated galleries. If no gallery is associated with the scene, setting `find_gallery` to true will enable the scrapper to look for gallery zips found within the scene's directory and associate the gallery to the scene as well as tag the gallery with the scene's data. Do not enable `find_gallery` if scenes don't exist in their own directory.