### PR TITLE
Fix KBProductions Parsing and Start Parsing Ricky's Room

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1037,6 +1037,7 @@ reidmylips.elxcomplete.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 renderfiend.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 restrictedsenses.com|RestrictedSenses.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 retroporncz.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+rickysroom.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 rim4k.com|Vip4K.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rk.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 roccosiffredi.com|Algolia_RoccoSiffredi.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-

--- a/scrapers/KBProductions.py
+++ b/scrapers/KBProductions.py
@@ -61,7 +61,7 @@ def make_request(request_url, origin_site):
 
 
 def fetch_page_json(page_html):
-    matches = re.findall(r'window\.__DATA__ = (.+)$', page_html, re.MULTILINE)
+    matches = re.findall(r'(?:<script id="__NEXT_DATA__" type="application\/json">({.+})<\/script>)', page_html, re.MULTILINE)
     return json.loads(matches[0]) if matches else None
 
 

--- a/scrapers/KBProductions.py
+++ b/scrapers/KBProductions.py
@@ -25,7 +25,7 @@ except ModuleNotFoundError:
 
 def get_from_url(url_to_parse):
     m = re.match(
-        r'https?://(?:www\.)?((\w+)\.com)/tour/(?:videos|upcoming|models)/(\d+)/([a-z0-9-]+)',
+        r'https?:\/\/(?:www\.)?((\w+)\.com)(?:\/tour)?\/(?:videos|upcoming|models)\/?(\d+)?\/([a-z0-9-]+)',
         url_to_parse)
     if m is None:
         return None, None, None, None

--- a/scrapers/KBProductions.py
+++ b/scrapers/KBProductions.py
@@ -87,6 +87,8 @@ def scrape_scene(page_json, studio):
     if scene.get('description'):
         details = BeautifulSoup(scene['description'], "html.parser").get_text()
         scrape['details'] = details
+    if scene.get('id'):
+        scrape['code'] = str(scene['id'])
     if scene.get('models'):
         models = []
         for m in scene['models']:
@@ -97,7 +99,7 @@ def scrape_scene(page_json, studio):
         for t in scene['tags']:
             tags.append(t)
         scrape['tags'] = [{'name': x} for x in tags]
-    if scene.get('extra_thumbs'):
+    if scene.get('extra_thumbnails'):
         # available image endings
         # ================
         #_player.jpg
@@ -107,12 +109,12 @@ def scrape_scene(page_json, studio):
         #_scene.jpg
         #_scenemobile.jpg
         img = None
-        for i in scene['extra_thumbs']:
+        for i in scene['extra_thumbnails']:
             if i.endswith("_player.jpg"):
                 image = i
                 break
         if img is None:
-            img = scene['extra_thumbs'][0]
+            img = scene['extra_thumbnails'][0]
         scrape['image'] = img
 
     url_path = page_json.get("page")

--- a/scrapers/KBProductions.py
+++ b/scrapers/KBProductions.py
@@ -126,53 +126,38 @@ def scrape_scene(page_json, studio):
     print(json.dumps(scrape))
 
 
-def get_dict_value(d: dict, v: str):
-    if d.get(v):
-        return d[v]
-    return None
-
-
 def scrape_performer(page_json):
-    if page_json.get("model") is None:
+    if page_json.get("props").get("pageProps").get("model") is None:
         log.error('Could not find performer in JSON data')
         sys.exit(1)
 
-    performer = page_json["model"]
+    performer = page_json.get("props").get("pageProps").get("model")
     scrape = {}
 
-    scrape['name'] = get_dict_value(performer, 'name')
-    scrape['gender'] = get_dict_value(performer, 'gender')
-    scrape['image'] = get_dict_value(performer, 'thumb')
+    scrape['name'] = performer.get('name')
+    scrape['gender'] = performer.get('gender')
+    scrape['image'] = performer.get('thumb')
+    details = BeautifulSoup(performer['Bio'], "html.parser").get_text()
+    scrape['details'] = details
+    scrape['birthdate'] = performer.get("Birthdate")
+    scrape['measurements'] = performer.get("Measurements")
+    scrape['eye_color'] = performer.get("Eyes")
 
