### PR TITLE
make filthyfamily scraper work with the mobile site

### DIFF
--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -5,6 +5,11 @@ sceneByURL:
       - filthyfamily.com
       - mobile.filthyfamily.com
     scraper: sceneScraper
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        - regex: https://filthyfamily\.com
+          with: https://mobile.filthyfamily.com
 xPathScrapers:
   sceneScraper:
     common:
@@ -36,4 +41,4 @@ xPathScrapers:
             - regex: mobile\.bangbros\.com
               with: mobile.filthyfamily.com
 
-# Last Updated February 22, 2023
+# Last Updated February 27, 2023

--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -3,30 +3,35 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - filthyfamily.com
+      - mobile.filthyfamily.com
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
+    common:
+      $videoinfo: //div[@id="video-player-meta"]/div[@class="card-info"]
     scene:
-      Title: //div[@class='hideWhilePlaying']/img/@alt
-      Details: //p[@class='videoDetail']/text()
+      Title: $videoinfo/h1/text()
+      Details:
+        selector: $videoinfo/p[@class[contains(.,"desc")]]
       Image:
-        selector: //div[@class="hideWhilePlaying"]/img/@src
+        selector: //video/@data-poster-url
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+              - regex: \[resolution\]
+                with: ipadbig.jpg
       Tags:
         Name:
-          selector: //meta[@http-equiv='keywords']/@content
-          split: ", "
+          selector: $videoinfo/div[@class="tags"]//a/text()
+      Performers:
+        Name: //section[@class="group"]/div[@data-scrollbar="#model-scroll"]/ul//li//div[@class="model-info"]/h2/a/text()
       Studio:
         Name:
           fixed: Filthy Family
       URL:
-        selector: //link[@rel='canonical']/@href
+        selector: $videoinfo/div[contains(@class, "act")]/a[@id="ovrl-share-btn"]/@*[name()="addthis:url"]
         postProcess:
           - replace:
-            - regex: ^
-              with: "https:"
+            - regex: mobile\.bangbros\.com
+              with: mobile.filthyfamily.com
 
-# Last Updated October 07, 2020
+# Last Updated February 22, 2023

--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -38,7 +38,6 @@ xPathScrapers:
         selector: $videoinfo/div[contains(@class, "act")]/a[@id="ovrl-share-btn"]/@*[name()="addthis:url"]
         postProcess:
           - replace:
-            - regex: mobile\.bangbros\.com
-              with: mobile.filthyfamily.com
-
+              - regex: mobile\.bangbros\.com
+                with: mobile.filthyfamily.com
 # Last Updated February 27, 2023

--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -19,6 +19,8 @@ xPathScrapers:
           - replace:
               - regex: \[resolution\]
                 with: ipadbig.jpg
+              - regex: ^//
+                with: https://
       Tags:
         Name:
           selector: $videoinfo/div[@class="tags"]//a/text()

--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -8,7 +8,7 @@ sceneByURL:
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: https://filthyfamily\.com
+        - regex: https://(www\.)?filthyfamily\.com
           with: https://mobile.filthyfamily.com
 xPathScrapers:
   sceneScraper:


### PR DESCRIPTION
# Background

## filthyfamily.com now paywalled

filthyfamily.com appears to now be fully behind a paywall, so existing stashdb scenes such as https://stashdb.org/scenes/08a9c8ad-87c8-49ce-9b8a-88400b32e7ce with studio URL https://filthyfamily.com/video3409033/julz-the-virgin-fucks-her-step-parents end up redirecting to https://filthyfamily.com/?warning=false where all the clickable links are /join URLs

## mobile.filthyfamily.com still browsable

HOWEVER... the mobile.filthyfamily.com site is still at least partially browsable, like you can see a list of videos at https://mobile.filthyfamily.com/videos and a second page at https://mobile.filthyfamily.com/videos/2

each of the listed scenes can be clicked to go to that scene, e.g. https://mobile.filthyfamily.com/video3407991/squirter-and-stepmom-worship-a-cock

and that is what I have rewritten this scraper to scrape, the mobile site scene URL...

# examples

## existing links for filthyfamily.com

In the example above where an existing stashdb scene has studio URL https://filthyfamily.com/video3409033/julz-the-virgin-fucks-her-step-parents, the `mobile.` subdomain can be added in to give https://mobile.filthyfamily.com/video3409033/julz-the-virgin-fucks-her-step-parents which is now viewable in a browser _and_ scrapable by this updated scraper.

## scenes on mobile.filthyfamily.com

You should be able to click on any scene listed at:

- https://mobile.filthyfamily.com/videos
- https://mobile.filthyfamily.com/videos/2

and put the resulting scene URL into the stashapp to scrape by URL, e.g.:

- https://mobile.filthyfamily.com/video3407745/family-sex-vacation
- https://mobile.filthyfamily.com/video3407799/my-hot-stepmom-and-step-sister
- https://mobile.filthyfamily.com/video3408593/fucking-my-stepson-after-graduation