### PR TITLE
add agentredgirl.com to Algolia_Adultime.yml

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -42,6 +42,7 @@ adultprime.com|AdultPrime.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 adulttime.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|Python|-
 adulttimepilots.com|Algolia_Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-
 aebn.com|AEBN.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|Straight + Gay
+agentredgirl.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 alettaoceanempire.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 alexismonroe.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 alexlegend.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -59,7 +59,8 @@ MOVIE_SITES = {
 # this is because the `serie_name` is the Movie (series) title on these sites,
 # not the studio
 SITES_USING_OVERRIDE_AS_STUDIO_FOR_SCENE = {
-    "Devilstgirls": "Devil's Tgirls"
+    "Devilstgirls": "Devil's Tgirls",
+    "AgentRedGirl": "Agent Red Girl"
 }
 
 # a list of sites (`sitename_pretty` from the API) which should pick out the

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -6,6 +6,7 @@ sceneByURL:
       - adamandevepictures.com/en/video/
       - adulttime.com/en/video/
       - adulttimepilots.com/en/video/
+      - agentredgirl.com/en/video/
       - analteenangels.com/en/video/
       - assholefever.com/en/video/
       - beingtrans247.com/en/video/
@@ -95,4 +96,4 @@ movieByURL:
       - Algolia.py
       - puretaboo
       - movie
-# Last Updated December 22, 2022
+# Last Updated February 06, 2023


### PR DESCRIPTION
This adds the agentredgirl.com site to the existing Adulttime scraper using Algolia API

example scene URL: https://www.agentredgirl.com/en/video/agentredgirl/Amys-Big-Wish-Episode-2--3/176036