### PR TITLE
Fix for IfeelMyself lazy loading image tags

### DIFF
--- a/scrapers/IFeelMyself.py
+++ b/scrapers/IFeelMyself.py
@@ -41,7 +41,10 @@ def extract_SceneInfo(table,cover_url=None):
     debugPrint(f"performer:{performer}")
     date = datetime.strptime(date, '%d %b %Y').date().strftime('%Y-%m-%d') #Convert date to ISO format
     if cover_url == None:
-        cover_url=str(table.find("video")['poster'])
+        if table.find("img"):
+            cover_url=str(table.find("img")['src'])
+        else:
+            cover_url=str(table.find("video")['poster'])
     title = table.find(class_= ["entryHeadingFlash","entryHeading"]).find('a').get_text().replace("\x92","'")
     media_id = re.search(r"\/(\d{3,5})\/",cover_url,re.I).group(1)
     artist_id = re.search(r"\/(f\d{4,5})",cover_url,re.I).group(1)
@@ -99,7 +102,7 @@ def scrapeScene(filename,date,url):
                     if table.find('video'):
                         img=str(table.find("video")['poster'])
                         debugPrint(f"Image:{str(img)}")
-                        if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
+                        if (f"/{artist_id}-{video_id}vg.jpg" in img) or (f"/{artist_id}-{video_id}hs.jpg" in img):
                             debugPrint("Found a single match video!")
                             # Extract data from this single result
                             ret = extract_SceneInfo(table)
@@ -117,7 +120,7 @@ def scrapeScene(filename,date,url):
                             if table.find('video'):
                                 img=str(table.find("video")["poster"])
                                 debugPrint(f"Image:{img}")
-                                if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
+                                if (f"/{artist_id}-{video_id}vg.jpg" in img) or (f"/{artist_id}-{video_id}hs.jpg" in img):
                                     sys.stderr.write("FOUND")
                                     ret = extract_SceneInfo(table)
                                     break

--- a/scrapers/IFeelMyself.py
+++ b/scrapers/IFeelMyself.py
@@ -41,7 +41,7 @@ def extract_SceneInfo(table,cover_url=None):
     debugPrint(f"performer:{performer}")
     date = datetime.strptime(date, '%d %b %Y').date().strftime('%Y-%m-%d') #Convert date to ISO format
     if cover_url == None:
-        cover_url=str(table.find("img")['src'])
+        cover_url=str(table.find("video")['poster'])
     title = table.find(class_= ["entryHeadingFlash","entryHeading"]).find('a').get_text().replace("\x92","'")
     media_id = re.search(r"\/(\d{3,5})\/",cover_url,re.I).group(1)
     artist_id = re.search(r"\/(f\d{4,5})",cover_url,re.I).group(1)
@@ -96,13 +96,14 @@ def scrapeScene(filename,date,url):
             debugPrint(artist_id+"-"+video_id)
             tables = response.find_all(class_= ["blog_wide_news_tbl entry ppss-scene","entry ppss-scene"])
             for table in tables:
-                img=str(table.find("img")['src'])
-                debugPrint(f"Image:{str(img)}")
-                if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
-                    debugPrint("Found a single match video!")
-                    # Extract data from this single result
-                    ret = extract_SceneInfo(table)
-                    break
+                    if table.find('video'):
+                        img=str(table.find("video")['poster'])
+                        debugPrint(f"Image:{str(img)}")
+                        if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
+                            debugPrint("Found a single match video!")
+                            # Extract data from this single result
+                            ret = extract_SceneInfo(table)
+                            break
             else:
                 sys.stderr.write("0 matches found! Checking offset")
                 pages=int(response.find_all("a", class_="pagging_nonsel")[-1].get_text())
@@ -113,12 +114,13 @@ def scrapeScene(filename,date,url):
                         response = browser.page
                         tables = response.find_all(class_= ["blog_wide_news_tbl entry ppss-scene","entry ppss-scene"])
                         for table in tables:
-                            img=str(table.find("img")["src"])
-                            debugPrint(f"Image:{img}")
-                            if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
-                                sys.stderr.write("FOUND")
-                                ret = extract_SceneInfo(table)
-                                break
+                            if table.find('video'):
+                                img=str(table.find("video")["poster"])
+                                debugPrint(f"Image:{img}")
+                                if (f"/{artist_id}-{video_id}" in img) and img.endswith(("vg.jpg","hs.jpg")):
+                                    sys.stderr.write("FOUND")
+                                    ret = extract_SceneInfo(table)
+                                    break
                 else:
                     sys.stderr.write("0 matches found!, check your filename")
 


### PR DESCRIPTION
This caused a None type to return. The video tag appears to be load right away and shares the same information need for the rest of the code to work correctly. Had to add a check to ensure there was a video tag. As some actress have galleries now and these are not lazy loaded and have no video tag.