### PR TITLE
add analtherapyxxx.com

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -79,6 +79,7 @@ analnippon.com|karatmedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 analonly.com|Nympho.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 analoverdose.com|PervCity.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 analteenangels.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
+analtherapyxxx.com|FamilyTherapyXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 analvids.com|LegalPorno.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 analviolation.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 analyzedgirls.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -2,6 +2,7 @@ name: "FamilyTherapyXXX"
 sceneByURL:
   - action: scrapeXPath
     url:
+      - analtherapyxxx.com
       - familytherapyxxx.com
       - momcomesfirst.com
       - perfectgirlfriend.com
@@ -45,4 +46,4 @@ xPathScrapers:
                 with: $1/?s=$2
           - subScraper:
               selector: //div[@id="left-area"]/article[1]//img/@src
-# Last Updated January 29, 2022
+# Last Updated December 19, 2022


### PR DESCRIPTION
Adds analtherapyxxx.com to the existing FamilyTherapyXXX scraper.

It is another site under [RSGH Media](https://stashdb.org/studios/e42f2af3-d410-4bb4-bb5c-1b5fbbb07eae)