### PR TITLE
Strip commas from tags

### DIFF
--- a/scrapers/RealityKingsOL.yml
+++ b/scrapers/RealityKingsOL.yml
@@ -30,7 +30,12 @@ xPathScrapers:
           - parseDate: January 2, 2006
       Details: //span/div[text()="Description:"]/following-sibling::text()
       Tags:
-        Name: //span[div[text()='Categories:']]/a/text()[1]
+        Name:
+          selector: //span[div[text()='Categories:']]/a/text()[1]
+          postProcess:
+            - replace:
+                - regex: \,
+                  with: ""
       Performers:
         Name: //h1/following-sibling::div//a[contains(@href,"/model")]/text()
       Studio:

--- a/scrapers/RealityKingsOL.yml
+++ b/scrapers/RealityKingsOL.yml
@@ -34,7 +34,7 @@ xPathScrapers:
           selector: //span[div[text()='Categories:']]/a/text()[1]
           postProcess:
             - replace:
-                - regex: \,
+                - regex: ^\s*\,|\,\s*$
                   with: ""
       Performers:
         Name: //h1/following-sibling::div//a[contains(@href,"/model")]/text()
@@ -51,4 +51,4 @@ xPathScrapers:
           - replace:
               - regex: '.*"thumbnailUrl": "([^"]+)".*'
                 with: $1
-# Last Updated April 29, 2022
+# Last Updated May 07, 2022

--- a/scrapers/RealityKingsOL.yml
+++ b/scrapers/RealityKingsOL.yml
@@ -51,4 +51,4 @@ xPathScrapers:
           - replace:
               - regex: '.*"thumbnailUrl": "([^"]+)".*'
                 with: $1
-# Last Updated December 08, 2021
+# Last Updated April 29, 2022


### PR DESCRIPTION
lesbea & bellesa (and perhaps others) are including trailing commas in the content of the HTML element for the tag - so you end up with a parsed tag like "Socks,". This strips them out and hopefully shouldn't be destructive for any sites that aren't doing this.