### PR TITLE
add Movies and Code to sceneByURL in MindGeek.yml; add more sites to movieByURL

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -377,7 +377,7 @@ disruptivefilms.com|Algolia_disruptivefilms.yml|:heavy_check_mark:|:heavy_check_
 dlsite.com|DLsite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 doegirls.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dogfartnetwork.com|DogFart.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-doghousedigital.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
+doghousedigital.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|-
 dollrotic.com|GymRotic.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dollsporn.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 domai.com|SARJ-LLC.yml|:x:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
@@ -625,7 +625,7 @@ hustlerslesbians.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Lesbian
 hustlerstaboo.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 hypnotube.com|Hypnotube.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 iafd.com|IAFD.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|Python|Database
-iconmale.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+iconmale.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 idols69.com|karatmedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 ifeelmyself.com|IFeelMyself.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 ihuntmycunt.com|DollsHub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -794,7 +794,7 @@ metadataapi.net (JSON API)|ThePornDB.yml|:heavy_check_mark:|:x:|:heavy_check_mar
 metart.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
 metartnetwork.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
 metartx.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
-milehighmedia.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+milehighmedia.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 milfed.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 milfthing.com|PerfectGonzo.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 milftrip.com|VegasDreamsLLC.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -892,7 +892,7 @@ nhentai.net|nhentai.yml|:x:|:heavy_check_mark:|:x:|:x:|-|Hentai
 nikkibenz.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nikkiphoenixxx.com|NikkiAndTera.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ninakayy.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-noirmale.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+noirmale.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 noodledude.io|NoodleDude.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 notmygrandpa.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nubilefilms.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
@@ -1052,7 +1052,7 @@ ravenswallowzxxx.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rawattack.com|RawAttack.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rawcouples.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 reaganfoxx.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
-realityjunkies.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+realityjunkies.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 realitykings.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 realitylovers.com|RealityLovers.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 realjamvr.com|RealJamVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
@@ -1202,8 +1202,8 @@ swallowed.com|Nympho.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swallowsalon.com|AmateurAllure.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 sweetcarla.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 sweetfemdom.com|SweetFemdom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-sweetheartvideo.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Lesbian
-sweetsinner.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
+sweetheartvideo.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Lesbian
+sweetsinner.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|-
 sweetyx.com|SweetyX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swinger-blog.xxx|SwingerBlog.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swnude.com|Williamhiggins.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -73,6 +73,8 @@ xPathScrapers:
   sceneScraper:
     common:
       $section: //div[contains(@class,"tg5e7m")]/ancestor::section
+      $canonicalUrl: &canonicalUrl //link[@rel="canonical"]/@href
+      $movieUriPath: &movieUriPath //a[text()="Movie Info"]/@href
     scene:
       Title: $section//h1/text()|$section//h2/text()
       Date:
@@ -115,11 +117,34 @@ xPathScrapers:
                 sweetsinner: Sweet Sinner
                 teenslovehugecocks: Teens Love Huge Cocks
       Image: $section//img[contains(@src,"poster")]/@src
+      Movies: &sceneMovies
+        URL:
+          selector: $canonicalUrl|$movieUriPath
+          concat: __SEPARATOR__
+          postProcess:
+            - replace:
+              - regex: '^(https://[^/]+).+__SEPARATOR__'
+                with: $1
+        Name:
+          selector: $canonicalUrl|$movieUriPath
+          concat: __SEPARATOR__
+          postProcess:
+            - replace:
+              - regex: '^(https://[^/]+).+__SEPARATOR__'
+                with: $1
+            - subScraper:
+                selector: //h1/text()|//h2/text()
+      Code: &sceneCode
+        selector: $canonicalUrl
+        postProcess:
+          - replace:
+              - regex: '.*/scene/(\d+).*'
+                with: $1
   scriptScraper:
     common:
       $script: //script[@type="application/ld+json"]
-      $canonicalUrl: //link[@rel="canonical"]/@href
-      $movieUriPath: //a[text()="Movie Info"]/@href
+      $canonicalUrl: *canonicalUrl
+      $movieUriPath: *movieUriPath
     scene:
       Title:
         selector: $script
@@ -177,29 +202,8 @@ xPathScrapers:
                 with: '"'
       Performers:
         Name: //div/*[self::h1 or self::h2]/..//a[contains(@href,"/model")]
