### PR TITLE
fix: mylf.com - get details/description text from all element in div

### DIFF
--- a/scrapers/Mylf.yml
+++ b/scrapers/Mylf.yml
@@ -8,7 +8,7 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //h2[contains(@class,"sceneTitle")]/text()
-      Details: //div[contains(@class,"sceneDesc")]/text()
+      Details: //div[contains(@class,"sceneDesc")]//text()
       Date:
         selector: //div[contains(@class,"sceneDate")]/text()
         postProcess:
@@ -47,4 +47,4 @@ xPathScrapers:
                 MylfBoss: Mylf Boss
                 MylfSelects: Mylf Selects
                 StayHomeMilf: Stay Home Milf
-# Last Updated June 27, 2022
+# Last Updated July 21, 2023


### PR DESCRIPTION
# problem

Currently the scraper only gets text from the matching `<div>`, so scenes like https://www.mylf.com/movies/concept-maid-in-heaven don't get the Details scraped as the text is in a child `<p>` tag within the `<div>`

# solution

this fix gets text from all elements within the div, see example scene URL HTML and try scraping with/without this fix to see it in action