### PR TITLE
Refactor PMVHaven scraper

### DIFF
--- a/scrapers/PMVHaven/PMVHaven.py
+++ b/scrapers/PMVHaven/PMVHaven.py
@@ -35,7 +35,8 @@ def getData(sceneId):
     return req.json()
 
 def getIMG(video):
-    for item in video['thumbnails']:
+    # reversed as we want most recent thumb
+    for item in reversed(video['thumbnails']):
         if item.startswith("https://storage.pmvhaven.com/"):
             return item
     return ""

--- a/scrapers/PMVHaven/PMVHaven.py
+++ b/scrapers/PMVHaven/PMVHaven.py
@@ -2,22 +2,11 @@ import os
 import json
 import sys
 import requests
-import random
-import time
-from urllib.parse import urlparse
-# extra modules below need to be installed
-try:
-    import cloudscraper
-except ModuleNotFoundError:
-    print("You need to install the cloudscraper module. (https://pypi.org/project/cloudscraper/)", file=sys.stderr)
-    print("If you have pip (normally installed with python), run this command in a terminal (cmd): pip install cloudscraper", file=sys.stderr)
-    sys.exit()
 
 try:
-    from lxml import html
+    from py_common import log
 except ModuleNotFoundError:
-    print("You need to install the lxml module. (https://lxml.de/installation.html#installation)", file=sys.stderr)
-    print("If you have pip (normally installed with python), run this command in a terminal (cmd): pip install lxml", file=sys.stderr)
+    print("You need to download the folder 'py_common' from the community repo! (CommunityScrapers/tree/master/scrapers/py_common)", file=sys.stderr)
     sys.exit()
 
 # to import from a parent directory we need to add that directory to the system path
@@ -27,12 +16,6 @@ sys.path.append(
     parent
 )  # add parent dir to sys path so that we can import py_common from there
 
-try:
-    from py_common import log
-except ModuleNotFoundError:
-    print("You need to download the folder 'py_common' from the community repo! (CommunityScrapers/tree/master/scrapers/py_common)", file=sys.stderr)
-    sys.exit()
-
 #bugfix for socks5 proxies, due to pySocks implementation incompatibility with Stash
 proxy = os.environ.get('HTTPS_PROXY', '')
 if proxy != "" and proxy.startswith("socks5://"):
@@ -40,37 +23,9 @@ if proxy != "" and proxy.startswith("socks5://"):
     os.environ['HTTPS_PROXY'] = proxy
     os.environ['HTTP_PROXY'] = proxy
 
-URL_XPATH = '//meta[@property="og:video:url"]/@content'
-URL_XPATH_2 = '//meta[@property="og:video:secure_url"]/@content'
-IMAGE_XPATH = '//meta[@property="og:image"]/@content'
-
-def getHTML(url, retries=0):
-    scraper = cloudscraper.create_scraper()
-    
-    try:
-        scraped = scraper.get(url)
-    except requests.exceptions.Timeout as exc_time:
-        log.debug(f"Timeout: {exc_time}")
-        return getHTML(url, retries + 1)
-    except Exception as e:
-        log.error(f"scrape error {e}")
-        sys.exit(1)
-    if scraped.status_code >= 400:
-        if retries < 10:
-            wait_time = random.randint(1, 4)
-            log.debug(f"HTTP Error: {scraped.status_code}, waiting {wait_time} seconds")
-            time.sleep(wait_time)
-            return getHTML(url, retries + 1)
-        log.error(f"HTTP Error: {scraped.status_code}, giving up")
-        sys.exit(1)
-
-    return html.fromstring(scraped.text)
-
-def getXPATH(pageTree, XPATH):
-    res = pageTree.xpath(XPATH)
-    if res:
-        return res[0]
-    return ""
+def fail(message):
+    log.error(message)
+    sys.exit(1)
 
 def getData(sceneId):
     try:
@@ -80,40 +35,51 @@ def getData(sceneId):
             "view": True
         })
     except Exception as e:
