### PR TITLE
Add Studio Code and Director (and some more) to JavLibrary_python

### DIFF
--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -57,6 +57,8 @@ DEBUG_MODE = False
 STASH_SUPPORTED = False
 # Stash isn't support Labels yet
 STASH_SUPPORT_LABELS = False
+# ...and name order too...
+STASH_SUPPORT_NAME_ORDER = False
 # Tags you don't want to scrape
 IGNORE_TAGS = [
     "Features Actress", "Hi-Def", "Beautiful Girl", "Blu-ray",
@@ -428,6 +430,18 @@ def buildlist_tagperf(data, type_scrape=""):
             if p_name not in IGNORE_PERF_REVERSE and not NAME_ORDER_JAPANESE:
                 # Invert name (Aoi Tsukasa -> Tsukasa Aoi)
                 p_name = re.sub(r"([a-zA-Z]+)(\s)([a-zA-Z]+)", r"\3 \1", p_name)
+            if STASH_SUPPORT_NAME_ORDER:
+                # There is such names as "Aoi." and even "@you". Indeed, JAV is fun!
+                parsed_name = re.search("([a-zA-Z\.@]+)(\s)?([a-zA-Z]+)?", p_name)
+                p_name = {}
+                if parsed_name[2] == ' ' and parsed_name[3]:
+                    p_name[
+                        "surname"] = parsed_name[1]
+                    p_name[
+                        "first_name"] = parsed_name[3]
+                else:
+                    p_name[
+                        "nickname"] = parsed_name[0]
         if type_scrape == "tags" and p_name in IGNORE_TAGS:
             continue
         if type_scrape == "perf_jav" and dict_jav.get("performer_aliases"):

--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -60,6 +60,8 @@ IGNORE_TAGS = [
     "Features Actress", "Hi-Def", "Beautiful Girl", "Blu-ray",
     "Featured Actress", "VR Exclusive", "MOODYZ SALE 4", "Girl", "Tits"
 ]
+# Select preferable name order
+NAME_ORDER_JAPANESE = False
 # Some performers don't need to be reversed
 IGNORE_PERF_REVERSE = ["Lily Heart"]
 
@@ -421,7 +423,7 @@ def buildlist_tagperf(data, type_scrape=""):
         if p_name == "":
             continue
         if type_scrape == "perf_jav":
-            if p_name not in IGNORE_PERF_REVERSE:
+            if p_name not in IGNORE_PERF_REVERSE and not NAME_ORDER_JAPANESE:
                 # Invert name (Aoi Tsukasa -> Tsukasa Aoi)
                 p_name = re.sub(r"([a-zA-Z]+)(\s)([a-zA-Z]+)", r"\3 \1", p_name)
         if type_scrape == "tags" and p_name in IGNORE_TAGS:

--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -55,6 +55,8 @@ JAV_HEADERS = {
 DEBUG_MODE = False
 # We can't add movie image atm in the same time as Scene
 STASH_SUPPORTED = False
+# Stash isn't support Labels yet
+STASH_SUPPORT_LABELS = False
 # Tags you don't want to scrape
 IGNORE_TAGS = [
     "Features Actress", "Hi-Def", "Beautiful Girl", "Blu-ray",
@@ -612,6 +614,9 @@ jav_xPath[
 jav_xPath[
     "studio"] = '//td[@class="header" and text()="Maker:"]'\
                 '/following-sibling::td/span[@class="maker"]/a/text()'
+jav_xPath[
+    "label"] = '//td[@class="header" and text()="Label:"]'\
+                '/following-sibling::td/span[@class="label"]/a/text()'
 jav_xPath["image"] = '//div[@id="video_jacket"]/img/@src'
 jav_xPath["r18"] = '//a[text()="purchasing HERE"]/@href'
 
@@ -706,6 +711,8 @@ if JAV_MAIN_HTML:
                                             jav_result["title"][0])).lstrip()
         if jav_result.get("director"):
             jav_result["director"] = jav_result["director"][0]
+        if jav_result.get("label"):
+            jav_result["label"] = jav_result["label"][0]
         if jav_result.get("performers_url") and IGNORE_ALIASES is False:
             javlibrary_aliases_thread = threading.Thread(
                 target=th_request_perfpage,
@@ -823,6 +830,10 @@ if r18_result.get('studio'):
     scrape['studio']['name'] = r18_result['studio']
 if jav_result.get('studio'):
     scrape['studio']['name'] = jav_result['studio'][0]
+
+# Not supported by Stash yet
+if jav_result.get('label') and STASH_SUPPORT_LABELS:
+    scrape['label']['name'] = jav_result['label']
 
 # Performer - Javlibrary > R18
 if r18_result.get('performers'):

--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -55,7 +55,7 @@ JAV_HEADERS = {
 DEBUG_MODE = False
 # We can't add movie image atm in the same time as Scene
 STASH_SUPPORTED = False
-# Stash isn't support Labels yet
+# Stash doesn't support Labels yet
 STASH_SUPPORT_LABELS = False
 # ...and name order too...
 STASH_SUPPORT_NAME_ORDER = False
@@ -70,7 +70,7 @@ NAME_ORDER_JAPANESE = False
 IGNORE_PERF_REVERSE = ["Lily Heart"]
 
 # Keep the legacy field scheme:
-# Actual Code -> Title, actual Title ->> Details, actual Details -> /dev/null
+# Actual Code -> Title, actual Title -> Details, actual Details -> /dev/null
 LEGACY_FIELDS = True
 # Studio Code now in a separate field, so it may (or may not) be stripped from title
 # Makes sense only if not LEGACY_FIELDS
@@ -607,8 +607,8 @@ jav_xPath[
 # or '//div[@id="video_id"]//td[2][@class="text"]/text()'
 jav_xPath[
     "title"] = jav_xPath["code"] if LEGACY_FIELDS else '//div[@id="video_title"]/h3/a/text()'
-#There are no actual Details in JavLibrary,
-#but for legacy reasons you have to put Title in Details by default
+#There are no actual Details in JavLibrary
+#For legacy reasons we add the Title in Details by default
 jav_xPath[
     "details"] = None if not LEGACY_FIELDS else '//div[@id="video_title"]/h3/a/text()'
 jav_xPath["url"] = '//meta[@property="og:url"]/@content'
@@ -676,7 +676,7 @@ if JAV_SEARCH_HTML:
     JAV_MAIN_HTML = jav_search(JAV_SEARCH_HTML, jav_xPath_search)
 
 if JAV_MAIN_HTML is None and R18_MAIN_HTML is None and SCENE_TITLE:
-    # If javlibrary don't have it, there is no way that R18 have it but why not trying...
+    # If javlibrary doesn't have it, there is no way that R18 while have it but why not try...
     log.info("Javlib doesn't give any result, trying search with R18...")
     R18_SEARCH_HTML = send_request(
         f"https://www.r18.com/common/search/searchword={SCENE_TITLE}/?lg=en",

--- a/scrapers/JavLibrary_python.yml
+++ b/scrapers/JavLibrary_python.yml
@@ -16,4 +16,4 @@ sceneByQueryFragment:
       - python
       - JavLibrary_python.py
       - validSearch
-# Last Updated August 20, 2022
+# Last Updated December 06, 2022


### PR DESCRIPTION
Changes:

- Add new field that recently added to Stash: Studio Code and Director
- Reorganize fields: move DVD code from Title to actual Code, move scene title from Details to actual Title
- Add option to strip (or not) DVD code from Title
- Disable Details parsing since there are no real details in JavLibrary
- Add Label and Performer name order. This features are not supported by Stash yet, but why not implement it in advance? JAV progress in Stash tracked in stashapp/stash#3065
- Reverse Performer name order only if explicitly selected. Set Western name order for Japanese performers is ~~always a silly idea~~ not always preferable, so it better to have option to control that.