### PR TITLE
Update GroobyClub for new layout

### DIFF
--- a/scrapers/GroobyClub.yml
+++ b/scrapers/GroobyClub.yml
@@ -6,7 +6,6 @@ sceneByURL:
       - asianamericantgirls.com
       - canada-tgirl.com
       - euro-tgirls.com
-      - grooby.club
       - hazel-tucker.com
       - krissy4u.com
       - russian-tgirls.com
@@ -17,33 +16,63 @@ sceneByURL:
       - transexdomination.com
       - ts-castingcouch.com
       - uk-tgirls.com
+    scraper: substudioScraper
+  - action: scrapeXPath
+    url:
+      - grooby.club
       # other grooby sites which work
       - tgirljapan.com
       - tgirljapanhardcore.com
-    scraper: sceneScraper
+    scraper: clubScraper
+
 xPathScrapers:
-  sceneScraper:
+  clubScraper:
     scene:
-      Title: //div[@class="trailer_videoinfo"]//h3/text()
-      Date:
-        selector: //div[@class="trailer_videoinfo"]//b[contains(.,"Added")]/following-sibling::text()[1]
+      Title: &title //div[@class="trailer_toptitle_left"]
+      Date: &date
+        selector: //b[contains(.,"Added")]/following-sibling::text()[1]
         postProcess:
           - replace:
               - regex: ^-
                 with: ""
-          - parseDate: Jan 2, 2006
-      Details: //div[@class="trailer_videoinfo"]/p[not(b)]
-      Performers:
-        Name: //div[@class="trailer_videoinfo"]//b[contains(.,"Featuring")]/following-sibling::a/text()[1]
+          - parseDate: January 2, 2006
+      Details: &details
+        selector: //div[@class="trailerpage_info"]/p/text()
+        concat: " "
+      Performers: &performers
+        Name: //div[@class="setdesc"]//a[contains(@href, "models")]/text()
       Studio:
-        Name: //meta[@name="author"]/@content
-      Image:
-        selector: //base/@href|//div[@class="videohere"]/img[@class="thumbs stdimage"]/@src|//script[contains(.,'jwplayer("jwbox").setup')]/text()
-        concat: "|"
+        Name: //div[@class="sitename"]/a/text()
+      URL: &url //link[@rel="canonical"]/@href
+      Image: &image
+        selector: //meta[@property="og:image"]/@content
         postProcess:
           - replace:
-              - regex: "(^[^|]+)\\|.*/tour/([^\\.]+\\.jpg).*"
-                with: $1$2
+              - regex: ^//
+                with: https://
       Tags:
-        Name: //div[@class="set_tags"]/ul/li//a/text()
-# Last Updated June 07, 2023
+        Name: &tagName //div[@class="set_tags"]/ul/li//a/text()
+
+  substudioScraper:
+    scene:
+      Title: *title
+      Date: *date
+      Details: *details
+      Performers: *performers
+      Studio:
+        Name: //meta[@name="author"]/@content
+      URL: *url
+      Image: *image
+      # Tags for these subsites only appear on grooby.club as of 2023-08-15
+      # but we have to extend the subScraper functionality in Stash
+      # if we want to be able to scrape more than just a single field
+      # TODO: write a python scraper, merge with GroobyNetwork-*.yml ?
+      Tags:
+        Name:
+          selector: //link[@rel="canonical"]/@href
+          postProcess:
+            - replace:
+                - regex: ^.+/tour
+                  with: https://grooby.club/tour
+            - subScraper: *tagName
+# Last Updated August 21, 2023


### PR DESCRIPTION
Noticed that the subsite scrapers weren't getting any metadata so I updated them for the new layout: they don't have the tags yet, so users might still want to scrape using the grooby.club URL instead. We can't use a subscraper to grab the tags either because subscrapers only work for single selectors ATM

I'll probably get around to rewriting this entire scraper in Python to solve the issue of tags but for now this will work