### PR TITLE
Pornhub - scrape description when available

### DIFF
--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -136,5 +136,10 @@ xPathScrapers:
       Studio:
         Name: $studio
         URL: $studio/@href
-      Details: //div[@class="video-info-row"][1]/text()
+      Details:
+        selector: //div[@class="video-info-row"][1]/text()
+        postProcess:
+          - replace:
+              - regex: "Description: (.*)"
+                with: $1
 # Last Updated July 08, 2022

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -136,4 +136,5 @@ xPathScrapers:
       Studio:
         Name: $studio
         URL: $studio/@href
-# Last Updated July 04, 2022
+      Details: //div[@class="video-info-row"][1]/text()
+# Last Updated July 08, 2022

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -137,7 +137,7 @@ xPathScrapers:
         Name: $studio
         URL: $studio/@href
       Details:
-        selector: //div[@class="video-info-row"][1]/text()
+        selector: //div[@class="video-info-row"][1]/text()[starts-with(normalize-space(.),"Description:")]
         postProcess:
           - replace:
               - regex: "Description: (.*)"


### PR DESCRIPTION
As discussed on Discord, the latest Pornhub update removed the Details field because it's all boilerplate.
Turn out, this is only true for **most** scenes.

This update attempts to add scraping of description when it's available.

Used this scene for reference, could not find other examples.
`https://www.pornhub.com/view_video.php?viewkey=ph5acbe62b84b39`