### PR TITLE
Improve IWC cover scraping

### DIFF
--- a/scrapers/IWantClips.yml
+++ b/scrapers/IWantClips.yml
@@ -54,6 +54,13 @@ xPathScrapers:
           split: ","
       Image:
         selector: //div[contains(@class,'vidStuff')]//video[contains(@id,'html5_api')]/@poster | //div[contains(@class,'vidStuff')]//img/@src
+        postProcess:
+          - replace:
+            - regex: (\d*_)
+              with: t_$1
+          - replace:
+            - regex: '(\.gif)|(\.mp4)'
+              with: ".jpg"
       Studio:
         Name: $model
       Performers:

--- a/scrapers/IWantClips.yml
+++ b/scrapers/IWantClips.yml
@@ -56,7 +56,7 @@ xPathScrapers:
         selector: //div[contains(@class,'vidStuff')]//video[contains(@id,'html5_api')]/@poster | //div[contains(@class,'vidStuff')]//img/@src
         postProcess:
           - replace:
-            - regex: (\d*_)
+            - regex: (\d*_.*((\.gif)|(\.mp4)))
               with: t_$1
           - replace:
             - regex: '(\.gif)|(\.mp4)'


### PR DESCRIPTION
Today IWC image scraper gets the image from a "poster" placeholder in the page. However, this placeholder can contain still images (jpg, png, ...), .gif, or .mp4 files resulting in the following behavior :
* still images => scraping OK
* gif => scrape an animated image that is against the guidelines
* mp4 => error while scraping (image doesn't show)

This PR updates the "poster" url to grab the cover that is displayed in the search results which results in :
* still images  => no change, scraping OK
* gif => scrape a jpg being the cover of the scene => OK
* mp4 => scraped a jpg sometimes, or gets an error (similar to previous behavior)

In essence, this PR improves the image scraping by avoiding GIF retrieval and some MP4 errors.