### PR TITLE
Update graphql.py

### DIFF
--- a/scrapers/py_common/graphql.py
+++ b/scrapers/py_common/graphql.py
@@ -277,7 +277,6 @@ def getScene(scene_id):
             stream
             webp
             vtt
-            chapters_vtt
             sprite
             funscript
         }
@@ -538,7 +537,6 @@ def getSceneByPerformerId(performer_id):
             stream
             webp
             vtt
-            chapters_vtt
             sprite
             funscript
             interactive_heatmap


### PR DESCRIPTION
the chapters_vtt field is no longer in the paths data for scenes so any call to get scenes now fails. We should remove this from the request as this is breaking any scrapers that use this python library to query stash such as the onlyfans scraper.