### PR TITLE
Correctly handle missing scene/movie dates for IAFD scraper

### DIFF
--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -572,7 +572,6 @@ def scene_from_tree(tree):
             s.date = datetime.datetime.strptime(s.date, iafd_date_scene).strftime(stash_date)
         except:
             s.date = None
-            pass
 
     scene_details = tree.xpath('//div[@id="synopsis"]/div[@class="padded-panel"]//text()')
     s.details = s.set_value(scene_details)

--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -609,7 +609,6 @@ def movie_from_tree(tree):
             m.date = datetime.datetime.strptime(m.date, iafd_date_scene).strftime(stash_date)
         except:
             m.date = None
-            pass
 
     movie_aliases = tree.xpath('//div[@class="col-sm-12"]/dl/dd//text()')
     m.aliases = m.set_concat_value(", ", movie_aliases)

--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -571,6 +571,7 @@ def scene_from_tree(tree):
         try:
             s.date = datetime.datetime.strptime(s.date, iafd_date_scene).strftime(stash_date)
         except:
+            s.date = None
             pass
 
     scene_details = tree.xpath('//div[@id="synopsis"]/div[@class="padded-panel"]//text()')
@@ -608,6 +609,7 @@ def movie_from_tree(tree):
         try:
             m.date = datetime.datetime.strptime(m.date, iafd_date_scene).strftime(stash_date)
         except:
+            s.date = None
             pass
 
     movie_aliases = tree.xpath('//div[@class="col-sm-12"]/dl/dd//text()')

--- a/scrapers/IAFD.py
+++ b/scrapers/IAFD.py
@@ -609,7 +609,7 @@ def movie_from_tree(tree):
         try:
             m.date = datetime.datetime.strptime(m.date, iafd_date_scene).strftime(stash_date)
         except:
-            s.date = None
+            m.date = None
             pass
 
     movie_aliases = tree.xpath('//div[@class="col-sm-12"]/dl/dd//text()')

--- a/scrapers/IAFD.yml
+++ b/scrapers/IAFD.yml
@@ -28,4 +28,4 @@ movieByURL:
       - python3
       - IAFD.py
       - movie
-# Last Updated June 02, 2022
+# Last Updated August 10, 2022


### PR DESCRIPTION
When a scene in IAFD has no release date listed, the field will have the value `No Data`. When that field is scraped, the scraper tries to parse the string as a date value and then convert it to a Stash date format. That conversion fails when the value is `No Data`, but then the scraper just leaves the `date` field as `No Data` which Stash then rejects when you try to save the scene.

This change tweaks the logic, so if parsing of the scene's release date fails, we set the scene/movie date back to `None` so that Stash doesn't try to update it to an invalid value.