### PR TITLE
add scraper for nvg network sites

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1006,6 +1006,7 @@ naturalbornbreeders.com|AdultSiteRunner.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 naughtyamerica.com|NaughtyAmerica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 naughtyamericavr.com|NaughtyAmericaVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 naughtynatural.com|NaughtyNatural.yml|:heavy_check_mark:|:heavy_check_mark:|-|-|-|-
+netvideogirls.com|NVGNetwork.yml|:heavy_check_mark:|-|-|-|-|-
 newsensations.com/tour_ns/|NewSensationsMain.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 newsensations.com/tour_rs/|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nextdoorbuddies.com|Algolia_NextDoorStudios.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Gay
@@ -1673,7 +1674,7 @@ For each scraper a short description, an optional comment with the usage and the
 Scraper | Description | Comments | PR
 --------|-------------|----------|:--:
 ComicInfoXML.yml| A ComixInfo XML gallery scraper | A python scraper that looks for ComicInfo xml compatible  files in the gallery's folder/filename and parses them | [#827](https://github.com/stashapp/CommunityScrapers/pull/827)
-CopyFromScene.yml| A gallery scraper that returns metadata from the first linked scene | A python scraper that returns metadata from copied scenes, first link the scene to the gallery then run the scraper on the gallery | 
+CopyFromScene.yml| A gallery scraper that returns metadata from the first linked scene | A python scraper that returns metadata from copied scenes, first link the scene to the gallery then run the scraper on the gallery |
 CopyToGallery.yml| A scene to gallery scraper | A python scene scraper that copies metadata from a scene to the associated galleries. Can optionally (check .py file) associate and copy meta to all galleries in the same folder as the scene| [#895](https://github.com/stashapp/CommunityScrapers/pull/895)
 dc-onlyfans.yml| An Onlyfans DB scene scraper | A python scraper that scrapes Only Fans scenes using the DB file (user_data.db) created from DIGITALCRIMINAL's tool | [#847](https://github.com/stashapp/CommunityScrapers/pull/847)
 Filename.yml | Scrape a scenes (local) filename to set as scene title | Utility scraper useful if you've bulk updated filenames outside of stash and want the changes synced back into stash | [#1136](https://github.com/stashapp/CommunityScrapers/pull/1136)

--- a/scrapers/NVGNetwork.yml
+++ b/scrapers/NVGNetwork.yml
@@ -1,0 +1,51 @@
+name: NVG Network
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - vip.netvideogirls.com/members/video/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $details: //div[@class="movie-info"]
+    scene:
+      Title:
+        selector: //title
+        postProcess:
+          - replace:
+            - regex: '.+ / (.+?) / .+'
+              with: $1
+      Code:
+        selector: //div[@class="react-player__preview"]/@style
+        postProcess:
+          - replace:
+            - regex: '.+static\.netvideogirls\.com\/(\d+)-.+'
+              with: $1
+      Date:
+        selector: //div[@class="tool_inform"]//i[@class="icon-calendar"]/../span/text()
+        postProcess:
+          - parseDate: Jan 2, 2006
+      Studio:
+        Name: //div[@class="tool_inform"]//div[@class="name"]/a/text()
+        URL:
+          selector: //div[@class="tool_inform"]//div[@class="name"]/a/@href
+          postProcess:
+            - replace:
+              - regex: (.+)
+                with: https://vip.netvideogirls.com$1
+      Image:
+        selector: //div[@class="react-player__preview"]/@style
+        postProcess:
+          - replace:
+              - regex: .+url\("(.+)"\).+
+                with: $1
+      Tags:
+        Name: //div[@class="tool_list"]//div[@class="item"]/span/text()
+driver:
+  useCDP: true
+  headers:
+    - Key: User-Agent
+      Value: ''
+    - Key: Cookie
+      Value: ''
+# Last Updated October 19, 2023


### PR DESCRIPTION
nvg is exclusively a paid site so if this doesn't belong I understand and we can just close it. I no longer have access to the site myself but this functioned as of about a month ago and they dont seem to update to often.

Not sure about the user-agent being a header here so if that seems wrong let me know and I can remove it, it does have to be in sync with the cookie though so I felt it was better to have here so if a user updates one seeing the other might remind them that they have to update both.