### PR TITLE
Add BoyCrush network scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -164,6 +164,7 @@ bangteenpussy.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 barbarafeet.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 barebackplus.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 barelylegal.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+baretwinks.com|BoyCrush.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 bathhousebait.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 battlebang.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 bbcparadise.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -232,6 +233,7 @@ boundlife.com|Boundlife.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boundtwinks.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 bountyhunterporn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 boxtrucksex.com|BoxTruckSex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+boycrush.com|BoyCrush.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boyforsale.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boyfriendsharing.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boyfun.com|BoyFun.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay

--- a/scrapers/BoyCrush.yml
+++ b/scrapers/BoyCrush.yml
@@ -1,0 +1,52 @@
+name: BoyCrush Network
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - tour.boycrush.com/boy-crush-watch-gay-movies/
+      - tour.baretwinks.com/bare-twinks-watch/
+    scraper: bcScraper
+
+xPathScrapers:
+  bcScraper:
+    common:
+      $imageUrl: //div[@class="flv-player-holder"]//video/@poster|//div[@class="flv-player-holder" and not(//video)]//img/@src
+    scene:
+      Title:
+        selector: //head/title
+        postProcess:
+        - replace:
+          - regex: .* showing (.*) featuring.*
+            with: $1
+      Date:
+        selector: //h2[@class="fsize16"]/text()
+        postProcess:
+        - replace:
+          - regex: (.+) - .*
+            with: $1
+        - parseDate: January 2, 2006
+      Details: //div[@class="diary-descr"]
+      Image: $imageUrl
+      Code: 
+        selector: $imageUrl
+        postProcess:
+        - replace:
+          - regex: .*/largethumbs/([^_]+)_.*
+            with: $1
+      Studio:
+        Name:
+          selector: $imageUrl
+          postProcess:
+          - replace:
+            - regex: .*/largethumbs/([a-z]+).*
+              with: $1
+          - map:
+              bc: BoyCrush
+              bt: BareTwinks
+              hmt: HomeMadeTwinks
+              tast: TastyTwink
+              bf: BoyFeast
+      Performers:
+        Name: //div[@class="models-name"]//h2//a
+      Tags:
+        Name: //div[@class="models-name"]//h4//a
+# Last Updated October 02, 2023


### PR DESCRIPTION
This adds a scraper for the two main BoyCrush network sites that have public scene pages: boycrush.com and baretwinks.com.

Both sites have public pages for the scenes of all 5 sites under the BoyCrush network, so the scraper will read which site the video is supposed to be a part of and assign the proper studio. The other 3 sites do not have public scene pages, so URLs for them are not added to the scraper. I figure the idea will be if you want a public link for those sites, you will use the boycrush.com one, because that is the main network site at this point.
