### PR TITLE
Fix tags due to recent page structure change

### DIFF
--- a/scrapers/IWantClips.yml
+++ b/scrapers/IWantClips.yml
@@ -45,9 +45,12 @@ xPathScrapers:
         concat: "\n\n"
       Tags:
         Name:
-          selector: //div[@class="col-xs-12 hashtags fix"]/span/em | //div[@class="col-xs-12 category fix"]/span
+          selector: //div[@class="col-xs-12 hashtags hashtags-grey fix"]/span/em | //div[@class="col-xs-12 category fix"]/a
           concat: ","
           postProcess:
+            - replace:
+                - regex: 'Keywords:'
+                  with: $1
             - replace:
                 - regex: ',\s+'
                   with: ","
@@ -88,4 +91,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated November 24, 2023
+# Last Updated December 14, 2023


### PR DESCRIPTION
IWC has changed their page structure in the last 24 hours breaking the tags scraping.

This fixes it.