-        log.error(f"scrape error {e}")
-        sys.exit(1)
+        fail(f"Error fetching data from PMVHaven API: {e}")
     return req.json()
 
-def getURL(pageTree):
-    url = getXPATH(pageTree, URL_XPATH)
-    if not url:
-        return getXPATH(pageTree, URL_XPATH_2)
-    return url
-
-def getIMG(data):
-    for item in data['thumbnails']:
+def getIMG(video):
+    for item in video['thumbnails']:
         if item.startswith("https://storage.pmvhaven.com/"):
             return item
     return ""
 
+'''    
+    This assumes a URL of https://pmvhaven.com/video/{title}_{alphanumericVideoId}
+    As of 2023-12-31, this is the only valid video URL format. If this changes in
+    the future (i.e. more than one valid URL type, or ID not present in URL) and
+    requires falling back to the old cloudscraper method, an xpath of 
+        //meta[@property="video-id"]/@content 
+    can be used to pass into the PMVHaven API
+'''
+
 def main():
     params = json.loads(sys.stdin.read())
-    if not params['url']:
-        log.error('No URL entered.')
-        sys.exit(1)
-    
-    tree = getHTML(params['url'])
-    data = getData(getURL(tree).split('_')[-1])['video'][0]
 
-    tags = data['tags'] + data['categories']
+    if not params['url']:
+        fail('No URL entered.')
+
+    sceneId = params['url'].split('_')[-1]
+
+    if not sceneId or not sceneId.isalnum():
+        fail(f"Did not find scene ID from PMVStash video URL {params['url']}")
+
+    data = getData(sceneId)
+
+    if not 'video' in data or len(data['video']) < 1:
+        fail(f"Video data not found in data: {data}")
+
+    video = getData(sceneId)['video'][0]
+
+    tags = video['tags'] + video['categories']
 
     ret = {
-        'title': data['title'],
-        'image': getIMG(data),
-        'date': data['isoDate'].split('T')[0],
-        'details': data['description'],
+        'title': video['title'],
+        'image': getIMG(video),
+        'date': video['isoDate'].split('T')[0],
+        'details': video['description'],
         'studio': {
-            'Name': data['creator']
+            'Name': video['creator']
         },
         'tags':[
             {
@@ -123,7 +89,7 @@ def main():
         'performers': [
             {
                 'name': x.strip()
-            } for x in data['stars']
+            } for x in video['stars']
         ]
     }
     print(json.dumps(ret))

--- a/scrapers/PMVHaven/PMVHaven.py
+++ b/scrapers/PMVHaven/PMVHaven.py
@@ -11,14 +11,6 @@ except ModuleNotFoundError:
         file=sys.stderr)
     sys.exit(1)
 
-try:
-    from lxml import html
-except ModuleNotFoundError:
-    print("You need to install the lxml module. (https://lxml.de/installation.html#installation)", file=sys.stderr)
-    print("If you have pip (normally installed with python), run this command in a terminal (cmd): pip install lxml",
-          file=sys.stderr)
-    sys.exit(1)
-
 def fail(message):
     log.error(message)
     sys.exit(1)
@@ -31,11 +23,11 @@ def getData(sceneId):
             "view": True
         })
     except Exception as e:
-        sys.exit(f"Error fetching data from PMVHaven API: {e}")
+        fail(f"Error fetching data from PMVHaven API: {e}")
     return req.json()
 
 def getIMG(video):
-    # reversed as we want most recent thumb
+    # reversed because we want the most recent thumb
     for item in reversed(video['thumbnails']):
         if item.startswith("https://storage.pmvhaven.com/"):
             return item

--- a/scrapers/PMVHaven/PMVHaven.py
+++ b/scrapers/PMVHaven/PMVHaven.py
@@ -4,24 +4,20 @@ import sys
 import requests
 
 try:
-    from py_common import log
+    import py_common.log as log
 except ModuleNotFoundError:
