### PR TITLE
Added xpath scenescraper for camwhores.tv

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -250,6 +250,7 @@ bushybushy.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bustybeauties.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 buttman.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 calicarter.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+camwhores.tv|CamWhorestv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 canada-tgirl.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 caribbeancom.com|Carib.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 caribbeancompr.com|Carib.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored

--- a/scrapers/CamWhorestv.yml
+++ b/scrapers/CamWhorestv.yml
@@ -1,0 +1,23 @@
+name: "CamWhores.tv"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - camwhores.tv
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //meta[@property="og:title"]/@content
+      Image: //meta[@property="og:image"]/@content
+      Tags:
+        Name: //div[@class="item"]//a[contains(@href,"/tags/")]/text()
+      Performers:
+        Name: //div[@class="item"]//a[contains(@href,"/models/")]/text()
+      Details: //meta[@property="og:description"]/@content
+      Code:
+        selector: //meta[@property="og:image"]/@content
+        postProcess:
+          - replace:
+              - regex: .+/videos_screenshots/(\d+)/.+?$
+                with: $1
+# Last Updated September 08, 2023


### PR DESCRIPTION
A basic xpath scene scraper for camwhores.tv. This will even work on URLs to videos that have been made private by users as all the necessary HTML is still visible on the page.

Note that most videos on this site are uploaded by random users, so I decided not to bother using their username as studio.

You can grab any video off `https://www.camwhores.tv/latest-updates/` to test, even those marked private, otherwise here's a couple of sample URLs:
`https://www.camwhores.tv/videos/2329963/asiandreamx-oil-my-ass-in-private-premium-video-7ef0594b-6de4c6bd7b89daac/`
`https://www.camwhores.tv/videos/6940762/rorriegomez-june-09-2021/`

Also, I didn't bother adding a performerScraper because if you look at pretty much any model page (e.g. `https://www.camwhores.tv/models/rorriegomez/`) you can see that they never have any info it's just got "N/A" for every field.