### PR TITLE
Fixed bug in EroProfile sceneScraper when a video has no description

### DIFF
--- a/scrapers/EroProfile.yml
+++ b/scrapers/EroProfile.yml
@@ -17,5 +17,5 @@ xPathScrapers:
               - regex: (.+)\s\((.+)ago\)
                 with: $1
           - parseDate: 2 January 2006
-      Details: //div[@class="boxCnt"]//h1[@class="capMultiLine"]/following-sibling::p/text() | //table[@class="data marT"]//tbody//tr//th[contains(text(),"Description:")]/following::td/text()
+      Details: //h1[@class="capMultiLine"]/following-sibling::p/text() | //table[@class="data marT"]//tbody//tr//th[contains(text(),"Description:")]/following::td/text()
 # Last Updated September 09, 2023

--- a/scrapers/EroProfile.yml
+++ b/scrapers/EroProfile.yml
@@ -17,5 +17,5 @@ xPathScrapers:
               - regex: (.+)\s\((.+)ago\)
                 with: $1
           - parseDate: 2 January 2006
-      Details: //h1[@class="capMultiLine"]/following::p/text() | //table[@class="data marT"]//tbody//tr//th[contains(text(),"Description:")]/following::td/text()
-# Last Updated May 24, 2023
+      Details: //div[@class="boxCnt"]//h1[@class="capMultiLine"]/following-sibling::p/text() | //table[@class="data marT"]//tbody//tr//th[contains(text(),"Description:")]/following::td/text()
+# Last Updated September 09, 2023


### PR DESCRIPTION
Noticed a bug in my EroProfile sceneScraper the other day where if a video has NO description but does have at least 1 user comment, the first comment will be scraped and parsed as the Details field because it will be the first `<p>` tag it finds after the title.

Simple fix by ensuring the scraper only looks for a **_following-sibling_** `<p>` tag after the title, rather than just the next `<p>` anywhere on the page.
URLs to the mobile version of video pages were unaffected.

### For testing the fix
The video I had this happen on seems to have deleted the comment now and it took me a while to find another video where I could show this bug occurring and my fixing of it, but here's one with no description but a comment:
`https://www.eroprofile.com/m/videos/view/Wife-beach-fucked-by-stranger-filmed-by-hubby-2018`
If you test this _before_ pulling my fix you will see it gets that user's comment (the German text) parsed for the Details field.
Test again after pulling this fix and you will see it no longer does that and will just remain empty. Any other URLs to videos with actual descriptions will still work as intended.