### PR TITLE
Add option to scrape all performers in Algolia API scenes, not just females

### DIFF
--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -385,11 +385,10 @@ def scraping_json(api_json, url=None):
     # Performer
     perf = []
     for x in api_json.get('actors'):
-        if x.get('gender') == "female":
-            perf.append({
-                "name": x.get('name').strip(),
-                "gender": x.get('gender')
-            })
+        perf.append({
+            "name": x.get('name').strip(),
+            "gender": x.get('gender')
+        })
     scrape['performers'] = perf
 
     # Tags

--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -34,6 +34,8 @@ PRINT_MATCH = True
 STOCKAGE_FILE_APIKEY = "Algolia.ini"
 # Tag you always want in Scraper window.
 FIXED_TAGS = ""
+# Include non female performers
+NON_FEMALE = True
 
 # Setup
 
@@ -385,10 +387,11 @@ def scraping_json(api_json, url=None):
     # Performer
     perf = []
     for x in api_json.get('actors'):
-        perf.append({
-            "name": x.get('name').strip(),
-            "gender": x.get('gender')
-        })
+        if x.get('gender') == "female" or NON_FEMALE:
+            perf.append({
+                "name": x.get('name').strip(),
+                "gender": x.get('gender')
+            })
     scrape['performers'] = perf
 
     # Tags

--- a/scrapers/Algolia_21Naturals.yml
+++ b/scrapers/Algolia_21Naturals.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - 21naturals
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_21Sextreme.yml
+++ b/scrapers/Algolia_21Sextreme.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - 21sextreme
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_21Sextury.yml
+++ b/scrapers/Algolia_21Sextury.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - 21sextury
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_AddictedToGirls.yml
+++ b/scrapers/Algolia_AddictedToGirls.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - addicted2girls
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - girlsway
       - validName
-# Last Updated December 31, 2021
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_AllGirlMassage.yml
+++ b/scrapers/Algolia_AllGirlMassage.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - allgirlmassage
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_Biphoria.yml
+++ b/scrapers/Algolia_Biphoria.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - biphoria
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_BurningAngel.yml
+++ b/scrapers/Algolia_BurningAngel.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - burningangel
       - validName
-# Last Updated January 23, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_ClubInfernoDungeon.yml
+++ b/scrapers/Algolia_ClubInfernoDungeon.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - clubinfernodungeon
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_DevilsFilm.yml
+++ b/scrapers/Algolia_DevilsFilm.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - devilsfilm
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_FantasyMassage.yml
+++ b/scrapers/Algolia_FantasyMassage.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - fantasymassage
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_Girlsway.yml
+++ b/scrapers/Algolia_Girlsway.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - girlsway
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_PureTaboo.yml
+++ b/scrapers/Algolia_PureTaboo.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - puretaboo
       - validName
-# Last Updated January 25, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_RoccoSiffredi.yml
+++ b/scrapers/Algolia_RoccoSiffredi.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - roccosiffredi
       - validName
-# Last Updated January 18, 2022
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_disruptivefilms.yml
+++ b/scrapers/Algolia_disruptivefilms.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - disruptivefilms
       - validName
-# Last Updated December 31, 2021
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_filthykings.yml
+++ b/scrapers/Algolia_filthykings.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - filthykings
       - validName
-# Last Updated November 29, 2021
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_mypervyfamily.yml
+++ b/scrapers/Algolia_mypervyfamily.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - mypervyfamily
       - validName
-# Last Updated December 31, 2021
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_touchmywife.yml
+++ b/scrapers/Algolia_touchmywife.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - touchmywife
       - validName
-# Last Updated December 31, 2021
+# Last Updated March 23, 2022

--- a/scrapers/Algolia_zerotolerancefilms.yml
+++ b/scrapers/Algolia_zerotolerancefilms.yml
@@ -27,4 +27,4 @@ sceneByQueryFragment:
       - Algolia.py
       - zerotolerancefilms
       - validName
-# Last Updated December 31, 2021
+# Last Updated March 23, 2022


### PR DESCRIPTION
I couldn't find an explanation in https://github.com/stashapp/CommunityScrapers/pull/793 nor the git history of Algolia.py as to why this is behaving this way. On the few PureTaboo pages I tested against, it seemed capable of retrieving the male performers just fine.

As far as updating dates, should I update all of the `Algolia_*.yml` configs to reflect this change, since they all depend on this file? Alternatively/additionally, it appears [the Scraper Checker Plugin](https://github.com/stashapp/CommunityScripts/blob/main/plugins/GHScraper_Checker/GHScraper_Checker.py) will only fetch .yml files, so if the main reason we'd want to update the dates is for that script, changing those dates would seemingly just cause unnecessary fetches.