### PR TITLE
Fixed issue in Baberotica.yml with Studio name map

### DIFF
--- a/scrapers/Baberotica.yml
+++ b/scrapers/Baberotica.yml
@@ -36,8 +36,8 @@ xPathScrapers:
           selector: //meta[@itemprop="url"]/@content
           postProcess:
             - map:
-                https://avidolz.com: AvIdolz
-                https://baberotica.com: Baberotica
-                https://baberoticavr.com: BaberoticaVR
-                https://teenthais.com: TeenThais
+                https://avidolz.com/: AvIdolz
+                https://baberotica.com/: Baberotica
+                https://baberoticavr.com/: BaberoticaVR
+                https://teenthais.com/: TeenThais
 # Last Updated June 30, 2021

--- a/scrapers/Baberotica.yml
+++ b/scrapers/Baberotica.yml
@@ -40,4 +40,4 @@ xPathScrapers:
                 https://baberotica.com/: Baberotica
                 https://baberoticavr.com/: BaberoticaVR
                 https://teenthais.com/: TeenThais
-# Last Updated June 30, 2021
+# Last Updated October 3, 2023

--- a/scrapers/Baberotica.yml
+++ b/scrapers/Baberotica.yml
@@ -40,4 +40,4 @@ xPathScrapers:
                 https://baberotica.com/: Baberotica
                 https://baberoticavr.com/: BaberoticaVR
                 https://teenthais.com/: TeenThais
-# Last Updated October 3, 2023
+# Last Updated October 03, 2023


### PR DESCRIPTION
Studio name mapping was not working, the URL would appear as the Studio name when scraping.  

URLs under "- map:" need the trailing "/" in order for the mapping to the name to work.