### PR TITLE
move tsplayground.com to its own scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1307,7 +1307,7 @@ truelesbian.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 tryteens.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ts-castingcouch.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tsfactor.com|Algolia_EvilAngel.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|Trans
-tsplayground.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+tsplayground.com|TSPlayground.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Trans
 tspov.com|ChristianXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tsvirtuallovers.com|RealityLovers.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 tuktukpatrol.com|TukTukPatrol.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -63,7 +63,6 @@ sceneByURL:
       - tittycreampies.com/
       - transsexualangel.com/en/video/
       - transsexualroadtrip.com/
-      - tsplayground.com/en/video/
       - whiteghetto.com/
     scraper: sceneScraper
 
@@ -217,7 +216,6 @@ xPathScrapers:
                 tittycreampies: Titty Creampies
                 transsexualangel: Transsexual Angel
                 transsexualroadtrip: Transsexual Roadtrip
-                tsplayground: TS Playground
                 whiteghetto: White Ghetto
                 xempire: XEmpire
 
@@ -240,4 +238,4 @@ xPathScrapers:
         Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()
       FrontImage: //a[@class='frontCoverImg']/@href
       BackImage: //a[@class='backCoverImg']/@href
-# Last Updated December 29, 2022
+# Last Updated January 13, 2023

--- a/scrapers/TSPlayground.yml
+++ b/scrapers/TSPlayground.yml
@@ -1,0 +1,35 @@
+name: "TS Playground"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - tsplayground.com/video/
+    scraper: sceneScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - tsplayground.com/models/
+    scraper: performerScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class="content-title"]/h1/text()
+      Details: //div[@class="content-desc more-desc"]
+      Date:
+        selector: //div[@class="content-date"]/div[@class="label"]/text()
+        postProcess:
+          - replace:
+              - regex: (\d{2}).(\d{2}).(\d{4})
+                with: $3-$2-$1
+      Image: //meta[@property="og:image"]/@content
+      Studio:
+        Name:
+          fixed: TS Playground
+      Tags:
+        Name: //div[@class="content-tags"]//a/text()
+      Performers:
+        Name: //div[@class="content-models"]//a/span/text()
+  performerScraper:
+    performer:
+      Name: //div[contains(@class, "title-col")]/h1/text()
+      Image: //div[@class="model-avatar"]/img/@src
+# Last Updated January 13, 2023


### PR DESCRIPTION
The tsplayground.com site has been relaunched and the existing scraper in GammaEntertainment no longer works.

These changes move the site to its own scraper (sceneByURL and performerByURL)

Example studio scene URL: https://tsplayground.com/video/valentina-bittencourt-and-alex-1985.html
Example performer URL: https://tsplayground.com/models/valentina-bittencourt-380.html