### PR TITLE
Update AniDB.yml: scrape performer URL when scrapping scene URL

### DIFF
--- a/scrapers/AniDB.yml
+++ b/scrapers/AniDB.yml
@@ -107,6 +107,7 @@ xPathScrapers:
   sceneScraper:
     common:
       $info: //div[@class="g_section info"]
+      $character: //div[@id="characterlist"]//div[contains(@class, 'main character') or contains(@class, 'secondary cast')]//div[@itemprop="character"]
     scene:
       Title: $info//div[@id="tab_1_pane"]//span[@itemprop="name"]
       Details: 
@@ -115,7 +116,13 @@ xPathScrapers:
       Tags:
         Name: $info//div[@id="tab_1_pane"]//span[@class="tagname"]
       Performers:
-        Name: //div[@id="characterlist"]//div[contains(@class, 'main character') or contains(@class, 'secondary cast')]//div[@itemprop="character"]/a/span
+        Name: $character/a/span
+        URL: 
+          selector: $character/a/@href
+          postProcess:
+            - replace:
+                - regex: ^
+                  with: https://anidb.net
       Studio:
         Name: $info//table[@id="staffoverview"]//tr[last()]/td[@class="name creator"]/a
       Image: $info//div[@class="image"]//img/@src
@@ -135,4 +142,4 @@ driver:
           Domain: "anidb.net"
           Value: "" # Enter the value of the 'adbuin' here
           Path: "/"
-# Last Updated June 23, 2023
+# Last Updated Dec 5, 2023


### PR DESCRIPTION
Currently the scene scraper scrapes for performer names. This change also scrapes the performer urls, which makes it easier to use the performer scraper on the performer's page.

Example:

| Series | Series URL | Performers | Performer URLs |
| - | - | - | - | 
| Pocket Monsters | https://anidb.net/anime/230 | Pikachu (Satoshi), ... | https://anidb.net/character/8091, ... |