### PR TITLE
improvement: get higher resolution cover image for bangbros.com

### DIFF
--- a/scrapers/BangBros.yml
+++ b/scrapers/BangBros.yml
@@ -19,8 +19,8 @@ xPathScrapers:
         #selector: //img[@id="player-overlay-image"]/@src # Better image but can fail on older scenes
         postProcess:
           - replace:
-              - regex: ^
-                with: "https:"
+              - regex: '.*(//x-images\d\.bangbros\.com/[^/]+/shoots/[^/]+).*'
+                with: "https:$1/big_trailer.jpg"
       Studio:
         Name:
           selector: //div[@class="vdoCast"]/a[1]/text()
@@ -37,4 +37,4 @@ xPathScrapers:
           - subScraper:
               selector: //span[@class="thmb_mr_cmn thmb_mr_2 clearfix"]/span[@class="faTxt"]
           - parseDate: Jan 2, 2006
-# Last Updated June 08, 2022
+# Last Updated May 11, 2023

--- a/scrapers/FilthyFamily.yml
+++ b/scrapers/FilthyFamily.yml
@@ -22,8 +22,8 @@ xPathScrapers:
         selector: //video/@data-poster-url
         postProcess:
           - replace:
-              - regex: \[resolution\]
-                with: ipadbig.jpg
+              - regex: members/\[resolution\]
+                with: big_trailer.jpg
               - regex: ^//
                 with: https://
       Tags:
@@ -40,4 +40,4 @@ xPathScrapers:
           - replace:
               - regex: mobile\.bangbros\.com
                 with: mobile.filthyfamily.com
-# Last Updated February 27, 2023
+# Last Updated May 11, 2023


### PR DESCRIPTION
On the bangbros.com site, the cover image is in the `video` tag, with `poster` attribute, e.g.

https://bangbros.com/video3412985/harper-loves-money-and-anal has `//video/@poster` as `//x-images1.bangbros.com/bangbus/shoots/bb19269/members/450x340.jpg`

which is this 450x360 image:
![450x340](https://fapping.empornium.sx/images/2023/05/11/68747470733a2f2f782d696d61676573312e62616e6762726f732e636f6d2f62616e676275732f73686f6f74732f626231393236392f6d656d626572732f343530783334302e6a7067.jpg)

there are multiple variants of the image. The largest I could find is by dropping the `/members/450x340.jpg` and replacing with just `/big_trailer.jpg` to get a 980x571 image, e.g.

![980x571](https://fapping.empornium.sx/images/2023/05/11/screenshot_1.jpg)

this tweak of the scraper does this image URL transformation