### PR TITLE
xpath, improvement: add another xpath for image for Hustler

### DIFF
--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -39,19 +39,21 @@ sceneByURL:
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
+    common:
+      $content: //div[@class="panel-content"]
     scene:
-      Title: //h3/a/text()
+      Title: //h3/a/text()|$content//h3[contains(@class, "headline")]/a/text()
       URL: //link[@rel='canonical']/@href
       Performers:
         Name: 
-          selector: //span[@class="attr-key" and contains(text(),"Cast")]/following-sibling::span[@class="attr-value"]/a[not(text()="Hustler Models") and not(text()="Barely Legal Models")]/text()
+          selector: //span[@class="attr-key" and contains(text(),"Cast")]/following-sibling::span[@class="attr-value"]/a[not(text()="Hustler Models") and not(text()="Barely Legal Models")]/text()|$content//span[contains(text(), "Cast")]//following-sibling::span/a/text()
       Date:
-        selector: //span[@class="attr-key" and contains(text(),"Released")]/following-sibling::span[@class="attr-value"]/text()
+        selector: //span[@class="attr-key" and contains(text(),"Released")]/following-sibling::span[@class="attr-value"]/text()|$content//span[contains(text(), "Released")]//following-sibling::span/text()
         postProcess:
           - parseDate: Jan 02, 2006
-      Details: //meta[@property="og:description"]/@content|//div[@class="description"]/p
+      Details: //p[following-sibling::a[@class="clickable"]]|//meta[@property="og:description"]/@content|//div[@class="description"]/p
       Image:
-        selector: //div[@class="img-container"]/img/@src|//div[contains(@class, "jw-preview")]/@style
+        selector: //div[@class="img-container"]/img/@src|//div[contains(@class, "jw-preview")]/@style|$content/img/@src
         postProcess:
           - replace:
               - regex: (?:background-image:\s*url\(")(.+)(?:"\).*);?
@@ -66,4 +68,4 @@ driver:
   clicks:
     - xpath: //a[@class="clickable"]
       sleep: 2
-# Last Updated June 23, 2023
+# Last Updated June 30, 2023

--- a/scrapers/Hustler.yml
+++ b/scrapers/Hustler.yml
@@ -50,7 +50,12 @@ xPathScrapers:
         postProcess:
           - parseDate: Jan 02, 2006
       Details: //meta[@property="og:description"]/@content|//div[@class="description"]/p
-      Image: //div[@class="img-container"]/img/@src
+      Image:
+        selector: //div[@class="img-container"]/img/@src|//div[contains(@class, "jw-preview")]/@style
+        postProcess:
+          - replace:
+              - regex: (?:background-image:\s*url\(")(.+)(?:"\).*);?
+                with: $1
       Tags:
         Name: //div[@class="tag-list"]/a/text()
       Studio:
@@ -61,4 +66,4 @@ driver:
   clicks:
     - xpath: //a[@class="clickable"]
       sleep: 2
-# Last Updated February 01, 2020
+# Last Updated June 23, 2023


### PR DESCRIPTION
This adds another xpath selector for the existing Hustler.yaml scraper so that it can get the cover image for scene pages, e.g.

- https://www.hustler.com/model/charity-bangs/movie/20151116/black_cock_justice_pt__2
- https://www.hustler.com/model/madelyn-monroe/movie/20151123/black_cock_justice_pt__2

I left the existing selector in case there are different styles/layouts for scene pages where the existing selector will continue to work.