### PR TITLE
allow Algolia to scrape gallery from scene URL

### DIFF
--- a/scrapers/Algolia.py
+++ b/scrapers/Algolia.py
@@ -728,7 +728,7 @@ def parse_gallery_json(gallery_json: dict, url: str = None) -> dict:
     elif gallery_json.get('title'):
         scrape['title'] = gallery_json['title'].strip()
     # Date
-    scrape['date'] = gallery_json.get('date_online')
+    scrape['date'] = gallery_json.get('date_online') or gallery_json.get('release_date')
     # Details
     scrape['details'] = clean_text(gallery_json.get('description'))
 
@@ -972,15 +972,24 @@ elif "movie" in sys.argv:
 elif "gallery" in sys.argv:
     scraped_gallery = None
     if SCENE_URL:
-        log.debug("Scraping gallery by URL")
-        gallery_id = get_id_from_url(SCENE_URL)
-        if gallery_id:
-            gallery_results = api_search_gallery_id(gallery_id, api_url)
-            gallery = gallery_results.json()["results"][0].get("hits")
-            if gallery:
-                #log.debug(gallery[0])
-                scraped_gallery = parse_gallery_json(gallery[0])
-                #log.debug(scraped_gallery)
+        if "/video/" in SCENE_URL:
+            log.debug("Scraping scene by URL")
+            scene_id = get_id_from_url(SCENE_URL)
+            api_search_response = api_search_req("id", scene_id, api_url)
+            if api_search_response:
+                # log.debug(f"[API] Search gives {len(api_search_response)} result(s)")
+                # log.trace(f"api_search_response: {api_search_response}")
+                scraped_gallery = parse_gallery_json(api_search_response[0])
+        else:
+            log.debug("Scraping gallery by URL")
+            gallery_id = get_id_from_url(SCENE_URL)
+            if gallery_id:
+                gallery_results = api_search_gallery_id(gallery_id, api_url)
+                gallery = gallery_results.json()["results"][0].get("hits")
+                if gallery:
+                    #log.debug(gallery[0])
+                    scraped_gallery = parse_gallery_json(gallery[0])
+                    #log.debug(scraped_gallery)
     elif SCENE_TITLE:
         log.debug("Scraping gallery by fragment")
         # log.debug(f"[API] Searching using SCENE_TITLE: {SCENE_TITLE}")

--- a/scrapers/Algolia_Adultime.yml
+++ b/scrapers/Algolia_Adultime.yml
@@ -87,6 +87,7 @@ galleryByFragment:
 galleryByURL:
   - action: script
     url:
+      - accidentalgangbang.com/en/photo/
       - devilsfilm.com/en/photo/
       - joymii.com/en/photo/
       - mommysgirl.com/en/photo/
@@ -94,6 +95,7 @@ galleryByURL:
       - peternorth.com/en/photo/
       - prettydirty.com/en/photo/
       - puretaboo.com/en/photo/
+      - transfixed.com/en/video/
       - webyoung.com/en/photo/
     script:
       - python
@@ -112,4 +114,4 @@ movieByURL:
       - Algolia.py
       - puretaboo
       - movie
-# Last Updated July 18, 2023
+# Last Updated September 05, 2023


### PR DESCRIPTION
This tweak to the Algolia script scraper allows a gallery to be scraped from the (video) scene URL.

This is for situations where the studio site does not have (public/free) gallery URLs, but each scene has a photo set, e.g. transfixed.com consistently has 35 image photo sets for each scene

scene URL: https://www.transfixed.com/en/video/transfixed/Cater-Waiter-Quickie/230414

With this PR's changes, that scene URL can now be used to scrape the gallery for the photo set.

### Side quest

Also added accidentalgangbang.com to galleryByURL, as that site has public/free galleries, e.g.

https://www.accidentalgangbang.com/en/photo/In-Laws-In-Need/109962

is now scrapable.