### PR TITLE
ensure descriptions keep their paragraph structure

### DIFF
--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -20,7 +20,9 @@ xPathScrapers:
       $details: //div[@class="video-details"]
     scene:
       Title: //h2/@title
-      Details: //meta[@name="description"]/@content
+      Details:
+        selector: //div[@class="desc-text"]/span/text()
+        concat: "\n\n"
       # Only partial dates provides, which would currently be made as 0000-01-01
       # Date:
       #   selector: //div[@class="mb-1"]/span[2]/text()

--- a/scrapers/ManyVids.yml
+++ b/scrapers/ManyVids.yml
@@ -147,4 +147,4 @@ xPathScrapers:
 # Required for parsing sceneScraper tags
 driver:
   useCDP: true
-# Last Updated January 27, 2022
+# Last Updated July 23, 2022


### PR DESCRIPTION
Was running into an issue with scenes like:
- https://www.manyvids.com/Video/306013/Fuck-Mommys-Ass/
- https://www.manyvids.com/Video/81196/deepthroating-university-police/

The previous selector pulled from the metadata property which would drop any `<br>` tags. This now pulls from the actual description section on the page. and concats the paragraphs with a double new line to preserve the original format.

Not many ManyVids creators use multiple paragraphs so it makes sense that this flew under the radar before.