### PR TITLE
Update SexLikeReal.yml

### DIFF
--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -7,12 +7,14 @@ sceneByURL:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: &titleDef
-        selector: //div[@id="tabs-photos"]//a/img/@alt
+      Title: 
+        selector: //script[@type="text/javascript"][contains(.,"videoData:")]/text()
         postProcess:
             - replace:
-                - regex:  " VR porn$"
-                  with: ""
+                - regex:  '.+videoData:\s{[^{]+title":"([^"]+)",.+'
+                  with: $1
+                - regex: '\\u2019'
+                  with: "’"
       Date: //time/@datetime
       Details: //div[@data-qa="scene-about-tab-text"]
       Tags:

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -14,9 +14,7 @@ xPathScrapers:
                 - regex:  " VR porn$"
                   with: ""
       Date: //time/@datetime
-      Details: &detailsSel
-        selector: //div[@data-qa="scene-about-tab-text"]//text()
-        concat: " "
+      Details: //div[@data-qa="scene-about-tab-text"]
       Tags:
         Name: //meta[@property="video:tag"]/@content
       Performers:

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -22,6 +22,17 @@ xPathScrapers:
       Performers:
         Name: //meta[@property="video:actor"]/@content
       Studio:
-        Name: //a[contains(@href,"/studios/")]/div[last()]/text()
+        Name: 
+          selector: //a[contains(@href,"/studios/")]/div[last()]/text()
+          postProcess:
+              - map:
+                  LustReality: "Lust Reality"
+                  DDFNetworkVR: "DDF Network VR"
+                  POVcentralVR: "POV Central"
+                  RealHotVR: "Real Hot VR"
+                  WankitnowVR: "Wank It Now VR"
+                  VirtualXPorn: "Virtual X Porn"
+                  SinsVR: "XSinsVR"
+                  LethalHardcoreVR: "Lethal Hardcore VR"
       Image: //div[contains(@class,"splash-screen")]/img/@src
 # Last Updated August 29, 2022

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -7,9 +7,16 @@ sceneByURL:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: //h1/text()
+      Title: &titleDef
+        selector: //div[@id="tabs-photos"]//a/img/@alt
+        postProcess:
+            - replace:
+                - regex:  " VR porn$"
+                  with: ""
       Date: //time/@datetime
-      Details: //div[@id="modalSceneAbout"]//comment()[contains(.,'description')]/following-sibling::div
+      Details: &detailsSel
+        selector: //div[@data-qa="scene-about-tab-text"]//text()
+        concat: " "
       Tags:
         Name: //meta[@property="video:tag"]/@content
       Performers:
@@ -17,5 +24,4 @@ xPathScrapers:
       Studio:
         Name: //a[contains(@href,"/studios/")]/div[last()]/text()
       Image: //div[contains(@class,"splash-screen")]/img/@src
-
-# Last Updated March 21, 2021
+# Last Updated August 29, 2022

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -7,14 +7,14 @@ sceneByURL:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: 
+      Title:
         selector: //script[@type="text/javascript"][contains(.,"videoData:")]/text()
         postProcess:
-            - replace:
-                - regex:  '.+videoData:\s{[^{]+title":"([^"]+)",.+'
-                  with: $1
-                - regex: '\\u2019'
-                  with: "’"
+          - replace:
+              - regex: '.+videoData:\s{[^{]+title":"([^"]+)",.+'
+                with: $1
+              - regex: '\\u2019'
+                with: "’"
       Date: //time/@datetime
       Details: //div[@data-qa="scene-about-tab-text"]
       Tags:
@@ -22,17 +22,17 @@ xPathScrapers:
       Performers:
         Name: //meta[@property="video:actor"]/@content
       Studio:
-        Name: 
+        Name:
           selector: //a[contains(@href,"/studios/")]/div[last()]/text()
           postProcess:
-              - map:
-                  LustReality: "Lust Reality"
-                  DDFNetworkVR: "DDF Network VR"
-                  POVcentralVR: "POV Central"
-                  RealHotVR: "Real Hot VR"
-                  WankitnowVR: "Wank It Now VR"
-                  VirtualXPorn: "Virtual X Porn"
-                  SinsVR: "XSinsVR"
-                  LethalHardcoreVR: "Lethal Hardcore VR"
+            - map:
+                DDFNetworkVR: "DDF Network VR"
+                LethalHardcoreVR: "Lethal Hardcore VR"
+                LustReality: "Lust Reality"
+                POVcentralVR: "POV Central"
+                RealHotVR: "Real Hot VR"
+                SinsVR: "XSinsVR"
+                VirtualXPorn: "Virtual X Porn"
+                WankitnowVR: "Wank It Now VR"
       Image: //div[contains(@class,"splash-screen")]/img/@src
 # Last Updated August 29, 2022


### PR DESCRIPTION
Fix following two issues:
Description not beeing scraped
The name convention (The formerly scraped name - had <i>long name</i> which was not corresponding to correct titles (eg. titles checkable from other studios main pages. The new way scrapes the information from the image, where is " VR porn" additional in the end, but this is strippable.

Would be grateful for feedback & review - tested locally - should cover up the splitted description.