### PR TITLE
Fixed xpaths for Title, URL, and Image for IWantClips.yml

### DIFF
--- a/scrapers/IWantClips.yml
+++ b/scrapers/IWantClips.yml
@@ -29,9 +29,9 @@ xPathScrapers:
       Image: //div[@class='clip-thumb-16-9']/a/img/@src
   sceneScraper:
     scene:
-      Title: //span[@class="headline hidden-xs"]/text()
+      Title: //h1[@class="headline hidden-xs"]/text()
       URL:
-        selector: //button[@class='btn btn-default cart addToCart']/@data-id
+        selector: //link[@rel="canonical"]/@href
         postProcess:
           - replace:
               - regex: ^
@@ -54,7 +54,7 @@ xPathScrapers:
                   with: ","
           split: ","
       Image:
-        selector: //img[@class="videoPlayer show-flexible-picture"]/@src | //video[@class="video-js embed-responsive-item"]/@poster
+        selector: //div[contains(@class,'vidStuff')]//video[contains(@id,'html5_api')]/@poster | //div[contains(@class,'vidStuff')]//img/@src
       Studio:
         Name:
           fixed: IWantClips
@@ -83,4 +83,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated July 22, 2022
+# Last Updated October 19, 2023

--- a/scrapers/IWantClips.yml
+++ b/scrapers/IWantClips.yml
@@ -30,12 +30,7 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //h1[@class="headline hidden-xs"]/text()
-      URL:
-        selector: //link[@rel="canonical"]/@href
-        postProcess:
-          - replace:
-              - regex: ^
-                with: https://iwantclips.com/store/item/
+      URL: //link[@rel="canonical"]/@href
       Date:
         selector: //div[@class="col-xs-12 date fix"]/span/em/text()
         postProcess:


### PR DESCRIPTION
iwantclips.com appears to have changed xpaths that are scrapeable for Title, URL, and Image, so I have changed the xpaths in the scraper to accommodate.

Tested scraper with as many scenes as I could, the majority work fine, however some appear to only have an mp4 as the "image" for the scene and those cannot pull an image URL for stash.