### PR TITLE
Fix Oldje scene performers selector

### DIFF
--- a/scrapers/Oldje.yml
+++ b/scrapers/Oldje.yml
@@ -51,4 +51,4 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: "https://www.oldje-3some.com/"
-# Last Updated April 15, 2021
+# Last Updated February 25, 2023

--- a/scrapers/Oldje.yml
+++ b/scrapers/Oldje.yml
@@ -25,7 +25,7 @@ xPathScrapers:
           - parseDate: 2006-01-02
       Performers:
         Name:
-          selector: //a[contains(@href,'/models/preview/')]
+          selector: //a[@class="act_name_h"]
       Details:
         selector: //p[@class='text']|//div[@class="preview_desc"]
       Image:

--- a/scrapers/Oldje.yml
+++ b/scrapers/Oldje.yml
@@ -29,7 +29,7 @@ xPathScrapers:
       Details:
         selector: //p[@class='text']|//div[@class="preview_desc"]
       Image:
-        selector: (//div[@id="content" or @id="prev_m"]/a)[1]/img/@src
+        selector: //div[@id="content" or @id="prev_m"]/a[1]/img/@src
   oldje3someScraper:
     scene:
       Studio:


### PR DESCRIPTION
In the Oldje scene scraper the performer names were not being picked up and the image was not being loaded.

Performers using a new layout so added fix, and fixed the image not being loaded by removing redundant brackets