### PR TITLE
Resolved 400 error when saving images scraped from PaperStreat

### DIFF
--- a/scrapers/PaperStreetMedia.yml
+++ b/scrapers/PaperStreetMedia.yml
@@ -95,4 +95,8 @@ xPathScrapers:
                 teensloveblackcocks: Teens Love Black Cocks
                 thickumz: Thickumz
                 tinysis: Tiny Sis
+driver:
+  headers:
+    - Key: User-Agent
+      Value: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0)
 # Last Updated September 28, 2023


### PR DESCRIPTION
I was getting a 400 error when saving anything with an images scrapped from PaperStreat.  Added header data to scraper.