### PR TITLE
fix gallery scraping via algolia

### DIFF
--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -236,12 +236,13 @@ def api_search_movie_id(m_id, url):
     return req
 
 def api_search_gallery_id(p_id, url):
-    gallery_id = [f"set_id:{p_id}"]
+    gallery_id = [[f"set_id:{p_id}"]]
     request_api = {
         "requests": [{
             "indexName": "all_photosets",
             "params": "query=&hitsPerPage=20&page=0",
-            "facetFilters": gallery_id
+            "facetFilters": gallery_id,
+            "facets": []
         }]
     }
     req = send_request(url, HEADERS, request_api)
@@ -625,7 +626,9 @@ def parse_gallery_json(gallery_json: dict, url: str = None) -> dict:
     """
     scrape = {}
     # Title
-    if gallery_json.get('title'):
+    if gallery_json.get('clip_title'):
+        scrape['title'] = gallery_json['clip_title'].strip()
+    elif gallery_json.get('title'):
         scrape['title'] = gallery_json['title'].strip()
     # Date
     scrape['date'] = gallery_json.get('date_online')
@@ -689,8 +692,8 @@ def parse_gallery_json(gallery_json: dict, url: str = None) -> dict:
             hostname = "21sextury"
         elif net_name.lower() == "21 naturals":
             hostname = "21naturals"
-        scrape[
-            'url'] = f"https://{hostname.lower()}.com/en/video/{gallery_json['sitename'].lower()}/{gallery_json['url_title']}/{gallery_json['set_id']}"
+        scrape['url'] = f"https://www.{hostname.lower()}.com/en/photo/" \
+            f"{gallery_json['url_title']}/{gallery_json['set_id']}"
     except:
         if url:
             scrape['url'] = url


### PR DESCRIPTION
The galleryByURL scraping is not working (JSON marshalling error). This change fixes it.

Example gallery URLs:

- https://www.evilangel.com/en/photo/Isabela-Fontaneli-Lara-Lopes-TS---TS/101070
- https://www.transgressivexxx.com/en/photo/TS-Isa-%2B-TS-Lara-%2B-Stud--Anal-3-Way/101646

Also, the scraped URL was being created as the _video_ scene URL, which means any subsequent scrapes of the gallery (e.g. for updated info) will not work. The actually gallery URL is scraped by creating it in the form that is seen on the sites.