### PR TITLE
add gallery and performer scraper to dreamtranny.com

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -389,7 +389,7 @@ downtofuckdating.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dpfanatics.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 dreamsofspanking.com|DreamsOfSpanking.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 dreamteenshd.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-dreamtranny.com|DreamTranny.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+dreamtranny.com|DreamTranny.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|Trans
 drilledchicks.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 driverxxx.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 dtfsluts.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/DreamTranny.yml
+++ b/scrapers/DreamTranny.yml
@@ -4,17 +4,21 @@ sceneByURL:
     url:
       - dreamtranny.com
     scraper: sceneScraper
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - dreamtranny.com
+    scraper: galleryScraper
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: //div[@class="section-title"]/h4/text()
-      Details:
-        selector: //p[@class="read-more"]/text()
-      Date:
+      Title: &titleSel //div[@class="section-title"]/h4/text()
+      Details: &detailsSel //p[@class="read-more"]/text()
+      Date: &dateAttr
         selector: //small[@class="updated-at"]/text()
         postProcess:
           - parseDate: Jan 2, 2006
-      Performers:
+      Performers: &performersAttr
         Name: //a[@class="model-name no-text-decoration"]
       Image:
         selector: //video[contains(@class,"video-js")]/@poster|//div[contains(@class,"model-player")]//img/@src
@@ -22,15 +26,31 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: "https://dreamtranny.com"
-      Studio:
+      Studio: &studioAttr
         Name:
           fixed: "Dream Tranny"
-      Tags:
+      Tags: &tagsAttr
         Name: //div[@class="model-categories"]/a/text()
-      URL:
-        selector: //script[contains(.,"API_VIEW_URLS")]/text()
+      URL: &urlAttr
+        selector: &urlSel //script[contains(.,"API_VIEW_URLS")]/text()
         postProcess:
           - replace:
               - regex: .*/api(/update/\d+)/view_count.*
-                with: "https://dreamtranny.com$1"
-# Last Updated January 06, 2023
+                with: "https://dreamtranny.com$1/"
+      Code: &codeAttr
+        selector: *urlSel
+        postProcess:
+          - replace:
+              - regex: .*/api/update/(\d+)/view_count.*
+                with: "$1"
+  galleryScraper:
+    gallery:
+      Title: *titleSel
+      Details: *detailsSel
+      Date: *dateAttr
+      Tags: *tagsAttr
+      Performers: *performersAttr
+      Studio: *studioAttr
+      Code: *codeAttr
+      URL: *urlAttr
+# Last Updated April 20, 2023

--- a/scrapers/DreamTranny.yml
+++ b/scrapers/DreamTranny.yml
@@ -73,7 +73,7 @@ xPathScrapers:
         selector: //div[@class="model-content"]/p/span[text()="DATE OF BIRTH"]/following-sibling::span[1]
         postProcess:
           - replace:
-              - regex: (st|[nr]d|th)
-                with: ""
+              - regex: (\d)(st|[nr]d|th)
+                with: "$1"
           - parseDate: January 2, 2006
 # Last Updated April 20, 2023

--- a/scrapers/DreamTranny.yml
+++ b/scrapers/DreamTranny.yml
@@ -9,6 +9,11 @@ galleryByURL:
     url:
       - dreamtranny.com
     scraper: galleryScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - dreamtranny.com/models/
+    scraper: performerScraper
 xPathScrapers:
   sceneScraper:
     scene:
@@ -37,7 +42,7 @@ xPathScrapers:
           - replace:
               - regex: .*/api(/update/\d+)/view_count.*
                 with: "https://dreamtranny.com$1/"
-      Code: &codeAttr
+      Code:
         selector: *urlSel
         postProcess:
           - replace:
@@ -51,6 +56,24 @@ xPathScrapers:
       Tags: *tagsAttr
       Performers: *performersAttr
       Studio: *studioAttr
-      Code: *codeAttr
       URL: *urlAttr
+  performerScraper:
+    performer:
+      Name: //h1[@class="model-title"]/text()
+      Gender:
+        fixed: transgender_female
+      Image:
+        selector: //div[@class="model-img"]/a/img[@class="img"]/@src
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://dreamtranny.com/
+      Country: //div[@class="model-content"]/p/span[text()="NATIONALITY"]/following-sibling::span[1]
+      Birthdate:
+        selector: //div[@class="model-content"]/p/span[text()="DATE OF BIRTH"]/following-sibling::span[1]
+        postProcess:
+          - replace:
+              - regex: (st|[nr]d|th)
+                with: ""
+          - parseDate: January 2, 2006
 # Last Updated April 20, 2023


### PR DESCRIPTION
# Gallery

The dreamtranny.com site doesn't have a gallery section in the non-member preview/tour of the site.

This change allows a photo set to be scraped from the corresponding video scene page, e.g.

https://dreamtranny.com/update/626/

# Performer

Performers can now be scraped, e.g. https://dreamtranny.com/models/325/

# Scene

## Studio Code

Additionally, the studio code can be scraped from the URL, so I have added that to the scene scraper.