### PR TITLE
fix studio scraping for VR Bangers (and network sites)

### DIFF
--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -51,13 +51,18 @@ xPathScrapers:
         Name: //div[starts-with(@class, 'video-item__info-starring')]//a/text()
       Studio:
         Name: &studioName
-          selector: //meta[@name="dl8-customization-brand-name"]/@content
+          selector: &studioURLSel //meta[@name="dl8-customization-brand-url"]/@content
           postProcess:
             - replace:
-                - regex: \#
+                - regex: ^//
                   with: ""
+            - map:
+                vrbangers.com: VR Bangers
+                vrbgay.com: VRB Gay
+                vrbtrans.com: VRB Trans
+                vrconk.com: VR Conk
         URL: &studioURL
-          selector: //meta[@name="dl8-customization-brand-url"]/@content
+          selector: *studioURLSel
           postProcess:
             - replace:
                 - regex: ^
@@ -87,4 +92,4 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
-# Last Updated November 27, 2022
+# Last Updated Feburary 06, 2023

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -92,4 +92,4 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
-# Last Updated Feburary 06, 2023
+# Last Updated February 06, 2023


### PR DESCRIPTION
This just changes the studio name scraping for VR Bangers and its network sites, as currently it is incorrectly scraping network sites (e.g. vrbtrans.com) as "VR Bangers".

Here are example studio scene URLs, for each of the scraper's domains, that have been tested as now working correctly:

- https://vrbangers.com/video/anal-virginity/
- https://vrbgay.com/video/feeding-frenzy/
- https://vrbtrans.com/video/the-heartbreaker/
- https://vrconk.com/video/thor-love-and-thunder-a-xxx-parody/