### PR TITLE
xpath, improvement: Add gallery by url for transsensual

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1330,7 +1330,7 @@ transgressivexxx.com|Algolia_EvilAngel|:heavy_check_mark:|:heavy_check_mark:|:he
 transmodeldatabase.com|TransModelDatabase.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Trans
 transnificent.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 transroommates.com|Arx.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Trans
-transsensual.com|MindGeek.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|Trans
+transsensual.com|MindGeek.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|-|Trans
 transsexualangel.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 transsexualroadtrip.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tranzvr.com|POVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -39,6 +39,12 @@ sceneByURL:
       - trueamateurs.com/scene/
     scraper: scriptScraper
 
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - transsensual.com/scene
+    scraper: galleryFromSceneScriptScraper
+
 movieByURL:
   - action: scrapeXPath
     url:
@@ -149,17 +155,17 @@ xPathScrapers:
                 with: $1
   scriptScraper:
     common:
-      $script: //script[@type="application/ld+json"]
+      $script: &script //script[@type="application/ld+json"]
       $canonicalUrl: *canonicalUrl
       $movieUriPath: *movieUriPath
     scene:
-      Title:
+      Title: &title
         selector: $script
         postProcess:
           - replace:
               - regex: '.+"name": "([^"]+)".+'
                 with: $1
-      Date:
+      Date: &date
         selector: $script
         postProcess:
           - replace:
@@ -172,7 +178,7 @@ xPathScrapers:
           - replace:
               - regex: '.+"thumbnailUrl": "([^"]+)".+'
                 with: $1
-      Studio:
+      Studio: &studio
         Name:
           selector: //div[contains(@class,"tg5e7m")]/ancestor::section//a[contains(@href,"site=")]/@title|//link[@rel="canonical"]/@href
           postProcess:
@@ -197,7 +203,7 @@ xPathScrapers:
                 transsensual: TransSensual
                 trueamateurs: True Amateurs
       Tags: *tags
-      Details:
+      Details: &details
         selector: $script
         postProcess:
           - replace:
@@ -207,7 +213,7 @@ xPathScrapers:
                 with: $1
               - regex: '\|'
                 with: '"'
-      Performers:
+      Performers: &performers
         Name: //div/*[self::h1 or self::h2]/..//a[contains(@href,"/model")]
       Movies: *sceneMovies
       Code: *sceneCode
@@ -361,4 +367,14 @@ xPathScrapers:
       Image:
         selector: //img[contains(@src, "model")]/@src
       URL: //link[@rel="canonical"]/@href
-# Last Updated May 31, 2023
+  galleryFromSceneScriptScraper:
+    common:
+      $script: *script
+    gallery:
+      Title: *title
+      Date: *date
+      Details: *details
+      Performers: *performers
+      Tags: *tags
+      Studio: *studio
+# Last Updated July 21, 2023


### PR DESCRIPTION
This adds `galleryByURL` for transsensual.com by using the (video) scene URL.

The video scenes at transsensual.com have corresponding photo sets, but the public/free/preview view of the website does not have gallery URLs. This change allows a gallery to be scraped by using the scene URL instead, as the data will be identical.

Example URL: https://www.transsensual.com/scene/4488881/when-the-mans-away-a-lady-shall-play