### PR TITLE
xpath, improvement: Add tags to Grooby

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -447,6 +447,7 @@ femdomempire.com|FemdomEmpire.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|
 feminized.com|FemdomEmpire.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Trans
 femjoy.com|FemJoy.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 femlatex.com|GymRotic.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+femout.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 femoutsex.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 ferame.com|Jhdv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 fetishnetwork.com|FetishNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Fetish
@@ -1057,6 +1058,7 @@ realitykings.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 realitylovers.com|RealityLovers.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 realjamvr.com|RealJamVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 realsensual.com|RealSensual.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+realtgirls.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 realtimebondage.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realvr.com|BaDoink.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
 redheadmariah.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1262,6 +1264,8 @@ tgirls.porn|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|
 tgirls.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 tgirlsex.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 tgirlsfuck.com|GroobyNetwork-Brazilian.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+tgirlshookup.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
+tgirltops.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 thatsitcomshow.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 theartporn.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 theassfactory.com|JulesJordan.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
@@ -1313,6 +1317,7 @@ transgasm.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x
 transgressivefilms.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Trans
 transgressivexxx.com|Algolia_EvilAngel|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|Trans
 transmodeldatabase.com|TransModelDatabase.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Trans
+transnificent.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 transroommates.com|Arx.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Trans
 transsensual.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|Trans
 transsexualangel.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans

--- a/scrapers/GroobyClub.yml
+++ b/scrapers/GroobyClub.yml
@@ -44,4 +44,6 @@ xPathScrapers:
           - replace:
               - regex: "(^[^|]+)\\|.*/tour/([^\\.]+\\.jpg).*"
                 with: $1$2
-# Last Updated June 26, 2022
+      Tags:
+        Name: //div[@class="set_tags"]/ul/li//a/text()
+# Last Updated June 07, 2023

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -47,12 +47,25 @@ xPathScrapers:
         Name: //div[@class="setdesc"]//a/text()
       Studio: &studio
         Name: //meta[@name="author"]/@content
+        URL:
+          selector: //link[@rel="canonical"]/@href
+          postProcess:
+            - replace:
+                - regex: (https://[^/]*)/.*
+                  with: $1
       Image:
-        selector: //meta[@property="og:image"]/@content
+        selector: //link[@rel="canonical"]/@href|//img[contains(@class, "update_thumb thumbs stdimage")]/@src|//img[contains(@class, "update_thumb thumbs stdimage")]/@src0_1x
+        concat: "__SEPARATOR__"
         postProcess:
           - replace:
-              - regex: ^// # bobstgirls
+              - regex: ^.*__SEPARATOR__// # bobstgirls
                 with: "https://"
+              - regex: ^(https://[^/]*)/.*(__SEPARATOR__.*)$
+                with: $1$2
+              - regex: content//
+                with: content/
+              - regex: __SEPARATOR__
+                with: ''
       Tags: &tags
         Name: //div[@class="set_tags"]/ul/li//a/text()
   galleryScraper:

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -40,7 +40,9 @@ xPathScrapers:
         selector: //div[@class="setdesc"]//b[contains(.,"Added")]/following-sibling::text()[1]
         postProcess:
           - parseDate: January 2, 2006
-      Details: &details //div[@class="trailerpage_info"]/p[not(@class)]/text()
+      Details: &details
+        selector: //div[@class="trailerpage_info"]/p[not(@class)]/text()|//div[@class="trailerpage_info"]/p[not(@class)]/span/text()
+        concat: "\n\n"
       Performers: &performers
         Name: //div[@class="setdesc"]//a/text()
       Studio: &studio
@@ -68,7 +70,9 @@ xPathScrapers:
         selector: //div[@class="set_meta"]//b[contains(.,"Added")]/following-sibling::text()[1]
         postProcess:
           - parseDate: January 2, 2006
-      Details: //div[@class="trailerblock"]/p[not(@class)]/text()
+      Details:
+        selector: //div[@class="trailerblock"]/p[not(@class)]/text()
+        concat: "\n\n"
       Performers:
         Name: //div[@class="trailer_toptitle_left"]//a/text()
       Studio: *studio
@@ -82,4 +86,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.groobyvr.com/
       Tags: *tags
-# Last Updated June 07, 2023
+# Last Updated June 28, 2023

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -41,8 +41,7 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details: &details
-        selector: //div[@class="trailerpage_info"]/p[not(@class)]/text()|//div[@class="trailerpage_info"]/p[not(@class)]/span/text()
-        concat: "\n\n"
+        selector: string(//div[@class="trailerpage_info"]/p[not(@class)])
       Performers: &performers
         Name: //div[@class="setdesc"]//a/text()
       Studio: &studio

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -46,6 +46,8 @@ xPathScrapers:
           - replace:
               - regex: ^// # bobstgirls
                 with: "https://"
+      Tags: &tags
+        Name: //div[@class="set_tags"]/ul/li//a/text()
   galleryScraper:
     gallery:
       Title: *title
@@ -53,6 +55,7 @@ xPathScrapers:
       Details: *details
       Performers: *performers
       Studio: *studio
+      Tags: *tags
   sceneScraperGroobyVR:
     scene:
       Title: *title
@@ -73,4 +76,5 @@ xPathScrapers:
           - replace:
               - regex: ^/
                 with: https://www.groobyvr.com/
-# Last Updated December 19, 2022
+      Tags: *tags
+# Last Updated June 07, 2023

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -7,17 +7,22 @@ sceneByURL:
       - blacktgirlshardcore.com
       - black-tgirls.com
       - bobstgirls.com
+      - femout.xxx
       - femoutsex.xxx #Scenes on 'femout.xxx' can some times be found on this one as well
       - franks-tgirlworld.com
       - grooby-archives.com
       - groobygirls.com
       - ladyboy-ladyboy.com
       - ladyboy.xxx
+      - realtgirls.com
       - tgirlsex.xxx
       - tgirls.porn
       - tgirls.xxx
+      - tgirlshookup.com
+      - tgirltops.com
       - transexpov.com
       - transgasm.com
+      - transnificent.com
     scraper: sceneScraper
   - action: scrapeXPath
     url:

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -41,7 +41,8 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details: &details
-        selector: string(//div[@class="trailerpage_info"]/p[not(@class)])
+        selector: //div[@class="trailerpage_info"]/p[not(@class)]/descendant-or-self::*/text()
+        concat: "\n\n"
       Performers: &performers
         Name: //div[@class="setdesc"]//a/text()
       Studio: &studio
@@ -98,4 +99,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.groobyvr.com/
       Tags: *tags
-# Last Updated June 28, 2023
+# Last Updated July 03, 2023


### PR DESCRIPTION
Grooby sites appear to have recently added tags to their scenes.

This change adds tag scraping.

It also adds support for additional Grooby network sites.

Tested as working for scenes at various sites. Have not been able to confirm the gallery scraping with tags is working or not, as galleries seem to be not accessible in the free/preview/tour view of the sites.