### PR TITLE
Improve dreamtranny

### DIFF
--- a/scrapers/DreamTranny.yml
+++ b/scrapers/DreamTranny.yml
@@ -27,4 +27,10 @@ xPathScrapers:
           fixed: "Dream Tranny"
       Tags:
         Name: //div[@class="model-categories"]/a/text()
+      URL:
+        selector: //script[contains(.,"API_VIEW_URLS")]/text()
+        postProcess:
+          - replace:
+              - regex: .*/api(/update/\d+)/view_count.*
+                with: "https://dreamtranny.com$1"
 # Last Updated January 06, 2023

--- a/scrapers/DreamTranny.yml
+++ b/scrapers/DreamTranny.yml
@@ -17,7 +17,7 @@ xPathScrapers:
       Performers:
         Name: //a[@class="model-name no-text-decoration"]
       Image:
-        selector: //video[contains(@class,'video-js')]/@poster
+        selector: //video[contains(@class,"video-js")]/@poster|//div[contains(@class,"model-player")]//img/@src
         postProcess:
           - replace:
               - regex: ^
@@ -27,4 +27,4 @@ xPathScrapers:
           fixed: "Dream Tranny"
       Tags:
         Name: //div[@class="model-categories"]/a/text()
-# Last Updated December 14, 2022
+# Last Updated January 06, 2023


### PR DESCRIPTION
This adds an alternative xpath for the cover image which works with older scenes, e.g.

https://dreamtranny.com/update/164

Also, the URL for a scene is typically like https://dreamtranny.com/update/844/?nats=MC4wLjMuMTUuMC4wLjAuMC4w&step=2
The URL addition here will change the URL to remove the redundant query parameters, e.g. https://dreamtranny.com/update/844