### PR TITLE
Update Model Media US scraper to support /trailers/ urls

### DIFF
--- a/scrapers/ModelMediaUS.yml
+++ b/scrapers/ModelMediaUS.yml
@@ -3,6 +3,7 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - modelmediaus.com/videos/
+      - modelmediaus.com/trailers/
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
@@ -24,4 +25,4 @@ xPathScrapers:
           - subScraper:
               selector: //stream/@poster
 
-# Last Updated December 07, 2021
+# Last Updated March 27, 2022


### PR DESCRIPTION
I couldn't find any active /videos/ urls still around but their site's real slow so I didn't really give myself a _ton_ of time to poke around. Figured there's little harm in keeping the /videos/ path around.