### PR TITLE
Update Hypnotube.yml to pull in main video thumbnail

### DIFF
--- a/scrapers/Hypnotube.yml
+++ b/scrapers/Hypnotube.yml
@@ -12,11 +12,7 @@ xPathScrapers:
       Title: //div[@class='item-tr-inner-col inner-col']/h1/text()
       Details: //div[@class='main-description']/text()
       Image:
-        selector: //script[@type="text/javascript" and contains(text(),"og:image")]/text()
-        postProcess:
-          - replace:
-              - regex: '.+"og:image" content="([^"]+)".+'
-                with: $1
+        selector: //meta[@property="og:image"]/@content
       Studio:
         Name: $studio/@title
         URL: $studio/@href

--- a/scrapers/Hypnotube.yml
+++ b/scrapers/Hypnotube.yml
@@ -11,8 +11,7 @@ xPathScrapers:
     scene:
       Title: //div[@class='item-tr-inner-col inner-col']/h1/text()
       Details: //div[@class='main-description']/text()
-      Image:
-        selector: //meta[@property="og:image"]/@content
+      Image: //meta[@property='og:image']/@content
       Studio:
         Name: $studio/@title
         URL: $studio/@href
@@ -25,5 +24,4 @@ xPathScrapers:
       Tags:
         Name: //div[@class='tags-block']/a/text()
       URL: //link[rel='canonical']/@href
-
-# Last Updated July 16, 2022
+# Last Updated January 27, 2023


### PR DESCRIPTION
First time submitting a pull request, so apologies if I've made a hash of it.

I've made a change to the Hypnotube.yml scraper so that it pulls in the main thumbnail for the video (as seen on the front page/video list view). This thumbnail seems to be the best representation of videos from the site.

Tested on my own instance of Stash and validated via the validation script, which comes back clean.