### PR TITLE
fix: use cookies for rule34video.com

### DIFF
--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -52,4 +52,20 @@ xPathScrapers:
       Studio:
         Name: //div[@class="video_tools"]//div[text()="Artist:"]/following-sibling::a/span
         URL: //div[@class="video_tools"]//div[text()="Artist:"]/following-sibling::a/@href
-# Last Updated November 25, 2022
+driver:
+  useCDP: true
+  cookies:
+    - Cookies:
+        - Name: kt_rt_popAccess
+          Value: 1
+          Domain: .rule34video.com
+          Path: /
+        - Name: kt_tcookie
+          Value: 1
+          Domain: .rule34video.com
+          Path: /
+        - Name: cf_clearance
+          ValueRandom: 43
+          Domain: .rule34video.com
+          Path: /
+# Last Updated September 29, 2023

--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -57,11 +57,11 @@ driver:
   cookies:
     - Cookies:
         - Name: kt_rt_popAccess
-          Value: 1
+          Value: '1'
           Domain: .rule34video.com
           Path: /
         - Name: kt_tcookie
-          Value: 1
+          Value: '1'
           Domain: .rule34video.com
           Path: /
         - Name: cf_clearance


### PR DESCRIPTION
# Problem

When using the scrapeByURL feature, after scraping a scene successfully one day, all subsequent scrapes fail to parse any info. This is most probably due to the popup dialog to accept cookies, or the way rule34 shows other scenes in a modal window instead of the full page.

# Solution

Using CDP and setting some cookies allows the scraper to scrape more than one scene a day.