### PR TITLE
Update MFC.yml to add gallery and performer scrapers

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1189,6 +1189,7 @@ private.com|Private.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_m
 privatecastings.com|privatecastings.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 privatesextapes.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 producersfun.com|ProducersFun.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+profiles.myfreecams.com|MFC.yml|:x:|:x:|:x:|:heavy_check_mark:|-|-
 propertysex.com|RealityKingsOL.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 publicagent.com|MindGeek.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 publicfrombohemia.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1291,7 +1292,7 @@ shagmag.com|shagmag.yml|:x:|:heavy_check_mark:|:x:|:x:|-|Magazines
 shame4k.com|Vip4K.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shandafay.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shanedieselsbanginbabes.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-share.myfreecams.com|MFC.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+share.myfreecams.com|MFC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 shefucksonthefirstdate.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shegotsix.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 shelovesblack.com|LoveHerFilms.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-

--- a/scrapers/MFC.yml
+++ b/scrapers/MFC.yml
@@ -1,10 +1,19 @@
-name: "MFC Share"
+name: "MyFreeCams"
 sceneByURL:
   - action: scrapeXPath
     url:
       - share.myfreecams.com/a/
     scraper: sceneScraper
-
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - share.myfreecams.com/a/
+    scraper: galleryScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - profiles.myfreecams.com/
+    scraper: performerScraper
 xPathScrapers:
   sceneScraper:
     scene:
@@ -25,5 +34,49 @@ xPathScrapers:
         Name: //a[@class="user-link"]
       Image:
         selector: //meta[@name="twitter:image"]/@content
-
-# Last Updated November 01, 2020
+  galleryScraper:
+    gallery:
+      Title: //h3/text()
+      Studio:
+        Name:
+          fixed: "MFC Share"
+      Date: //span[@class[contains(., "album-at")]]/@title
+      Details: //div[@class="description-view"]/text()
+      Tags:
+        Name:
+          selector: //div[@class[contains(., "tags-container")]]/a/text()
+          postProcess:
+            - replace:
+              - regex: ^#
+                with: ""
+      Performers:
+        Name: //a[@class="user-link"]
+  performerScraper:
+    performer:
+      Name: //span[@id="username_value"]/text()
+      Country: //span[@id="country_value"]/text()
+      Ethnicity: //span[@id="ethnicity_value"]/text()
+      Gender: //span[@id="gender_value"]/text()
+      HairColor: //span[@id="hair_value"]/text()
+      EyeColor: //span[@id="eyes_value"]/text()
+      Height:
+        selector: //span[@id="height_value"][contains(text(), "centimeters")]/text() # only get metric because we can't handle both; it's one or the other
+        postProcess:
+          - replace:
+            - regex: ((\d+)\s(.*))
+              with: $2
+      Weight:
+        selector: //span[@id="weight_value"][contains(text(), "kilos")]/text() # only get metric because we can't handle both; it's one or the other
+        postProcess:
+          - replace:
+            - regex: ((\d+)\s(.*))
+              with: $2
+      Image:
+        selector: //img[@id="main_photo"]/@src | //img[@id="profile_avatar"]/@src
+        postProcess:
+          - replace: # main photo 250px size modifier can be removed to get full size image; 300px avatar can be fetched instead of the 90px one
+            - regex: \.250\.jpg
+              with: .jpg
+            - regex: \.90x90\.jpg
+              with: .300x300.jpg
+# Last Updated December 13, 2023


### PR DESCRIPTION
Gallery scraper is a copy paste of the already working scene scraper. MFC shares can contain both videos and photos, but regardless of content the underlying HTML is identical.

sample URL: `https://share.myfreecams.com/a/pwghp8y6`

Performer scraper works on `profiles.myfreecams.com` URLs. It's self explanatory for the most part.

Image: gets their "main photo" if one is set, otherwise falls back to their avatar. Gets the full size image where possible.
Height/weight: MFC allows models to input values in either imperial or metric. But as was the issue with the PornHex scraper I wrote, since we cannot perform math in YAML files and/or handle cases for both imperial and metric I have chosen to only get height/weight data if metric values are found. I (or someone else) could update this scraper in the future to use python to handle both cases. I don't know if it's still like it now, but MFC always used to have significantly more non-US models than US, so I'd think metric is more common.

sample URLs:
`https://profiles.myfreecams.com/lea_amano` (imperial measures ignored)
`https://profiles.myfreecams.com/Sindyy` metric
`https://profiles.myfreecams.com/RocknRose` customized profile using CSS to hide all the fields but the underlying HTML is still there. No main photo is set so gets her avatar instead.