### PR TITLE
Update CopyToGallery.py

### DIFF
--- a/scrapers/CopyToGallery.py
+++ b/scrapers/CopyToGallery.py
@@ -26,7 +26,7 @@ def get_gallery_id_by_path(gallery_path):
               }
             }
             """
-    variables = {"galleries_filter": {"path": {'value': gallery_path, "modifier": "INCLUDES_ALL"}}}
+    variables = {"galleries_filter": {"path": {'value': gallery_path, "modifier": "EQUALS"}}}
     result = call_graphql(query, variables)
     log.debug("get_gallery_by_path callGraphQL result " + str(result))
     return result['findGalleries']['galleries'][0]['id']


### PR DESCRIPTION
The `INCLUDES_ALL` modifier is no longer supported with gallery path filters. I've updated the code to use the `EQUALS` modifier instead.