### PR TITLE
Strip commas from tags

### DIFF
--- a/scrapers/RealityKingsOL.yml
+++ b/scrapers/RealityKingsOL.yml
@@ -30,7 +30,12 @@ xPathScrapers:
           - parseDate: January 2, 2006
       Details: //span/div[text()="Description:"]/following-sibling::text()
       Tags:
-        Name: //span[div[text()='Categories:']]/a/text()[1]
+        Name:
+          selector: //span[div[text()='Categories:']]/a/text()[1]
+          postProcess:
+            - replace:
+                - regex: \,
+                  with: ""
       Performers:
         Name: //h1/following-sibling::div//a[contains(@href,"/model")]/text()
       Studio:


### PR DESCRIPTION
lesbea & bellesa (and perhaps others) are including trailing commas in the content of the HTML element for the tag - so you end up with a parsed tag like "Socks,". This strips them out and hopefully shouldn't be destructive for any sites that aren't doing this.