### PR TITLE
Update RealJamVR to include PornCornVR

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1131,6 +1131,7 @@ plumperpass.com|PlumperPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 plushies.tv|Plushies.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 porkvendors.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 pornbox.com|Pornbox.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+porncornvr.com|RealJamVR.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|VR
 porncz.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 pornditos.com|Pornditos.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 porndudecasting.com|PornDudeCasting.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-

--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -3,6 +3,7 @@ sceneByURL: &byURL
   - action: scrapeXPath
     url:
       - realjamvr.com/scene/
+      - porncornvr.com/scene
     scraper: sceneScraper
 
 galleryByURL: *byURL
@@ -33,7 +34,11 @@ xPathScrapers:
         selector: //*[@id="video-player"]//@poster
       Studio: &studio
         Name:
-          fixed: RealJamVR
+          selector: //title
+          postProcess:
+          - replace:
+              - regex: '(.*)\| ([^\|]+VR)$'
+                with: $2
     gallery:
       Title: *title
       Date: *date
@@ -42,4 +47,4 @@ xPathScrapers:
       Details: *details
       Studio: *studio
       
-# Last Updated August 01, 2023
+# Last Updated October 22, 2023


### PR DESCRIPTION
Brand new site (September 2023) made by the RealJamVR folks which seems to have an identical page layout. Updated the Studio name to no longer be fixed and added the new URL, but otherwise seems to work great without any other adjustments from the handful of scenes I tested.