### PR TITLE
Add scene scraper for (ecchi.)iwara.tv

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -630,6 +630,7 @@ italianshotclub.com|MVG.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 itscleolive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 itspov.com|ItsPOV.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 iwantclips.com|IWantClips.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|CDP|-
+iwara.tv|Iwara.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jacquieetmicheltv.net|JacquieEtMichelTV.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 jamesdeen.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 janafox.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Iwara.yml
+++ b/scrapers/Iwara.yml
@@ -1,0 +1,92 @@
+name: "Iwara"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - iwara.tv
+    scraper: sceneScraper
+
+sceneByFragment:
+  action: scrapeXPath
+  scraper: sceneScraper
+  queryURL: https://ecchi.iwara.tv/videos/{filename} # also works for sfw videos
+  queryURLReplace:
+    filename: # expects the default filename format when saved from Iwara - <some digits>_<id>_<resolution>.<ext>
+      - regex: '.*_([0-9a-zA-Z]{12,})_.*'
+        with: $1
+      - regex: .*\.[^\.]+$ # if no id is found in the filename
+        with: # clear the filename so that it doesn't leak
+
+sceneByName:
+  action: scrapeXPath
+  queryURL: https://ecchi.iwara.tv/search?query={}
+  scraper: sceneSearch
+sceneByQueryFragment:
+  action: scrapeXPath
+  queryURL: "{url}"
+  scraper: sceneScraper
+
+xPathScrapers:
+  sceneSearch:
+    common:
+      $searchItem: //div[contains(@class,"view-search")]//div[contains(@class,"views-row")]//div[contains(@class,"node-video")]
+    scene:
+      Title: $searchItem//h3[@class="title"]/a/text()
+      URL:
+        selector: $searchItem//h3[@class="title"]/a/@href
+        postProcess:
+          - replace:
+              - regex: '^'
+                with: 'https://ecchi.iwara.tv'
+      Image:
+        selector: $searchItem//img/@src
+        postProcess:
+          - replace:
+              - regex: '^//'
+                with: 'https://'
+      Studio:
+        Name: $searchItem//a[@class="username"]/text()
+        URL:
+          selector: $searchItem//a[@class="username"]/@href
+          postProcess:
+            - replace:
+                - regex: '^'
+                  with: 'https://ecchi.iwara.tv'
+      Date:
+        selector: $searchItem//div[@class="submitted"]
+        postProcess:
+          - replace:
+              - regex: '.+(\d{4}-\d{2}-\d{2}).+'
+                with: $1
+          - parseDate: '2006-01-02'
+  sceneScraper:
+    common:
+      $infoNode: //div[@class="node-info"]
+    scene:
+      URL: //link[@rel="canonical"][contains(@href,"http")]/@href
+      Title: $infoNode//h1/text()
+      Details: $infoNode/div[contains(@class,"field-name-body")]//p
+      Image:
+        selector: //video/@poster
+        postProcess:
+          - replace:
+              - regex: '^'
+                with: 'https:'
+      Tags:
+        Name: $infoNode/div[contains(@class,"field-name-field-categories")]//a/text()
+      Studio:
+        Name: $infoNode//a[@class="username"]/text()
+        URL:
+          selector: $infoNode//a[@class="username"]/@href
+          postProcess:
+            - replace:
+                - regex: '^'
+                  with: 'https://ecchi.iwara.tv'
+      Date:
+        selector: $infoNode/div[@class="submitted"]
+        postProcess:
+          - replace:
+              - regex: '.+(\d{4}-\d{2}-\d{2}).+'
+                with: $1
+          - parseDate: '2006-01-02'
+
+# Last Updated November 25, 2022

--- a/scrapers/Iwara.yml
+++ b/scrapers/Iwara.yml
@@ -64,7 +64,9 @@ xPathScrapers:
     scene:
       URL: //link[@rel="canonical"][contains(@href,"http")]/@href
       Title: $infoNode//h1/text()
-      Details: $infoNode/div[contains(@class,"field-name-body")]/div/div
+      Details:
+        selector: $infoNode/div[contains(@class,"field-name-body")]//p//*/text()
+        concat: "\n"
       Image:
         selector: //video/@poster
         postProcess:

