### PR TITLE
Improve studio matching for WoodmanCastingX

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1417,7 +1417,7 @@ wicked.com|Algolia_Wicked.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check
 wildoncam.com|trafficpimps.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 williamhiggins.com|Williamhiggins.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 willtilexxx.com|WillTileXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-woodmancastingx.com|WoodmancastingX.y,l|:heavy_check_mark:|:x:|:x:|:x:|-|-
+woodmancastingx.com|WoodmancastingX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 wowgirls.xxx|WowPorn.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 wowgirlsblog.com|WOWGirlsBlog.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 wowporn.xxx|WowPorn.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/WoodmancastingX.yml
+++ b/scrapers/WoodmancastingX.yml
@@ -35,7 +35,13 @@ xPathScrapers:
                   with: "https://www.woodmancastingx.com/"
       Studio:
         Name:
-          fixed: Woodman Casting X
+          selector: //div[@id="breadcrumb"]
+          postProcess:
+            - replace:
+                - regex: ^[^>]*> (Casting|Sthuf).*$
+                  with: "Woodman Casting X"
+                - regex: ^[^>]*> (Scenes|Backstage|Live).*$
+                  with: "Pierre Woodman"
       Tags:
         Name: //a[@class="tag"]
       Image: //meta[@property="og:image"]/@content
@@ -52,4 +58,4 @@ xPathScrapers:
       URL:
         selector: $res/@href
         postProcess: *pp
-# Last Updated September 28, 2022
+# Last Updated May 30, 2023


### PR DESCRIPTION
After learning about the differences between the Woodman studios in [one of my edits](https://stashdb.org/edits/469bb3a0-8bb6-4714-ac10-f30e3eb4e03e) I figured I'd codify the correct behavior in the community scraper.

Woodman is split into three studios on StashDB:
[Woodman Casting X](https://stashdb.org/studios/cad7ddf0-c24c-4125-a2a3-af4287849364) - Casting scenes, both Soft and Hard. This also includes the older STHUF series of castings, of which there are only 37 and whose separate domain has expired.
[Pierre Woodman](https://stashdb.org/studios/f61bcdb2-1f43-4dd8-98ab-0b46e27e3dcb) - Everything else: stand-alone scenes, BTS content, live show recordings
[Wake Up n Fuck](https://stashdb.org/studios/c130a312-6144-40b7-a76b-cedad9e46707) - Separate series, handled by a separate scraper: unaffected by this PR

I have tested this improved scraper against every single scene from these two studios on StashDB and after [some](https://stashdb.org/edits/c01272f7-3eb8-4ed9-bb08-4ad79cbcac02) [edits](https://stashdb.org/edits/bab4d231-8d29-426b-88bc-c3d24a8973fe) [for](https://stashdb.org/edits/9e69d1c9-d90e-4b15-94d9-04eff4125efa) [the](https://stashdb.org/edits/c5d445c5-2983-4f56-bf14-c3de6323b02b) outliers that have slipped through the cracks, the results align with the above definitions.

Also fixes the typo in the scrapers list that I just now noticed that #1344 also fixes, so that can be closed if this accepted 😅 