### PR TITLE
Update Clips4Sale.yml

### DIFF
--- a/scrapers/Clips4Sale.yml
+++ b/scrapers/Clips4Sale.yml
@@ -92,10 +92,6 @@ xPathScrapers:
           split: ","
       Image:
         selector: $scene//img/@src
-        postProcess:
-            - replace:
-                - regex: ^
-                  with: "https:"
       URL: //meta[@property="og:url"]/@content
 
 driver:
@@ -111,4 +107,4 @@ driver:
       Value: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0)
 
 
-# Last Updated August 31, 2023
+# Last Updated November 7, 2023


### PR DESCRIPTION
Removed image link post-processing - previously, it was necessary to prepend 'https:' at the start of the link, however it seems that C4S have changed their site so this is no longer necessary.