-    if performer.get('attributes'):
-        pa = performer['attributes']
-        if pa.get('bio'):
-            scrape['details'] = get_dict_value(pa['bio'], 'value')
-        if pa.get('birthdate'):
-            scrape['birthdate'] = get_dict_value(pa['birthdate'], 'value')
-        if pa.get('measurements'):
-            scrape['measurements'] = get_dict_value(pa['measurements'],
-                                                    'value')
-        if pa.get('eyes'):
-            scrape['eye_color'] = get_dict_value(pa['eyes'], 'value')
-        if pa.get('height'):
-            height_ft = get_dict_value(pa['height'], 'value')
-            if height_ft:
-                h = re.match(r'(\d+)\D(\d+).+', height_ft)
-                if h:
-                    h_int = int(
-                        round((float(h.group(1)) * 12 + float(h.group(2))) *
+    height_ft = performer.get('Height')
+    if height_ft:
+        h = re.match(r'(\d+)\D(\d+).+', height_ft)
+        if h:
+            h_int = int(
+                    round((float(h.group(1)) * 12 + float(h.group(2))) *
                               2.54))  # ft'inches to cm
-                    scrape['height'] = f"{h_int}"
-        if pa.get('weight'):
-            weight_lb = get_dict_value(pa['weight'], 'value')
-            if weight_lb:
-                w = re.match(r'(\d+)\slbs', weight_lb)
-                if w:
-                    w_int = int(round(float(w.group(1)) / 2.2046))  # lbs to kg
-                    scrape['weight'] = f"{w_int}"
-        if pa.get('hair'):
-            scrape['hair_color'] = get_dict_value(pa['hair'], 'value')
+            scrape['height'] = f"{h_int}"
+    weight_lb = performer.get('Weight')
+    if weight_lb:
+        w = re.match(r'(\d+)\slbs', weight_lb)
+        if w:
+            w_int = int(round(float(w.group(1)) / 2.2046))  # lbs to kg
+            scrape['weight'] = f"{w_int}"
+    scrape['hair_color'] = performer.get('Hair')
     print(json.dumps(scrape))
 
 

--- a/scrapers/KBProductions.yml
+++ b/scrapers/KBProductions.yml
@@ -1,8 +1,13 @@
 name: "KB Productions"
 sceneByURL:
   - url:
+      # Keeping this to allow for updates
       - inserted.com/tour/upcoming/
+      # Keeping this to allow for updates
       - inserted.com/tour/videos/
+      - inserted.com/upcoming/
+      - inserted.com/videos/
+      - rickysroom.com/videos/
 
     action: script
     script:
@@ -12,9 +17,11 @@ sceneByURL:
 performerByURL:
   - url:
       - inserted.com/tour/models/
+      - inserted.com/models/
+      - rickysroom.com/models/
     action: script
     script:
       - python3
       - KBProductions.py
       - performer
-# Last Updated September 18, 2022
+# Last Updated December 24, 2022

--- a/scrapers/KBProductions.yml
+++ b/scrapers/KBProductions.yml
@@ -1,11 +1,11 @@
 name: "KB Productions"
 sceneByURL:
   - url:
-      # Keeping this to allow for updates
+      # Keeping this to allow for updates using old urls
       - inserted.com/tour/upcoming/
-      # Keeping this to allow for updates
       - inserted.com/tour/videos/
       - inserted.com/upcoming/
+
       - inserted.com/videos/
       - rickysroom.com/videos/
 


### PR DESCRIPTION
Tested this against a few Inserted and Ricky's Room pages. Old Inserted URLs (with the /tour/ paths) are still parseable with this update (since those redirect to the new URL structure), so I figured I'd leave them around for now as opposed to breaking the scraping for them.