### PR TITLE
Update PlayboyPlus.yml

### DIFF
--- a/scrapers/PlayboyPlus.yml
+++ b/scrapers/PlayboyPlus.yml
@@ -8,7 +8,7 @@ sceneByURL:
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: (?:https://)?(pbp-ma.playboy.com)/gallery/([^/]*)(?:/vip)?
+        - regex: (?:https://)?((pbp-ma|pbp-ma-legacy).playboy.com)/gallery/([^/]*)(?:/vip)?
           with: https://playboyplus.com/gallery/$2
 galleryByURL:
   - action: scrapeXPath
@@ -19,7 +19,7 @@ galleryByURL:
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: (?:https://)?(pbp-ma.playboy.com)/gallery/([^/]*)(?:/vip)?
+        - regex: (?:https://)?((pbp-ma|pbp-ma-legacy).playboy.com)/gallery/([^/]*)(?:/vip)?
           with: https://playboyplus.com/gallery/$2
 xPathScrapers:
   sceneScraper:

--- a/scrapers/PlayboyPlus.yml
+++ b/scrapers/PlayboyPlus.yml
@@ -51,4 +51,4 @@ xPathScrapers:
       Performers: *performers
       Details: *details
       Studio: *studio
-# Last Updated February 07, 2023
+# Last Updated March 27, 2023

--- a/scrapers/PlayboyPlus.yml
+++ b/scrapers/PlayboyPlus.yml
@@ -1,26 +1,25 @@
 name: PlayboyPlus
 sceneByURL:
   - action: scrapeXPath
-    url:
+    url: &urls
       - playboyplus.com
       - pbp-ma.playboy.com
+      - pbp-ma-legacy.playboy.com
     scraper: sceneScraper
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: (?:https://)?((pbp-ma|pbp-ma-legacy).playboy.com)/gallery/([^/]*)(?:/vip)?
-          with: https://playboyplus.com/gallery/$2
+        - regex: (?:https://)?(pbp-ma(-legacy)?.playboy.com)/gallery/([^/]*)(?:/vip)?
+          with: https://playboyplus.com/gallery/$3
 galleryByURL:
   - action: scrapeXPath
-    url:
-      - playboyplus.com
-      - pbp-ma.playboy.com
+    url: *urls
     scraper: galleryScraper
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: (?:https://)?((pbp-ma|pbp-ma-legacy).playboy.com)/gallery/([^/]*)(?:/vip)?
-          with: https://playboyplus.com/gallery/$2
+        - regex: (?:https://)?(pbp-ma(-legacy)?.playboy.com)/gallery/([^/]*)(?:/vip)?
+          with: https://playboyplus.com/gallery/$3
 xPathScrapers:
   sceneScraper:
     scene:


### PR DESCRIPTION
Updated regex with additional URL possibility per user request.

See below:

> Would you be able to add pbp-ma-legacy.playboy.com to this regex swap? I believe it's the exact same content, just different CSS.
> 
> Reference:
> https://www.playboyplus.com/gallery/kay-lovely-in-expose-yourself
> https://pbp-ma.playboy.com/gallery/kay-lovely-in-expose-yourself
> https://pbp-ma-legacy.playboy.com/gallery/kay-lovely-in-expose-yourself