### PR TITLE
Update SpankBang scraper

### DIFF
--- a/scrapers/SpankBang.yml
+++ b/scrapers/SpankBang.yml
@@ -4,6 +4,18 @@ sceneByURL:
     url:
       - spankbang.com
     scraper: sceneScraper
+
+sceneByFragment:
+  action: scrapeXPath
+  scraper: sceneScraper
+  queryURL: https://spankbang.com/{filename}/video/
+  queryURLReplace:
+    filename: # expects an id in square brackets before extension, as saved by yt-dlp by default
+      - regex: '.*\[([0-9a-z]{4,})\]\.[^\.]+$'
+        with: $1
+      - regex: .*\.[^\.]+$ # if no id is found in the filename
+        with: # clear the filename so that it doesn't leak
+
 xPathScrapers:
   sceneScraper:
     scene:

--- a/scrapers/SpankBang.yml
+++ b/scrapers/SpankBang.yml
@@ -8,14 +8,19 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //div[@class='left']/h1/@title
-      Details: //meta[@name='description']/@content
+      Details: //section[@class="details"]/div/p[2]/text()
       Image: //div[@class='play_cover']/img/@src
       Studio:
         Name: //li[@class='us']/a[@class='ul'][contains(@href,'channel')]/text()
       Tags:
-        Name: //div[@class='ent']/a[@href[contains(.,'tag')]]/text()|//li[@class='p']/text()
-      Performers:
-        Name: //div[@class='ent']/a[@href[contains(.,'pornstar')]]/text()|//div[@class='left']/h1/a/text()
-      URL: //link[rel='canonical']/@href
+        Name: //li[@class='p']/text()|//div[@class='searches']//a[not(@class='expand')]/text()
+      URL: //link[rel='canonical']/@href|//meta[@property='og:url']/@content
+      Date:
+        selector: //script[@type='application/ld+json'][contains(text(),'uploadDate')]/text()
+        postProcess:
+          - replace:
+              - regex: '.+\"uploadDate\"\: \"([0-9\-:T]+)\".+'
+                with: $1
+          - parseDate: '2006-01-02T15:04:05'
 
-# Last Updated October 06, 2020
+# Last Updated November 20, 2022


### PR DESCRIPTION
### Update scene properties

- no performers found on the page anymore;
- meta description is bogus, actual details rarely but exist;
- ~~added date (independent from another PR)~~ merged with master to account for another PR;
- tags - previously existed markers plus searches that function as tags.

### Add sceneByFragment

SpankBang scene id is a sequence of lowercase letters and digits,
no less than 4 characters long afaik.

yt-dlp save files in the format
`<title> [<id>].<ext>` by default.
This PR relies on this format to recover the id.

Example file names:
`Hell Is Where The Party Is [2bgur].mp4`
`Keep on Cumming [60my5].mp4`