### PR TITLE
Add StasyQVR XPath Scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1333,6 +1333,7 @@ squirtingorgies.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 stagcollective.com|Algolia_NextDoorStudios.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Gay
 staghomme.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 stasyq.com|StasyQ.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
+stasyqvr.com|StasyQVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 staxus.com|Staxus.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|gay
 stayhomepov.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 stephousexxx.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/StasyQVR.yml
+++ b/scrapers/StasyQVR.yml
@@ -13,6 +13,12 @@ xPathScrapers:
         selector: //div[@class='video-meta-date']/text()
         postProcess:
           - parseDate: Jan 2, 2006
+      Code:
+        selector: //script[contains(.,'vrPlayerSettings')]/text()
+        postProcess:
+          - replace:
+              - regex: '[\s\S]*videoId: (\d+),[\s\S]*'
+                with: $1
       Studio:
         Name:
           fixed: StasyQVR

--- a/scrapers/StasyQVR.yml
+++ b/scrapers/StasyQVR.yml
@@ -1,0 +1,27 @@
+name: "StasyQVR"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - stasyqvr.com/virtualreality
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[@class='video-title']/h1/text()
+      Details: //div[@class='video-info']/p/text()
+      Date: 
+        selector: //div[@class='video-meta-date']/text()
+        postProcess:
+          - parseDate: Jan 2, 2006
+      Studio:
+        Name:
+          fixed: StasyQVR
+      Performers:
+        Name: //div[@class='video-info']//a/h2/text()
+      Image:
+        selector: //div[@id='webvr']/div[contains(@style,'background-image:')]/@style
+        postProcess:
+          - replace:
+              - regex: '^background-image: url\(|\);$'
+                with: ""
+# Last Updated October 20, 2023


### PR DESCRIPTION
VR sister site of existing StasyQ scraper, but the VR site has a totally different layout so couldn't reuse the other scraper. Tested on a few videos older and newer. Performer page on VR site has zero details and didn't seem worth scraping.

Site is light on video details so scraper should be fairly straightforward, but feedback is welcomed. 