### PR TITLE
Move Active Duty over to Algolia scraper

### DIFF
--- a/scrapers/Algolia_ActiveDuty.yml
+++ b/scrapers/Algolia_ActiveDuty.yml
@@ -1,0 +1,30 @@
+name: "Active Duty"
+sceneByURL:
+  - action: script
+    url:
+      - activeduty.com/en/video
+    script:
+      - python
+      - Algolia.py
+      - activeduty
+sceneByFragment:
+  action: script
+  script:
+    - python
+    - Algolia.py
+    - activeduty
+sceneByName:
+  action: script
+  script:
+    - python
+    - Algolia.py
+    - activeduty
+    - searchName
+sceneByQueryFragment:
+  action: script
+  script:
+    - python
+    - Algolia.py
+    - activeduty
+    - validName
+# Last Updated September 26, 2023

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -3,7 +3,6 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - 1000facials.com/en/scene/
-      - activeduty.com/en/video/
       - alettaoceanempire.com/en/video/
       - analacrobats.com/en/video/
       - ashleyfires.com/


### PR DESCRIPTION
Active Duty is now using Algolia, so this creates an Algolia scraper for Active Duty and drops the Gamma scraper for that site