### PR TITLE
xpath, fix, improvement: transerotica.com - fixes the Date and Studio Name

### DIFF
--- a/scrapers/Transerotica.yml
+++ b/scrapers/Transerotica.yml
@@ -12,10 +12,10 @@ xPathScrapers:
       Title: //h1[@class='title_bar']
       Image: //div[@id="player"]/video/@poster
       Date:
-        selector: $update//comment()
+        selector: $update/p/span/preceding-sibling::comment()
         postProcess:
           - replace:
-              - regex: .*(?:class='upddate').*(\d{2}/\d{2}/\d{4}).*
+              - regex: .*(\d{2}/\d{2}/\d{4}).*
                 with: $1
           - parseDate: "01/02/2006"
           - map:
@@ -35,5 +35,5 @@ xPathScrapers:
           split: ","
       Studio:
         Name:
-          fixed: Trans Erotica
-# Last Updated February 06, 2023
+          fixed: TransErotica
+# Last Updated July 07, 2023


### PR DESCRIPTION
The Date scraping does not currently work, as it selects the duration text. This change fixes the selector to grab the commented date text, and then extract the MM/DD/YYYY date.

The fixed studio name should be TransErotica, to match that on stashdb, so I've done that too.