### PR TITLE
MenAtPlay: Fix line breaks in details

### DIFF
--- a/scrapers/MenAtPlay.yml
+++ b/scrapers/MenAtPlay.yml
@@ -10,8 +10,8 @@ xPathScrapers:
          Title:
             selector: //div[@class="gallery_info spacer"]/h1/text()
          Details:
-            selector: //div[@class="containerText"]/p
-            concat: "\n"
+            selector: //div[@class="containerText"]/p//text()
+            concat: "\n\n"
          Performers:
             Name:
                selector: //div[@class="gallery_info spacer"]/p/span[@class="tour_update_models"]/a/text()
@@ -26,4 +26,4 @@ xPathScrapers:
          Studio:
             Name:
                fixed: MenAtPlay
-# Last Updated May 29, 2022
+# Last Updated July 2, 2023


### PR DESCRIPTION
Seems that MenAtPlay has two different formats for the description block the scraper uses for details: one `<p></p>` per paragraph, and one big `<p></p>` with paragraphs split by `<br><br>`. The current scraper only worked for the former; all paragraph breaks get dropped with the latter. This change to the scraper makes it preserve paragraph breaks with both.
