### PR TITLE
[Python] update MindGeekAPI to use log.py

### DIFF
--- a/scrapers/MindGeekAPI.yml
+++ b/scrapers/MindGeekAPI.yml
@@ -18,4 +18,4 @@ sceneByQueryFragment:
       - MindGeekAPI.py
       - validName
 
-# Last Updated November 02, 2021
+# Last Updated June 12, 2022


### PR DESCRIPTION
updates the MindGeekAPI script to use log.py so that not all log items are received as errors like:

![image](https://user-images.githubusercontent.com/1358708/173150877-20c5324a-aa81-46d4-b18f-e97dabb18625.png)