-    print("You need to download the folder 'py_common' from the community repo! (CommunityScrapers/tree/master/scrapers/py_common)", file=sys.stderr)
-    sys.exit()
+    print(
+        "You need to download the folder 'py_common' from the community repo (CommunityScrapers/tree/master/scrapers/py_common)",
+        file=sys.stderr)
+    sys.exit(1)
 
-# to import from a parent directory we need to add that directory to the system path
-csd = os.path.dirname(os.path.realpath(__file__))  # get current script directory
-parent = os.path.dirname(csd)  # parent directory (should be the scrapers one)
-sys.path.append(
-    parent
-)  # add parent dir to sys path so that we can import py_common from there
-
-#bugfix for socks5 proxies, due to pySocks implementation incompatibility with Stash
-proxy = os.environ.get('HTTPS_PROXY', '')
-if proxy != "" and proxy.startswith("socks5://"):
-    proxy = proxy.replace("socks5://", "socks5h://")
-    os.environ['HTTPS_PROXY'] = proxy
-    os.environ['HTTP_PROXY'] = proxy
+try:
+    from lxml import html
+except ModuleNotFoundError:
+    print("You need to install the lxml module. (https://lxml.de/installation.html#installation)", file=sys.stderr)
+    print("If you have pip (normally installed with python), run this command in a terminal (cmd): pip install lxml",
+          file=sys.stderr)
+    sys.exit(1)
 
 def fail(message):
     log.error(message)
@@ -35,7 +31,7 @@ def getData(sceneId):
             "view": True
         })
     except Exception as e:
-        fail(f"Error fetching data from PMVHaven API: {e}")
+        sys.exit(f"Error fetching data from PMVHaven API: {e}")
     return req.json()
 
 def getIMG(video):
@@ -46,18 +42,18 @@ def getIMG(video):
 
 '''    
     This assumes a URL of https://pmvhaven.com/video/{title}_{alphanumericVideoId}
-    As of 2023-12-31, this is the only valid video URL format. If this changes in
+    As of 2024-01-01, this is the only valid video URL format. If this changes in
     the future (i.e. more than one valid URL type, or ID not present in URL) and
     requires falling back to the old cloudscraper method, an xpath of 
         //meta[@property="video-id"]/@content 
     can be used to pass into the PMVHaven API
 '''
 
-def main():
+def sceneByURL():
     params = json.loads(sys.stdin.read())
 
     if not params['url']:
-        fail('No URL entered.')
+        fail('No URL entered')
 
     sceneId = params['url'].split('_')[-1]
 
@@ -67,13 +63,13 @@ def main():
     data = getData(sceneId)
 
     if not 'video' in data or len(data['video']) < 1:
-        fail(f"Video data not found in data: {data}")
+        fail(f"Video data not found in API response: {data}")
 
     video = getData(sceneId)['video'][0]
 
     tags = video['tags'] + video['categories']
 
-    ret = {
+    return {
         'title': video['title'],
         'image': getIMG(video),
         'date': video['isoDate'].split('T')[0],
@@ -92,7 +88,6 @@ def main():
             } for x in video['stars']
         ]
     }
-    print(json.dumps(ret))
 
-if __name__ == "__main__":
-    main()
+if sys.argv[1] == 'sceneByURL':
+    print(json.dumps(sceneByURL()))

--- a/scrapers/PMVHaven/PMVHaven.yml
+++ b/scrapers/PMVHaven/PMVHaven.yml
@@ -8,4 +8,5 @@ sceneByURL:
     script:
       - python
       - PMVHaven.py
-# Last Updated December 30, 2023
+      - sceneByURL
+# Last Updated January 1, 2024


### PR DESCRIPTION
The old method using cloudscraper was heavy handed IMO, I have made these changes:

- New method takes video ID directly from input URL because that is the only valid video site URL format. Removed unnecessary imports
- Code deduplication (fail method)
- More helpful error logging
- Changed script layout to allow for possible future scrapeBy options
- More helpful var names
- Reverse search thumbnails as I found a case where a blank thumb was returned as it was a incompatible type for the video site, and this change will ensure the most recent thumb is pulled into stash
- Updated yml file to specify sceneByURL