### PR TITLE
Tweak data18 movie duration selector/pp

### DIFF
--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -78,4 +78,4 @@ xPathScrapers:
                 with:
       FrontImage: //a[@id='enlargecover']/@href
       BackImage: //a[text()='+Back']/@href
-# Last Updated june 30, 2022
+# Last Updated June 30, 2022

--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -51,11 +51,13 @@ xPathScrapers:
     movie:
       Name: //div[@id="topmedia"]//a/text()
       Duration:
-        selector: $movieInfo//b[contains(text(),"Length")]/following-sibling::text()
+        selector: $movieInfo//b[contains(text(),"Length")]/following-sibling::span|$movieInfo//b[contains(text(),"Length")]/following-sibling::text()
         postProcess:
           - replace:
-              - regex: '.+\s(\d+)\s?min.+$'
-                with: $1:00
+              - regex: ^\[(.+)\]$ # handle movies with proper [xx:xx:xx] duration
+                with: $1
+              - regex: ^[^\d]*(\d+)\s*min.* # handle movies with only xx mins duration
+                with: "$1:00"
       Date:
         selector: $movieInfo//span[contains(text(), "Release date")]/text()
         postProcess:
@@ -72,8 +74,8 @@ xPathScrapers:
         concat: " "
         postProcess:
           - replace:
-              - regex: '^Description -\s*"'
+              - regex: '^Description\s*-\s*'
                 with:
       FrontImage: //a[@id='enlargecover']/@href
       BackImage: //a[text()='+Back']/@href
-# Last Updated March 23, 2022
+# Last Updated june 30, 2022


### PR DESCRIPTION
Tweaks the duration selector mentioned in #123 and fixes a typo in the details pp.
For movies that have a `proper` duration that is used and we then fallback to the plain  text to catch cases like `120 min`
Sample movies `https://www.data18.com/movies/1225101-raw-43` , `https://www.data18.com/movies/1231098-it-takes-three-6` mentioned in #123 work fine. Problematic movies `https://www.data18.com/movies/1239543-naughty-little-sister-6` also seem to work ok. If there is another case please mention a URL or the format used.  