### PR TITLE
fix VRBangers script for vrbtrans.com

### DIFF
--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -92,6 +92,4 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
-debug:
-  printHTML: true
-# Last Updated February 06, 2023
+# Last Updated February 27, 2023

--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -35,7 +35,7 @@ sceneByFragment:
 xPathScrapers:
   sceneScraper:
     common:
-      $info: &info //div[starts-with(@class,"video-item__info ")]
+      $info: &info //div[starts-with(@class,"video-item__info ")]|//div[@class="single-video-info"]
     scene:
       Title: &titleSel //h1
       Date: &dateAttr
@@ -43,12 +43,12 @@ xPathScrapers:
         postProcess:
           - parseDate: Jan 2, 2006
       Details: &detailsAttr
-        selector: //div[contains(@class,"second-text")]/div//text()
+        selector: //div[contains(@class,"second-text")]/div//text()|//div[contains(@class,"single-video-description")]/div//text()
         concat: " "
       Tags:
-        Name: //div[@data-testid="video-categories-list"]/a[contains(@href,"category/")]/text()
+        Name: //div[@data-testid="video-categories-list"]/a[contains(@href,"category/")]/text()|//div[@class="single-video-categories"]//a[contains(@href,"category/")]/text()
       Performers:
-        Name: //div[starts-with(@class, 'video-item__info-starring')]//a/text()
+        Name: //div[starts-with(@class, 'video-item__info-starring')]//a/text()|//div[contains(@class, "single-video-info__starring")]//a/text()
       Studio:
         Name: &studioName
           selector: &studioURLSel //meta[@name="dl8-customization-brand-url"]/@content
@@ -92,4 +92,6 @@ xPathScrapers:
         Name: *studioName
         URL: *studioURL
       FrontImage: *imageSel
+debug:
+  printHTML: true
 # Last Updated February 06, 2023


### PR DESCRIPTION
It looks like VRBangers and/or VRBTrans altered the CSS styling so the class names are a little different here and there.

This tweaks the scraper to work with the updated CSS on vrbtrans.com scenes, e.g.:

- https://vrbtrans.com/video/date-night/

and the scraper works with other sites in the scraper, e.g.:

- https://vrbangers.com/video/my-milfshake-is-better-than-yours/

I've chosen to extend the existing scraped properties in case some sites/scenes use the older styling.