### PR TITLE
fix: move brazilian-transsexuals.com and tgirlsfuck.com to other Grooby scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -222,7 +222,7 @@ brasilvr.com|POVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 brattyfamily.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 brattymilf.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 brattysis.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
-brazilian-transsexuals.com|GroobyNetwork-Brazilian.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+brazilian-transsexuals.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 braziltgirls.xxx|GroobyNetwork-Brazilian.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 brazzers.com|Brazzers.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|CDP|-
 breeditraw.com|BreedItRaw.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
@@ -1279,7 +1279,7 @@ tgirlpostop.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tgirls.porn|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 tgirls.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 tgirlsex.xxx|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
-tgirlsfuck.com|GroobyNetwork-Brazilian.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+tgirlsfuck.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 tgirlshookup.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 tgirltops.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 thatsitcomshow.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-

--- a/scrapers/GroobyNetwork-Brazilian.yml
+++ b/scrapers/GroobyNetwork-Brazilian.yml
@@ -2,7 +2,6 @@ name: "GroobyNetwork-Brazilian"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - brazilian-transsexuals.com
       - braziltgirls.xxx
       - tgirlsfuck.com
     scraper: sceneScraper
@@ -36,4 +35,4 @@ xPathScrapers:
               - regex: ^\/\/
                 with: "https://"
 
-# Last Updated January 09, 2023
+# Last Updated July 27, 2023

--- a/scrapers/GroobyNetwork-Brazilian.yml
+++ b/scrapers/GroobyNetwork-Brazilian.yml
@@ -3,7 +3,6 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - braziltgirls.xxx
-      - tgirlsfuck.com
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -7,6 +7,7 @@ sceneByURL:
       - blacktgirlshardcore.com
       - black-tgirls.com
       - bobstgirls.com
+      - brazilian-transsexuals.com
       - femout.xxx
       - femoutsex.xxx #Scenes on 'femout.xxx' can some times be found on this one as well
       - franks-tgirlworld.com
@@ -99,4 +100,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.groobyvr.com/
       Tags: *tags
-# Last Updated July 03, 2023
+# Last Updated July 27, 2023

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -56,7 +56,7 @@ xPathScrapers:
                 - regex: (https://[^/]*)/.*
                   with: $1
       Image:
-        selector: //link[@rel="canonical"]/@href|//img[contains(@class, "update_thumb thumbs stdimage")]/@src|//img[contains(@class, "update_thumb thumbs stdimage")]/@src0_1x
+        selector: //link[@rel="canonical"]/@href|//img[contains(@class, "update_thumb thumbs stdimage")]/@src|//img[contains(@class, "update_thumb thumbs stdimage")]/@src0_1x|//div[@class="trailerposter"]/img/@src0
         concat: "__SEPARATOR__"
         postProcess:
           - replace:

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -19,6 +19,7 @@ sceneByURL:
       - tgirlsex.xxx
       - tgirls.porn
       - tgirls.xxx
+      - tgirlsfuck.com
       - tgirlshookup.com
       - tgirltops.com
       - transexpov.com


### PR DESCRIPTION
The brazilian-transsexuals.com and tgirlsfuck.com sites have changed their HTML layout code which now uses the same CSS classes as in the majority of other Grooby sites.

This change just moves the domains over. The braziltgirls.xxx site still uses the old layout style.