### PR TITLE
feat: add scraper for RedHotStraightBoys

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1211,6 +1211,7 @@ realtimebondage.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realvr.com|BaDoink.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
 redgifs.com|Redgifs.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|Python|Gifs
 redheadmariah.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
+redhotstraightboys.com|RedHotStraightBoys.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
 redpolishfeet.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 reidmylips.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 reidmylips.elxcomplete.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/RedHotStraightBoys.yml
+++ b/scrapers/RedHotStraightBoys.yml
@@ -1,0 +1,41 @@
+name: RedHotStraightBoys
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - redhotstraightboys.com/tour/updates
+    scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - redhotstraightboys.com/tour/models
+    scraper: performerScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //span[@class='update_title']/text()
+      Performers:
+        Name:
+          selector: //span[@class='tour_update_models']/a/text()
+        URL:
+          selector: //span[@class='tour_update_models']/a/@href
+      Details:
+        selector: //span[@class='latest_update_description']/text()
+      Tags:
+        Name: //span[@class='tour_update_tags']/a/text()
+      Image:
+        selector: //img[contains(@class,'large_update_thumb')]/@src
+      Studio:
+        Name:
+          fixed: RedHotStraightBoys.com
+
+  performerScraper:
+    performer:
+      Name: //span[@class='title_bar_hilite']/text()
+      Gender:
+        fixed: Male
+      Image:
+        selector: //img[contains(@class,'model_bio_thumb')]/@src0_2x
+# Last Updated October 14, 2023


### PR DESCRIPTION
This PR adds a scraper for [RedHotStraightBoys](https://redhotstraightboys.com/)

Scraper supports:

- sceneByURL
  - Title
  - Performers
    - Name
    - URL
  - Details
  - Tags
  - Image
  - Studio (fixed: RedHotStraightBoys.com)
- performerByURL
  - Name
  - Gender (fixed: MALE)
  - Image