### PR TITLE
Add scrapping by official filename to a few scrappers

### DIFF
--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -84,7 +84,7 @@ xPathScrapers:
               - regex: '^(.+)-(\d+)/?$'
                 with: $2
               - regex: '^.*[^\d].*$' # if no code is found in the url
-                with: # clear the filename so that it doesn't leak
+                with: # return an empty string
   # Uncomment this section to user Performer Search on this scraper
   # performerSearch:
   #   common:
@@ -154,5 +154,4 @@ xPathScrapers:
       Studio:
         Name: *studioName
       FrontImage: *imageSel
-#
 # Last Updated November 25, 2022

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -27,7 +27,7 @@ xPathScrapers:
     common:
       $details: &detailsAttr //div[@class="video-rating-and-details"]
     scene:
-      Title: $details/h1/text()
+      Title: //h1[contains(@class, "video-title")]/text()
       Date: &dateSel
         selector: $details//p[@class="video-upload-date"]/text()
         postProcess:

--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -1,4 +1,7 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+
 name: "BaDoink"
+
 sceneByURL:
   - action: scrapeXPath
     url: &urls
@@ -9,6 +12,31 @@ sceneByURL:
       - realvr.com
       - vrcosplayx.com
     scraper: sceneScraper
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        # remove the members part of the url since the scrapper would not attempt to login
+        - regex: "/members/"
+          with: "/"
+
+sceneByFragment:
+  action: scrapeXPath
+  # url format: https://{studio}.com/vrpornvideo/{title}-{code}
+  # The url without the code is what we will use for scrapping
+  # since it will forward to the correct one:
+  #   url format: https://{studio}.com/vrpornvideo/{title}
+  # both studio and title are part of the official file name
+  queryURL: "{filename}"
+  queryURLReplace:
+    # filename format:
+    #   {studio}_{title}_{res}_{vrtype}.{ext}
+    #     res: oculus|\d+k
+    #     vrtype: stuff we do not care about but could contain '_'
+    filename:
+      - regex: (?i)^(18vr|babevr|badoinkvr|kinkvr|realvr|vrcosplayx)_(.+)_(?:oculus|\dk)_.+$
+        with: https://$1.com/vrpornvideo/$2
+  scraper: sceneScraper
+
 performerByURL:
   - action: scrapeXPath
     url: *urls
@@ -48,7 +76,15 @@ xPathScrapers:
           - replace:
               - regex: \?.+
                 with: ""
-      URL: //link[@rel='canonical']/@href
+      URL: &sceneUrl //link[@rel="canonical"]/@href
+      Code:
+        selector: *sceneUrl
+        postProcess:
+          - replace:
+              - regex: '^(.+)-(\d+)/?$'
+                with: $2
+              - regex: '^.*[^\d].*$' # if no code is found in the url
+                with: # clear the filename so that it doesn't leak
   # Uncomment this section to user Performer Search on this scraper
   # performerSearch:
   #   common:
@@ -118,4 +154,5 @@ xPathScrapers:
       Studio:
         Name: *studioName
       FrontImage: *imageSel
-# Last Updated October 03, 2021
+#
+# Last Updated November 25, 2022

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -70,5 +70,4 @@ xPathScrapers:
           - replace:
               - regex: '^(.+)-(\d+)/?$'
                 with: $2
-#
 # Last Updated November 27, 2022

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -6,6 +6,25 @@ sceneByURL:
     url:
       - sexlikereal.com
     scraper: sceneScraper
+
+sceneByFragment:
+  action: scrapeXPath
+  # url format: https://www.sexlikereal.com/scenes/{title}-{code}
+  # However, the url:
+  #     https://www.sexlikereal.com/{code}
+  # will redirect to the full url so that is what we will use for scrapping
+  queryURL: https://www.sexlikereal.com/{filename}
+  queryURLReplace:
+    # filename format:
+    #   SLR_{stufio:[^_]+}_{title:[^_]+}_{res:\d+p}_{code:\d+}_{vrtype}.{ext}
+    #     vrtype: stuff we do not care about but could contain '_'
+    filename:
+      - regex: (?i)^SLR_.+_\d+p_(\d+)_.*$
+        with: $1
+      - regex: .*\.[^\.]+$ # if no id is found in the filename
+        with: # clear the filename so that it doesn't leak
+  scraper: sceneScraper
+
 xPathScrapers:
   sceneScraper:
     scene:
@@ -52,4 +71,4 @@ xPathScrapers:
               - regex: '^(.+)-(\d+)/?$'
                 with: $2
 #
-# Last Updated November 23, 2022
+# Last Updated November 27, 2022

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -24,8 +24,8 @@ xPathScrapers:
         selector: //div[@data-qa="scene-about-tab-text"]/text()[last()]
         postProcess:
           - replace:
-              - regex: '^\.\w*'
-                with: ''
+              - regex: '^\.\s*'
+                with:
       Tags:
         Name: //meta[@property="video:tag"]/@content
       Performers:
@@ -44,6 +44,12 @@ xPathScrapers:
                 VirtualXPorn: "Virtual X Porn"
                 WankitnowVR: "Wank It Now VR"
       Image: //div[contains(@class,"splash-screen")]/img/@src
