### PR TITLE
Improve ThisVid scraper

### DIFF
--- a/scrapers/ThisVid.yml
+++ b/scrapers/ThisVid.yml
@@ -4,6 +4,11 @@ sceneByURL:
     url:
       - thisvid.com
     scraper: sceneScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - thisvid.com
+    scraper: performerScraper
 xPathScrapers:
   sceneScraper:
     common:
@@ -27,5 +32,23 @@ xPathScrapers:
           - replace:
               - regex: .+/(\d+)/?$
                 with: $1
+  performerScraper:
+    common:
+      $profileCaseL: //div[@class="profile"]//div[@class="case"]//div[@class="case-left"]
+      $profileCaseR: //div[@class="profile"]//div[@class="case"]//div[@class="case-right"]
+    performer:
+      Name: $profileCaseL//span[contains(text(),"Name")]/strong|//div[@class="profile-menu"]//div[@class="headline"]//h2/text()
+      Birthdate:
+        selector: $profileCaseL//span[contains(text(),"Birth")]/strong
+        postProcess:
+          - parseDate: 02 January, 2006
+          - parseDate: 2006-01-02
+      Country:
+        selector: $profileCaseL//span[contains(text(),"Country")]/strong
+        postProcess:
+          - map:
+              United States: "USA"
+      Gender: $profileCaseR//span[contains(text(),"Gender")]/strong
+      Image: //div[@class="avatar"]/img[not(contains(@src,"no-avatar"))]/@src
 
-# Last Updated February 15, 2023
+# Last Updated February 26, 2023

--- a/scrapers/ThisVid.yml
+++ b/scrapers/ThisVid.yml
@@ -21,5 +21,11 @@ xPathScrapers:
       Tags:
         Name: $desc//li//a[contains(@href,"/tags/")]/text()
       Details: $desc//li//p/text()
+      Code:
+        selector: //meta[@property="og:video:url"]/@content
+        postProcess:
+          - replace:
+              - regex: .+/(\d+)/?$
+                with: $1
 
 # Last Updated February 15, 2023


### PR DESCRIPTION
* Now uses video id for Studio Code (as mentioned in the [original PR](https://github.com/stashapp/CommunityScrapers/pull/1274))
* Adds performerByURL scraper for fetching name, photo, country, birthdate and gender from a member page if available.

I'm well aware that the majority of ThisVid members simply upload videos they've found on other platforms, but for any actual content creators on there I'd figured we should be able to scrape them.