--- a/scrapers/Iwara.yml
+++ b/scrapers/Iwara.yml
@@ -18,7 +18,7 @@ sceneByFragment:
 
 sceneByName:
   action: scrapeXPath
-  queryURL: https://ecchi.iwara.tv/search?query={}
+  queryURL: https://ecchi.iwara.tv/search?f%5B0%5D=type%3Avideo&query={}
   scraper: sceneSearch
 sceneByQueryFragment:
   action: scrapeXPath

--- a/scrapers/Iwara.yml
+++ b/scrapers/Iwara.yml
@@ -64,7 +64,7 @@ xPathScrapers:
     scene:
       URL: //link[@rel="canonical"][contains(@href,"http")]/@href
       Title: $infoNode//h1/text()
-      Details: $infoNode/div[contains(@class,"field-name-body")]//p
+      Details: $infoNode/div[contains(@class,"field-name-body")]/div/div
       Image:
         selector: //video/@poster
         postProcess:

--- a/scrapers/Iwara.yml
+++ b/scrapers/Iwara.yml
@@ -11,7 +11,7 @@ sceneByFragment:
   queryURL: https://ecchi.iwara.tv/videos/{filename} # also works for sfw videos
   queryURLReplace:
     filename: # expects the default filename format when saved from Iwara - <some digits>_<id>_<resolution>.<ext>
-      - regex: '.*_([0-9a-zA-Z]{12,})_.*'
+      - regex: ".*_([0-9a-zA-Z]{12,})_.*"
         with: $1
       - regex: .*\.[^\.]+$ # if no id is found in the filename
         with: # clear the filename so that it doesn't leak
@@ -35,29 +35,29 @@ xPathScrapers:
         selector: $searchItem//h3[@class="title"]/a/@href
         postProcess:
           - replace:
-              - regex: '^'
-                with: 'https://ecchi.iwara.tv'
+              - regex: "^"
+                with: "https://ecchi.iwara.tv"
       Image:
         selector: $searchItem//img/@src
         postProcess:
           - replace:
-              - regex: '^//'
-                with: 'https://'
+              - regex: "^//"
+                with: "https://"
       Studio:
         Name: $searchItem//a[@class="username"]/text()
         URL:
           selector: $searchItem//a[@class="username"]/@href
           postProcess:
             - replace:
-                - regex: '^'
-                  with: 'https://ecchi.iwara.tv'
+                - regex: "^"
+                  with: "https://ecchi.iwara.tv"
       Date:
         selector: $searchItem//div[@class="submitted"]
         postProcess:
           - replace:
               - regex: '.+(\d{4}-\d{2}-\d{2}).+'
                 with: $1
-          - parseDate: '2006-01-02'
+          - parseDate: "2006-01-02"
   sceneScraper:
     common:
       $infoNode: //div[@class="node-info"]
@@ -71,8 +71,8 @@ xPathScrapers:
         selector: //video/@poster
         postProcess:
           - replace:
-              - regex: '^'
-                with: 'https:'
+              - regex: "^"
+                with: "https:"
       Tags:
         Name: $infoNode/div[contains(@class,"field-name-field-categories")]//a/text()
       Studio:
@@ -81,14 +81,13 @@ xPathScrapers:
           selector: $infoNode//a[@class="username"]/@href
           postProcess:
             - replace:
-                - regex: '^'
-                  with: 'https://ecchi.iwara.tv'
+                - regex: "^"
+                  with: "https://ecchi.iwara.tv"
       Date:
         selector: $infoNode/div[@class="submitted"]
         postProcess:
           - replace:
               - regex: '.+(\d{4}-\d{2}-\d{2}).+'
                 with: $1
-          - parseDate: '2006-01-02'
-
+          - parseDate: "2006-01-02"
 # Last Updated November 25, 2022


### PR DESCRIPTION
sceneByFragment relies on the default filename format from Iwara:
`<unix_timestamp>_<id>_<resolution>.<ext>`

Example file names:
`1543383579_G5mzkTeE5i7AJoe8_Source.mp4`
`1550374900_z028Qt4K7GIkyYbAD_540.mp4`