### PR TITLE
xHamster: fix studio, tags and performers extracting

### DIFF
--- a/scrapers/Xhamster.yml
+++ b/scrapers/Xhamster.yml
@@ -21,12 +21,12 @@ xPathScrapers:
       Image: //link[@as="image"]/@href
       Studio:
         Name:
-          selector: $player/ul/li/a[contains(@href,"/channels/")]
+          selector: $player/nav/ul/li/a[contains(@href,"/channels/")]
       Tags:
         Name:
-          selector: $player/ul/li/a[contains(@href,"/categories/") or contains(@href,"/tags/")]
+          selector: $player/nav/ul/li/a[contains(@href,"/categories/") or contains(@href,"/tags/")]
       Performers:
         Name:
-          selector: $player/ul/li/a[contains(@href,"/pornstars/")]
+          selector: $player/nav/ul/li/a[contains(@href,"/pornstars/")]
 
-# Last Updated July 29, 2020
+# Last Updated June 28, 2022


### PR DESCRIPTION
xHamster added an extra `<nav>` element around the information about channel, performers and tags.