### PR TITLE
Add scene and gallery xpath scraper for reddit

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1228,6 +1228,7 @@ realsensual.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realtgirls.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 realtimebondage.com|insex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 realvr.com|BaDoink.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+reddit.com|Reddit.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 redgifs.com|Redgifs.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|Python|Gifs
 redheadmariah.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 redhotstraightboys.com|RedHotStraightBoys.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay

--- a/scrapers/Reddit.yml
+++ b/scrapers/Reddit.yml
@@ -1,0 +1,57 @@
+name: "Reddit"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - reddit.com
+      - old.reddit.com
+    scraper: sceneScraper
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - reddit.com
+      - old.reddit.com
+    scraper: galleryScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //shreddit-post/@post-title | //meta[@property="og:title"]/@content
+      Date: 
+        selector: //shreddit-post/@created-timestamp | //div[@class="top-matter"]//p//time/@datetime
+        postProcess:
+          - replace:
+              - regex: (\d{4}-\d{2}-\d{2})T(.*)
+                with: $1
+          - parseDate: 2006-01-02
+      Performers:
+        Name:
+          selector: //shreddit-post/@author | //meta[@property="og:description"]/@content
+          postProcess:
+            - replace:
+              - regex: Posted in r\/([\w]+) by u\/([\w-]+)\s(.*)
+                with: $2
+  galleryScraper:
+    gallery:
+      Title: //shreddit-post/@post-title | //meta[@property="og:title"]/@content
+      Date: 
+        selector: //shreddit-post/@created-timestamp | //div[@class="top-matter"]//p//time/@datetime
+        postProcess:
+          - replace:
+              - regex: (\d{4}-\d{2}-\d{2})T(.*)
+                with: $1
+          - parseDate: 2006-01-02
+      Performers:
+        Name:
+          selector: //shreddit-post/@author | //meta[@property="og:description"]/@content
+          postProcess:
+            - replace:
+              - regex: Posted in r\/([\w]+) by u\/([\w-]+)\s(.*)
+                with: $2
+driver:
+  cookies: # over18 cookie necessary for old.reddit.com URLs due to redirect; new reddit just blurs content instead
+    - CookieURL: "https://old.reddit.com/over18/"
+      Cookies:
+        - Name: "over18"
+          Domain: ".reddit.com"
+          Value: "1"
+          Path: "/"
+# Last Updated December 12, 2023

--- a/scrapers/Reddit.yml
+++ b/scrapers/Reddit.yml
@@ -11,7 +11,7 @@ galleryByURL:
     scraper: galleryScraper
 xPathScrapers:
   sceneScraper:
-    scene:
+    scene: &redditPost
       Title: //shreddit-post/@post-title | //meta[@property="og:title"]/@content
       Date: 
         selector: //shreddit-post/@created-timestamp | //div[@class="top-matter"]//p//time/@datetime
@@ -28,22 +28,7 @@ xPathScrapers:
               - regex: Posted in r\/([\w]+) by u\/([\w-]+)\s(.*)
                 with: $2
   galleryScraper:
-    gallery:
-      Title: //shreddit-post/@post-title | //meta[@property="og:title"]/@content
-      Date: 
-        selector: //shreddit-post/@created-timestamp | //div[@class="top-matter"]//p//time/@datetime
-        postProcess:
-          - replace:
-              - regex: (\d{4}-\d{2}-\d{2})T(.*)
-                with: $1
-          - parseDate: 2006-01-02
-      Performers:
-        Name:
-          selector: //shreddit-post/@author | //meta[@property="og:description"]/@content
-          postProcess:
-            - replace:
-              - regex: Posted in r\/([\w]+) by u\/([\w-]+)\s(.*)
-                with: $2
+    gallery: *redditPost
 driver:
   cookies: # over18 cookie necessary for old.reddit.com URLs due to redirect; new reddit just blurs content instead
     - CookieURL: "https://old.reddit.com/over18/"
@@ -52,4 +37,4 @@ driver:
           Domain: ".reddit.com"
           Value: "1"
           Path: "/"
-# Last Updated December 12, 2023
+# Last Updated December 13, 2023

--- a/scrapers/Reddit.yml
+++ b/scrapers/Reddit.yml
@@ -3,13 +3,11 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - reddit.com
-      - old.reddit.com
     scraper: sceneScraper
 galleryByURL:
   - action: scrapeXPath
     url:
       - reddit.com
-      - old.reddit.com
     scraper: galleryScraper
 xPathScrapers:
   sceneScraper:


### PR DESCRIPTION
A basic xpath scraper for reddit, use for scenes or galleries. Intended use would be on "gonewild" type subreddits so the poster's username is used as performer name.

Scraper gets data from the `<shreddit-post>` tag but if not found (meaning the URL is old.reddit) will look for the normal HTML tags. Same markup for image or video content so doesn't matter what you test it on.
old.reddit still uses an "over 18?" redirect for NSFW content, hence a cookie needing to be set.

Sample URL taken from /r/gonewild just now that you can test:
normal: `https://www.reddit.com/r/gonewild/comments/18gx66j/think_i_may_be_on_the_naughty_list_this_year_f/`
old site: `https://old.reddit.com/r/gonewild/comments/18gx66j/think_i_may_be_on_the_naughty_list_this_year_f/`

A long time ago someone requested a reddit scraper in #73 but they wanted it for performers. There is literally no data to scrape from reddit user profiles that could be used to fill a Stash performer. But I hope this scene/gallery scraper will be useful for some.