-      Movies:
-        URL:
-          selector: $canonicalUrl|$movieUriPath
-          concat: __SEPARATOR__
-          postProcess:
-            - replace:
-              - regex: '^(https://[^/]+).+__SEPARATOR__'
-                with: $1
-        Name:
-          selector: $canonicalUrl|$movieUriPath
-          concat: __SEPARATOR__
-          postProcess:
-            - replace:
-              - regex: '^(https://[^/]+).+__SEPARATOR__'
-                with: $1
-            - subScraper:
-                selector: //h2/text()
-      Code:
-        selector: $canonicalUrl
-        postProcess:
-          - replace:
-              - regex: '.*/scene/(\d+).*'
-                with: $1
+      Movies: *sceneMovies
+      Code: *sceneCode
   movieScraper:
     common:
       $section: //div[text()="Release Date:"]/ancestor::section

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -42,8 +42,15 @@ sceneByURL:
 movieByURL:
   - action: scrapeXPath
     url:
-      - digitalplayground.com/movie
-      - transsensual.com/movie
+      - digitalplayground.com/movie/
+      - doghousedigital.com/movie/
+      - iconmale.com/movie/
+      - milehighmedia.com/movie/
+      - noirmale.com/movie/
+      - realityjunkies.com/movie/
+      - sweetheartvideo.com/movie/
+      - sweetsinner.com/movie/
+      - transsensual.com/movie/
     scraper: movieScraper
 
 performerByURL:

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -118,6 +118,8 @@ xPathScrapers:
   scriptScraper:
     common:
       $script: //script[@type="application/ld+json"]
+      $canonicalUrl: //link[@rel="canonical"]/@href
+      $movieUriPath: //a[text()="Movie Info"]/@href
     scene:
       Title:
         selector: $script
@@ -175,7 +177,29 @@ xPathScrapers:
                 with: '"'
       Performers:
         Name: //div/*[self::h1 or self::h2]/..//a[contains(@href,"/model")]
-
+      Movies:
+        URL:
+          selector: $canonicalUrl|$movieUriPath
+          concat: __SEPARATOR__
+          postProcess:
+            - replace:
+              - regex: '^(https://[^/]+).+__SEPARATOR__'
+                with: $1
+        Name:
+          selector: $canonicalUrl|$movieUriPath
+          concat: __SEPARATOR__
+          postProcess:
+            - replace:
+              - regex: '^(https://[^/]+).+__SEPARATOR__'
+                with: $1
+            - subScraper:
+                selector: //h2/text()
+      Code:
+        selector: $canonicalUrl
+        postProcess:
+          - replace:
+              - regex: '.*/scene/(\d+).*'
+                with: $1
   movieScraper:
     common:
       $section: //div[text()="Release Date:"]/ancestor::section
@@ -326,4 +350,4 @@ xPathScrapers:
       Image:
         selector: //img[contains(@src, "model")]/@src
       URL: //link[@rel="canonical"]/@href
-# Last Updated January 15, 2023
+# Last Updated May 31, 2023


### PR DESCRIPTION
# sceneByURL

This improves the MindGeek.yml scraper to add scene Studio Code and scene Movies to the `sceneByURL`  scraper.

Not all scenes have a corresponding movie. Example scene URLs that can now scrape the scene's studio code and corresponding movie:

- https://www.doghousedigital.com/scene/8735141/teen-anal-scene-2
- https://www.iconmale.com/scene/8531671/hot-daddies-4-scene-3
- https://www.milehighmedia.com/scene/8694661/cream-pie-virgins-8-scene-4-not-so-innocent
- https://www.noirmale.com/scene/4392840/gym-rat
- https://www.realityjunkies.com/scene/8636861/big-boob-babysitters-scene-3-adult-playdate
- https://www.sweetheartvideo.com/scene/8696661/lesbian-beauties-22-interracial-scene-4-interracial-love
- https://www.sweetsinner.com/scene/8735271/the-seductress-4-scene-4-seduce-me
- https://www.transsensual.com/scene/8691901/ts-wife-swap-4-scene-2-my-wife-your-wife

# movieByURL

The following domains are added:

- doghousedigital.com
- iconmale.com
- milehighmedia.com
- noirmale.com
- realityjunkies.com
- sweetheartvideo.com
- sweetsinner.com

