### PR TITLE
ClubDom and SubbyHubby name scrapers

### DIFF
--- a/scrapers/ClubDom.yml
+++ b/scrapers/ClubDom.yml
@@ -1,16 +1,16 @@
-name: SubbyHubby
+name: ClubDom
 sceneByURL:
   - action: scrapeXPath
     url:
-      - subbyhubby.com/tour
+      - clubdom.com/tour
     scraper: sceneScraper
   - action: scrapeXPath
     url:
-      - subbyhubby.com/vod
+      - clubdom.com/vod
     scraper: vodScraper
 sceneByName:
   action: scrapeXPath
-  queryURL: https://www.subbyhubby.com/vod/search.php?query={}
+  queryURL: https://www.clubdom.com/vod/search.php?query={}
   scraper: vodSearch
 sceneByQueryFragment:
   action: scrapeXPath
@@ -39,7 +39,7 @@ xPathScrapers:
                 with: "https:"
       Studio:
         Name:
-          fixed: Subby Hubby
+          fixed: Club Dom
   vodScraper:
     scene:
       Title:
@@ -63,8 +63,7 @@ xPathScrapers:
                 with: $1$2
       Studio:
         Name:
-          fixed: Subby Hubby
-
+          fixed: Club Dom
   vodSearch:
     common:
       $update-details: //div[@class="update_details"]

--- a/scrapers/ClubDom.yml
+++ b/scrapers/ClubDom.yml
@@ -69,11 +69,11 @@ xPathScrapers:
       $update-details: //div[@class="update_details"]
     scene:
       Title:
-        selector: //div[@class="update_details"]/a[2]/text()
+        selector: $update-details/a[2]/text()
       URL:
-        selector: //div[@class="update_details"]/a[2]/@href
+        selector: $update-details/a[2]/@href
       Image:
-        selector: //div[@class="update_details"]/a[1]/img/@src
+        selector: $update-details/a[1]/img/@src
         postProcess:
           - replace:
               - regex: ^

--- a/scrapers/SubbyHubby.yml
+++ b/scrapers/SubbyHubby.yml
@@ -70,11 +70,11 @@ xPathScrapers:
       $update-details: //div[@class="update_details"]
     scene:
       Title:
-        selector: //div[@class="update_details"]/a[2]/text()
+        selector: $update-details/a[2]/text()
       URL:
-        selector: //div[@class="update_details"]/a[2]/@href
+        selector: $update-details/a[2]/@href
       Image:
-        selector: //div[@class="update_details"]/a[1]/img/@src
+        selector: $update-details/a[1]/img/@src
         postProcess:
           - replace:
               - regex: ^


### PR DESCRIPTION
Adds name search scraping for ClubDom.com and SubbyHubby.com native site search.

Previously the ClubDom and SubbyHubby scrapers were in one - which makes sense given they duplicate a lot and are part of the same network. However they have different name search queries, so in order to search either by name, they have to be split out into different scrapers.