### PR TITLE
fix: sexbabesvr - fix for updated layout

### DIFF
--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -26,8 +26,7 @@ xPathScrapers:
             - replace:
                 - regex: ^\s*(.+)\s*$
                   with: $1
-      Image:
-        selector: //dl8-video/@poster
+      Image: //dl8-video/@poster
       Studio:
         Name:
           fixed: "SexBabesVR"

--- a/scrapers/SexBabesVR.yml
+++ b/scrapers/SexBabesVR.yml
@@ -7,30 +7,28 @@ sceneByURL:
 xPathScrapers:
   sceneScraper:
     common:
-      $info: //div[@class="video-info"]
+      $detail: //div[@class="video-detail"]
     scene:
-      Title: $info//div[@class="video-group-left"]//h1[@class="title"]/text()
+      Title: $detail//h1/text()
       Date:
-        selector: $info//span[@class="date-display-single"]/@content
+        selector: $detail//div[@class="video-detail__description--container"]/div[contains(@style, "padding-top")]/text()
         postProcess:
-          - replace:
-              - regex: (\d{4}-\d{2}-\d{2})T.+
-                with: $1
-          - parseDate: 2006-01-02
+          - parseDate: Jan 02
       Details:
-        selector: $info//p/text()
+        selector: $detail/div[@class="container"]/p/text()
         concat: " "
       Tags:
-        Name: $info//div[@class="video-group-left"]/div[@class="video-tags"]//a/text()
+        Name: $detail//div[@class="tags"]//a/text()
       Performers:
-        Name: $info//div[@class="video-group-left"]/div[@class="video-actress-name"]//a/text()
+        Name:
+          selector: $detail//div[@class="video-detail__description--author"]//a/text()
+          postProcess:
+            - replace:
+                - regex: ^\s*(.+)\s*$
+                  with: $1
       Image:
-        selector: //div[@class="splash-screen fullscreen-message is-visible"]/@style
-        postProcess:
-          - replace:
-              - regex: .+(http[^\)]+).+
-                with: $1
+        selector: //dl8-video/@poster
       Studio:
         Name:
           fixed: "SexBabesVR"
-# Last Updated August 14, 2022
+# Last Updated July 21, 2023


### PR DESCRIPTION
The scraper appears to be for a layout that has now changed.

Example scene: https://sexbabesvr.com/video/the-best-plans

Note that the date presented on the scene pages is in "mmm dd" format without the year, so it doesn't look like the year can be determined from the scene page.

With these changes the date is scraped, e.g. 0000-03-25, so at least the day of the month and month are present and the person scraping can just replace with the correct year.