### PR TITLE
Improve WowNetworkVenus

### DIFF
--- a/scrapers/WowNetworkVenus/WowNetworkVenus.py
+++ b/scrapers/WowNetworkVenus/WowNetworkVenus.py
@@ -242,13 +242,24 @@ def search_query_prep(string: str):
 def similar(a, b):
     return SequenceMatcher(None, a, b).ratio()
 
+def isSingleLetterEnglishWord(word: str):
+    word = word.lower()
+    return (word == "a" or word == "i")
+
+def commonWordFixes(word: str):
+    word = word.lower()
+    if word == "cant":
+        return "can't"
+    else:
+        return word
+
 def unCamelCase(string: str):
     substring = ""
     resultstring = ""
     for i, v in enumerate(string):
         if v.isupper() or v.isnumeric():
-            if len(substring) > 1:
-                resultstring = resultstring + substring + " "
+            if len(substring) > 1 or isSingleLetterEnglishWord(substring):
+                resultstring = resultstring + commonWordFixes(substring) + " "
                 substring = ""
         substring = substring + v
     
@@ -275,20 +286,26 @@ def parseFilename(string: str):
             "artists": []
         }
 
-def sortBySimilarity(originalName, originalArtists, options):
+def sortBySimilarity(originalName, originalPerformers, options):
     scores = arr.array('d', [])
 
+    originalName_lowercase = originalName.lower()
+    originalPerformers_lowercase = [x.lower() for x in originalPerformers]
+
     for scene in options:
-        scene_name = scene["title"]
-        scene_artists = [artist["name"] for artist in scene["performers"]]
+        optionName = scene["title"]
+        optionName_lowercase = optionName.lower()
 
-        name_similarity = similar(NAME, scene_name)
-        artists_similarity = similar(sorted(ARTISTS), sorted(scene_artists))
+        optionPerformers = [artist["name"] for artist in scene["performers"]]
+        optionPerformers_lowercase = [x.lower() for x in optionPerformers]
 
-        log.debug("similarity between " + str(NAME) + " and " + str(scene_name) + " is: " + str(name_similarity * 100) + "%")
-        log.debug("similarity between " + str(ARTISTS) + " and " + str(scene_artists) + " is: " + str(artists_similarity * 100) + "%")
+        nameSimilarity = similar(originalName_lowercase, optionName_lowercase)
+        performersSimilarity = similar(sorted(originalPerformers_lowercase), sorted(optionPerformers_lowercase))
 
-        this_similarity = ((name_similarity + artists_similarity) / 2)
+        log.debug("similarity between \"" + str(originalName) + "\" and \"" + str(optionName) + "\" is: " + str(nameSimilarity * 100) + "%")
+        log.debug("similarity between " + str(originalPerformers) + " and " + str(optionPerformers) + " is: " + str(performersSimilarity * 100) + "%")
+
+        this_similarity = ((nameSimilarity + performersSimilarity) / 2)
 
         log.debug("score: "+ str(this_similarity))
 

--- a/scrapers/WowNetworkVenus/WowNetworkVenus.yml
+++ b/scrapers/WowNetworkVenus/WowNetworkVenus.yml
@@ -4,6 +4,7 @@ sceneByURL:
     script:
       - python
       - WowNetworkVenus.py
+      - url
     url:
       - venus.ultrafilms.com
       - venus.wowgirls.com
@@ -14,9 +15,17 @@ sceneByName:
     script:
       - python
       - WowNetworkVenus.py
+      - search
 sceneByQueryFragment:
     action: script
     script:
       - python
       - WowNetworkVenus.py
-# Last Updated September 21, 2022
+      - fragment
+sceneByFragment:
+    action: script
+    script:
+      - python
+      - WowNetworkVenus.py
+      - query
+# Last Updated July 9, 2023


### PR DESCRIPTION
- added filename schema parsing for files downloaded via the normal download buttons (still works with filenames, that do not fit the schema)
- results sorted by similarity taking performers into account if they could be determined from the filename, instead of the useless default sorting of the scraped search results
- fix no result issue, if there is a number in the scene name (removes numbers from search scraping request)
- added sceneByFragment/Scene Identify capabilities

It is unlikely, that I will find the time to implement changes the maintaners may want, It works for my usecases so basically I am leaving this here for anyone that wants to use it, or for anybody that has the time to upstream it. I may miss notifications, as this is obvsiously a throwaway account.

Potential Improvements (listing this here in case somebody else takes over):
- [x] Bring into naming conventions (artists -> performers)
- [ ] Change param[1] naming, currently in line with torrent.py, but quite confusing
- [ ] Get rid of interleave_results(), the sorting makes this unnecessary, but still calling the function
- [ ] Check if the new sys.argv[1] logic covers all usecases of the previous  if NAME / if URL logic
- [ ] remove debug log messages (?)