### PR TITLE
Fix GammaEntertainment movie cropped images

### DIFF
--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -464,9 +464,9 @@ def parse_movie_json(movie_json: dict) -> dict:
     scrape["date"] = movie_json[0].get(date_by_studio)
 
     scrape[
-        "front_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_front_400x625.jpg?format=webp"
+        "front_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_front_400x625.jpg?width=450&height=636"
     scrape[
-        "back_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_back_400x625.jpg"
+        "back_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_back_400x625.jpg?width=450&height=636"
 
     directors = []
     if movie_json[0].get('directors') is not None:

--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -464,7 +464,7 @@ def parse_movie_json(movie_json: dict) -> dict:
     scrape["date"] = movie_json[0].get(date_by_studio)
 
     scrape[
-        "front_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_front_400x625.jpg"
+        "front_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_front_400x625.jpg?format=webp"
     scrape[
         "back_image"] = f"https://transform.gammacdn.com/movies{movie[0].get('cover_path')}_back_400x625.jpg"
 


### PR DESCRIPTION
Closes #1188

``?format=webp`` missing in front image request. Without this parameter, image gets cropped at the top and bottom.