### PR TITLE
Use `availableAt` instead of `createdAt` for date in Arx scraper

### DIFF
--- a/scrapers/Arx.yml
+++ b/scrapers/Arx.yml
@@ -15,4 +15,4 @@ sceneByURL:
       - Arx.py
       - scrapeByURL
 
-# Last Updated October 01, 2021
+# Last Updated April 24, 2023


### PR DESCRIPTION
The API results gives scenes with two date properties, `createdAt` and `availableAt`. The former is currently the one being scraped and is presumably the recorded or possibly final edit date. The latter is the published date that we are interested in. This change picks the correct date.

 The rest of the changes are just to reduce the number of python warnings around casing, overrides of built-ins , etc.