-      URL: //link[@rel="canonical"]/@href
-
-# Last Updated November 04, 2022
+      URL: &sceneUrl //link[@rel="canonical"]/@href
+      Code:
+        selector: *sceneUrl
+        postProcess:
+          - replace:
+              - regex: '^(.+)-(\d+)/?$'
+                with: $2
+#
+# Last Updated November 23, 2022

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -63,6 +63,8 @@ xPathScrapers:
                 - regex: ^
                   with: "https:"
       Image: &imageSel //meta[@property="og:image"]/@content
+      URL: //link[@rel="canonical"]/@href
+
   movieScraper:
     common:
       $info: *info

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -87,6 +87,4 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
-#
 # Last Updated November 27, 2022
-

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -1,4 +1,7 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+
 name: "VRBangers"
+
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -12,6 +15,23 @@ movieByURL:
     url:
       - vrbangers.com
     scraper: movieScraper
+sceneByFragment:
+  action: scrapeXPath
+  # url format: https://{studio}.com/video/{title}
+  queryURL: "{filename}"
+  queryURLReplace:
+    # filename format:
+    #   {studio}_{title}_{res}_{vrtype}.{ext}
+    #     res: oculus|\d+k
+    #     vrtype: stuff we do not care about but could contain '_'
+    filename:
+      - regex: (?i)^(vrbangers|vrbgay|vrbtrans|vrconk)_(.+)_(?:oculus|\dk)_.+$
+        with: https://$1.com/video/$2
+      # Titles have spaces replaced with '_' and the url expects '-' instead of spaces
+      - regex: _
+        with: "-"
+  scraper: sceneScraper
+
 xPathScrapers:
   sceneScraper:
     common:
@@ -65,4 +85,6 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
-# Last Updated August 14, 2022
+#
+# Last Updated November 27, 2022
+

--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -37,6 +37,11 @@ sceneByFragment:
         with: "-"
   scraper: sceneScraper
 
+movieByURL:
+  - action: scrapeXPath
+    url: *urlSel
+    scraper: movieScraper
+
 xPathScrapers:
   sceneScraper:
     scene:
@@ -74,5 +79,21 @@ xPathScrapers:
                 VirtualRealAmateurPorn: "VirtualRealAmateur"
       Image: &imageSel //meta[@property="og:image"]/@content
       URL: //link[@rel="canonical"]/@href
-#
+      # Movies:
+      #   Name:
+      #     selector: //meta[@property="og:site_name"]/@content|//h1[@class="titleVideo"]
+      #     concat: " - "
+      #   Date: *dateAttr
+      #   Synopsis: *detailsSel
+      #   URL: //meta[@property="og:url"]/@content
+  movieScraper:
+    movie:
+      Name:
+        selector: //meta[@property="og:site_name"]/@content|//h1[@class="titleVideo"]
+        concat: " - "
+      Date: *dateAttr
+      Studio:
+        Name: *studioName
+      Synopsis: *detailsSel
+      FrontImage: *imageSel
 # Last Updated November 25, 2022

--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -1,4 +1,7 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+
 name: "VirtualRealPorn"
+
 sceneByURL:
   - action: scrapeXPath
     url: &urlSel
@@ -9,10 +12,31 @@ sceneByURL:
       - virtualrealporn.com
       - virtualrealtrans.com
     scraper: sceneScraper
-movieByURL:
-  - action: scrapeXPath
-    url: *urlSel
-    scraper: movieScraper
+
+sceneByFragment:
+  action: scrapeXPath
+  # url format: https://virtualrealporn.com/vr-porn-video/{title}
+  # title is part of the official filename for more recent scenes
+  # however, title will have spaces replaced with '_' in the file name
+  queryURL: https://virtualrealporn.com/vr-porn-video/{filename}/
+  queryURLReplace:
+    # filename format:
+    #   - older scenes
+    #       VirtualRealPorn.com_-_{title}_-_{misc}.{ext}
+    #         misc: could be vrtype, instructios for their player etc. Not relevant.
+    #   - new scenes:
+    #       VirtualRealPorn_{title}_{res}_{vrtype}.{ext}
+    #         res: oculus|\d+k
+    #         vrtype: stuff we do not care about but could contain '_'
+    filename:
+      - regex: (?i)^(?:VirtualRealPorn_(?P<title>.+)_(?:oculus|\dk)_.+)|(?:VirtualRealPorn.com_-_(?P<title>.+?)_-_.+)$
+        with: $title
+      # title has spaces replaced with '_' in the filename
+      # but we need '-' for the url
+      - regex: _
+        with: "-"
+  scraper: sceneScraper
+
 xPathScrapers:
   sceneScraper:
     scene:
@@ -49,19 +73,6 @@ xPathScrapers:
             - map:
                 VirtualRealAmateurPorn: "VirtualRealAmateur"
       Image: &imageSel //meta[@property="og:image"]/@content
-      Movies:
-        Name: &movieName
-          selector: //meta[@property="og:site_name"]/@content|//h1[@class="titleVideo"]
-          concat: " - "
-        Date: *dateAttr
-        Synopsis: *detailsSel
-        URL: //meta[@property="og:url"]/@content
-  movieScraper:
-    movie:
-      Name: *movieName
-      Date: *dateAttr
-      Studio:
-        Name: *studioName
-      Synopsis: *detailsSel
-      FrontImage: *imageSel
-# Last Updated August 14, 2022
+      URL: //link[@rel="canonical"]/@href
+#
+# Last Updated November 25, 2022


### PR DESCRIPTION
Some studios have a filename descriptive enough that we can build the scrapping url from it and then use the existing scrape by url.
To use simply pick the scrapper either when identifying or from the dropdown in the scene editor   