### PR TITLE
Fix excogi details (ExploitedX.yml)

### DIFF
--- a/scrapers/ExploitedX.yml
+++ b/scrapers/ExploitedX.yml
@@ -38,4 +38,5 @@ xPathScrapers:
         selector: //div[@class="player-thumb"]//img[contains(@class, "update_thumb")]/@src0_1x
       Details:
         selector: //div[@class="update-info-block"]/h3[text()="Description:"]/following-sibling::text()
-# Last Updated May 10, 2021
+        concat: "\n\n"
+# Last Updated March 02, 2022


### PR DESCRIPTION
Fixes the details for excogi (for example `https://exploitedcollegegirls.com/site/trailers/naomi.html` )
Didnt notice anything with the other sites and the fix doesn't seem to break them.