### PR TITLE
script, improvement: add galleryByFragment to Algolia.py / Algolia_Adulttime.yml

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -104,6 +104,7 @@ asianamericantgirls.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 asianfever.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 asiansexdiary.com|VegasDreamsLLC.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 asiantgirl.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
+asmrfantasy.com|Algolia_Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
 assholefever.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 assmeat.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 assteenmouth.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -938,7 +939,7 @@ onlyblowjob.com|DDFNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 onlygolddigger.com|Only3xGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 onlyprince.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 onlyteenblowjobs.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-oopsie.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
+oopsie.com|Algolia_Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
 openlife.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 oraloverdose.com|PervCity.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 oreno3d.com|Oreno3d.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1323,7 +1324,7 @@ transerotica.com|Transerotica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 transexdomination.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 transexpov.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 transfeet.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-transfixed.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Trans
+transfixed.com|Algolia_Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Trans
 transgasm.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 transgressivefilms.com|Algolia_Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Trans
 transgressivexxx.com|Algolia_EvilAngel|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|Trans

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -81,7 +81,7 @@ galleryByFragment:
     script:
       - python
       - Algolia.py
-      - girlsway
+      - puretaboo
       - gallery
 galleryByURL:
   - action: script

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -8,6 +8,7 @@ sceneByURL:
       - adulttimepilots.com/en/video/
       - agentredgirl.com/en/video/
       - analteenangels.com/en/video/
+      - asmrfantasy.com/en/video/
       - assholefever.com/en/video/
       - beingtrans247.com/en/video/
       - blowmepov.com/en/video/

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -76,6 +76,13 @@ sceneByQueryFragment:
       - Algolia.py
       - girlsway
       - validName
+galleryByFragment:
+    action: script
+    script:
+      - python
+      - Algolia.py
+      - girlsway
+      - gallery
 galleryByURL:
   - action: script
     url:
@@ -104,4 +111,4 @@ movieByURL:
       - Algolia.py
       - puretaboo
       - movie
-# Last Updated May 25, 2023
+# Last Updated July 18, 2023


### PR DESCRIPTION
This allows `galleryByFragment` to be added to any scraper yaml that uses Algolia.py script, to add `Scrape With...` option to the gallery to allow search by Title (Saved), e.g.:

- Caught In The Shower

gives https://www.oopsie.com/en/photo/Caught-In-The-Shower/92293, which _would_ be the gallery URL (by convention) if the oopsie.com site had a Pictures section, but it does not.

So this allows Studios without public/free/tour galleries, that have scene photosets, to be scraped from the Algolia API.

For reference, the gallery corresponds to scene:

- https://oopsie.com/en/video/oopsie/Caught-In-The-Shower/201547

### More examples:

Title (Saved): Love Is In Your Future
gives: https://www.asmrfantasy.com/en/photo/Love-Is-In-Your-Future/96680
(which is not public)
but is the photoset for https://www.asmrfantasy.com/en/video/asmrfantasy/Love-Is-In-Your-Future/199196

Title (Saved): Morning Pleasures
gives: https://www.transfixed.com/en/photo/Morning-Pleasures/89259
(which is not public)
but is the photoset for https://transfixed.com/en/video/transfixed/Morning-Pleasures/197315

### Additional

Studio asmrfantasy.com added