### PR TITLE
JavLibrary_python.yml, Better formatting keywords before sending request to source site

### DIFF
--- a/scrapers/JavLibrary_python.py
+++ b/scrapers/JavLibrary_python.py
@@ -41,6 +41,8 @@ JAV_MAIN_HTML = None
 R18_MAIN_HTML = None
 PROTECTION_CLOUDFLARE = False
 
+JAV_REGEX = r"([a-zA-Z|tT28]+-\d+[zZ]?[eE]?)(?:-pt)?(\d{1,2})?"
+
 R18_HEADERS = {
     "User-Agent":
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0',
@@ -556,6 +558,8 @@ if FRAGMENT.get("title"):
     SCENE_TITLE = re.sub(r"-JG\d", "", SCENE_TITLE)
     SCENE_TITLE = re.sub(r"\s.+$", "", SCENE_TITLE)
     SCENE_TITLE = re.sub(r"[ABCDEFGH]$", "", SCENE_TITLE)
+    SCENE_TITLE = re.sub(JAV_REGEX, r"\1", SCENE_TITLE)
+
 else:
     SCENE_TITLE = None
 


### PR DESCRIPTION
 javlibrary python is sending  whole filename as  scene title, therefore Identifying task usually have zero result just because media file naming is bad

use https://github.com/jvlflame/Javinizer/blob/master/src/Javinizer/jvSettings.json#L45 from javinizer seem to be better for guessing jav code

Some of testcase:

```
[Mosaic Removed Uncensored]MEYD-799 愛妻交換 後輩の妻と俺の妻を交換して中出ししまくった4日間の記録。 森沢かな 南ま
```
become `MEYD-799`


`hhd800.com@JUQ-208.mp4`

become `JUQ-208`
