### PR TITLE
Fix xbvrdb date parsing

### DIFF
--- a/scrapers/xbvrdb.py
+++ b/scrapers/xbvrdb.py
@@ -10,7 +10,7 @@ from os import path
    '''
 def lookup_scene(id):
     c=conn.cursor()
-    c.execute('select title,synopsis,site,cover_url,scene_url,date(release_date) from scenes where id=?',(id,))
+    c.execute('select title,synopsis,site,cover_url,scene_url,date(release_date, "localtime") from scenes where id=?',(id,))
     row=c.fetchone()
     res={}
     res['title']=row[0]

--- a/scrapers/xbvrdb.yml
+++ b/scrapers/xbvrdb.yml
@@ -12,4 +12,4 @@ galleryByFragment:
     - python3
     - xbvrdb.py
     - gallery_query
-# Last Updated November 16, 2021
+# Last Updated March 13, 2022


### PR DESCRIPTION
xvbr database has dates in local time instead of UTC. This causes the dates to be one day off if timezone offset is positive.

Parse release date using localtime to fix the issue.