### PR TITLE
update fix shinybound.com and shinysboundsluts.com

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1116,7 +1116,7 @@ shesbrandnew.com|TopWebModels.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 sheseducedme.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shewillcheat.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shinybound.com|ShinyBound.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-shinysboundsluts.com|ShinyBound.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+shinysboundsluts.com|ShinyBound.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 shiofuky.com|Jhdv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 shoplyfter.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shoplyftermylf.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/ShinyBound.yml
+++ b/scrapers/ShinyBound.yml
@@ -8,32 +8,34 @@ sceneByURL:
 
 xPathScrapers:
   sceneScraper:
-    common:
-      $logo: //div[@class="logo"]/a/@href
     scene:
-      Title: //span[@class='update_title']
+      Title: //h1
       Details:
-        selector: //span[@class='latest_update_description']
+        selector: //div[contains(@class, "videoDescription")]/p
       Date:
-        selector: //span[@class='availdate']
+        selector: //div[@class="contentT"]/ul[@class="contentInfo"]/li[./i[contains(@class, "fa-calendar")]]/text()
         postProcess:
-          - parseDate: 01/02/2006
+          - parseDate: Jan 2, 2006
       Tags:
-        Name: //span[@class='update_tags']/a
+        Name: //div[@class="tags"]//a/text()
       Performers:
         Name:
-          selector: //span[@class='tour_update_models']/a
+          selector: //div[@class="models"]//a/text()
       Studio:
         Name:
-          selector: $logo
+          selector: //div[@class="logo"]/a/@href
           postProcess:
             - replace:
                 - regex: https://([^.]+)\..+
                   with: $1
             - map:
-                shinysboundsluts: ShinysBoundSluTS
-                shinybound: ShinyBound
+                shinysboundsluts: Shiny's Bound SluTS
+                shinybound: Shinybound
       Image:
-        selector: $logo|//img[@class='stdimage promo_thumb left thumbs']/@src
-        concat: "/"
-# Last Updated May 23, 2022
+        selector: //iframe/@src
+        postProcess:
+          - replace:
+              - regex: .*\?poster=(.*\.jpg).*
+                with: $1
+
+# Last Updated February 23, 2023


### PR DESCRIPTION
This updates the existing scraper to fix the sites:
- shinybound.com
- shinysboundsluts.com

shinysboundsluts.com is still listed as an outstanding requested site in #73 

### example scenes

- https://shinysboundsluts.com/updates/office-gal-captured-2
- https://shinybound.com/updates/Chairtied-Struggles

### studio name

I've altered the studio names to match the casing/format seen in each site's title text, and also submitted edits on stashdb:

- Shiny's Bound Sluts -> Shiny's Bound SluTS https://stashdb.org/edits/54446438-3696-4957-9288-8d38ca15c63d
- Shinybound https://stashdb.org/edits/710628bc-fbfb-4430-a483-843c49ceceba