### PR TITLE
Update tag and performer parsing for VNAGirls site

### DIFF
--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -45,13 +45,13 @@ xPathScrapers:
       Performers:
         Name:
           selector: //div[@class='customcontent']/h3/text()
-          split: ","
-          postProcess:
+          postProcess: &pp
             - replace:
                 - regex: \x{0020}|\x{00A0} # unicode SP, NBSP
                   with: " "
                 - regex: '\s*,\s*'
                   with: ","
+          split: ","
       Title:
         selector: //div[@class='customcontent']/h1/text()
       Details:
@@ -59,13 +59,8 @@ xPathScrapers:
       Tags:
         Name:
           selector: //div[@class='customcontent']/h4/text()
+          postProcess: *pp
           split: ","
-          postProcess:
-            - replace:
-                - regex: \x{0020}|\x{00A0} # unicode SP, NBSP
-                  with: " "
-                - regex: '\s*,\s*'
-                  with: ","
       Studio:
         Name:
           selector: //p[@class="copyright"]

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -53,7 +53,7 @@ xPathScrapers:
       Tags:
         Name:
           selector: //div[@class='customcontent']/h4/text()
-          split: ", "
+          split: ","
       Studio:
         Name:
           selector: //p[@class="copyright"]
@@ -75,4 +75,4 @@ xPathScrapers:
               - regex: (\d+)(st|nd|rd|th)
                 with: "$1"
           - parseDate: January 2 2006
-# Last Updated July 18, 2021
+# Last Updated March 25, 2021

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -82,4 +82,4 @@ xPathScrapers:
               - regex: (\d+)(st|nd|rd|th)
                 with: "$1"
           - parseDate: January 2 2006
-# Last Updated March 25, 2021
+# Last Updated March 25, 2022

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -46,6 +46,12 @@ xPathScrapers:
         Name:
           selector: //div[@class='customcontent']/h3/text()
           split: ","
+          postProcess:
+            - replace:
+                - regex: \x{0020}|\x{00A0} # unicode SP, NBSP
+                  with: " "
+                - regex: '\s*,\s*'
+                  with: ","
       Title:
         selector: //div[@class='customcontent']/h1/text()
       Details:
@@ -54,6 +60,12 @@ xPathScrapers:
         Name:
           selector: //div[@class='customcontent']/h4/text()
           split: ","
+          postProcess:
+            - replace:
+                - regex: \x{0020}|\x{00A0} # unicode SP, NBSP
+                  with: " "
+                - regex: '\s*,\s*'
+                  with: ","
       Studio:
         Name:
           selector: //p[@class="copyright"]


### PR DESCRIPTION
Spot-checked a few linked sites to verify they have seemingly migrated to a `tag1,tag2` format vs `tag1, tag2`.

Also, something I spent a lot of time debugging but ultimately couldn't solve is the Performer Name parsing. It appears common/normal for these sites to have the performer names formatted as `First1 Last1,&nbsp;First2 Last2`, which, with the split set to `","`, causes them to get parsed as:

* `First1 Last1`
* `&nbsp;First2 Last2`

Nothing I tried (`normalize-space`, trying to use regex to rip out `nbsp;`s) worked. Is there something I'm missing, or is the inconsistent formatting of the site too much for the relatively strict XPath (and/or Stash's use of it) to play nice with?