### PR TITLE
Add support for Worst Behavior Productions to Assume the Position scraper

### DIFF
--- a/scrapers/AssumeThePositionStudios.py
+++ b/scrapers/AssumeThePositionStudios.py
@@ -16,11 +16,7 @@ except ModuleNotFoundError:
 
 
 def debugPrint(t):
-    #sys.stderr.write(t + "\n");
-
-def call_graphql(query, variables=None):
-    return graphql.callGraphQL(query, variables)
-
+    log.debug(t + "\n");
 
 def scrape_scene(url):
     query = """
@@ -75,7 +71,7 @@ query scrapeSceneURL($url: String!) {
 }"""
 
     variables = {"url": url}
-    result = call_graphql(query, variables)
+    result = graphql.callGraphQL(query, variables)
     log.debug(f"result {result}")
     res = result["scrapeSceneURL"]
     res["url"] = url
@@ -99,7 +95,7 @@ if m := re.match(r"(\d+)_[a-z]+_[a-z]+_\d+_([A-Z]+).*", title):
         apiUrl = "https://assumethepositionstudios.com/api/site/13/updates/0"
         sceneUrlFragment = "https://assumethepositionstudios.com/trailer?updateId="
     else:
-        print("{ Unknown site code }" + siteCode)
+        debugPrint("Unknown site code " + siteCode)
         sys.exit();
 
     debugPrint("Searching for " + str(contentId) + " on " + apiUrl)

--- a/scrapers/AssumeThePositionStudios.py
+++ b/scrapers/AssumeThePositionStudios.py
@@ -1,0 +1,123 @@
+import json
+import sys
+import requests
+import re
+import os
+
+try:
+    import py_common.graphql as graphql
+    import py_common.log as log
+except ModuleNotFoundError:
+    print(
+        "You need to download the folder 'py_common' from the community repo! (CommunityScrapers/tree/master/scrapers/py_common)",
+        file=sys.stderr,
+    )
+    sys.exit()
+
+
+def debugPrint(t):
+    #sys.stderr.write(t + "\n");
+
+def call_graphql(query, variables=None):
+    return graphql.callGraphQL(query, variables)
+
+
+def scrape_scene(url):
+    query = """
+query scrapeSceneURL($url: String!) {
+    scrapeSceneURL(url: $url) {
+        title
+        details
+        code
+        date
+        image
+        urls
+        studio {
+            name
+            url
+            image
+            parent {
+                name
+                url
+                image
+            }
+        }
+        tags {
+            name
+        }
+        performers {
+            aliases
+            birthdate
+            career_length
+            country
+            death_date
+            details
+            ethnicity
+            eye_color
+            fake_tits
+            gender
+            hair_color
+            height
+            instagram
+            images
+            measurements
+            name
+            piercings
+            tags {
+                name
+            }
+            tattoos
+            twitter
+            url
+            weight
+        }
+    }
+}"""
+
+    variables = {"url": url}
+    result = call_graphql(query, variables)
+    log.debug(f"result {result}")
+    res = result["scrapeSceneURL"]
+    res["url"] = url
+    return res
+
+
+fragment = json.loads(sys.stdin.read())
+debugPrint(json.dumps(fragment))
+title = fragment.get("title")
+
+debugPrint("title is " + title)
+if m := re.match(r"(\d+)_[a-z]+_[a-z]+_\d+_([A-Z]+).*", title):
+    #Turn the content id from the filename into a scene id
+    contentId = int(m.group(1))
+    siteCode = m.group(2)
+    debugPrint("Site code is " + siteCode)
+    if siteCode.casefold() == "WBP".casefold():
+        apiUrl = "https://www.worstbehaviorproductions.com/api/site/21/updates/0"
+        sceneUrlFragment = "https://worstbehaviorproductions.com/trailer?updateId="
+    elif siteCode.casefold() == "ATP".casefold():
+        apiUrl = "https://assumethepositionstudios.com/api/site/13/updates/0"
+        sceneUrlFragment = "https://assumethepositionstudios.com/trailer?updateId="
+    else:
+        print("{ Unknown site code }" + siteCode)
+        sys.exit();
+
+    debugPrint("Searching for " + str(contentId) + " on " + apiUrl)
+    page = requests.get(apiUrl)
+    updates = json.loads(page.content)
+    matches = [scene for scene in updates["data"] if scene["scene"]["id"] == contentId]
+    if len(matches) != 1:
+        debugPrint("Couldn't find match for " + str(contentId) + " found " + str(len(matches)) + " matches")
+        sys.exit()
+    debugPrint("Match is " + json.dumps(matches[0]))
+    sceneId = matches[0]["id"]
+
+    #Build a scene url from the sceneId
+    sceneUrl = sceneUrlFragment + str(sceneId)
+    debugPrint("Scene URL is " + sceneUrl)
+
+    result = scrape_scene(sceneUrl)
+    print(json.dumps(result))
+else:
+    debugPrint("title didn't match")
+    print(json.dumps({}))

--- a/scrapers/AssumeThePositionStudios.yml
+++ b/scrapers/AssumeThePositionStudios.yml
@@ -32,7 +32,7 @@ jsonScrapers:
         selector: data.scene.description
         postProcess:
           - replace:
-              - regex: (.*?)[A-Z,'\s]+\.?$
+              - regex: (.*?)[A-Z,/'\s]+\.?$
                 with: $1
       Date: data.live_date
       Image:

--- a/scrapers/AssumeThePositionStudios.yml
+++ b/scrapers/AssumeThePositionStudios.yml
@@ -9,6 +9,21 @@ sceneByURL:
       url:
         - regex: '.+/trailer\?updateId=(\d+).*'
           with: "${1}"
+  - action: scrapeJson
+    url:
+      - worstbehaviorproductions.com/trailer
+    scraper: sceneScraper
+    queryURL: "https://worstbehaviorproductions.com/api/update/{url}/trailer/"
+    queryURLReplace:
+      url:
+        - regex: '.+/trailer\?updateId=(\d+).*'
+          with: "${1}"
+sceneByFragment:
+  action: script
+  script:
+    - python
+    - AssumeThePositionStudios.py
+    - sceneByFragment
 jsonScrapers:
   sceneScraper:
     scene:
@@ -21,11 +36,8 @@ jsonScrapers:
                 with: $1
       Date: data.live_date
       Image:
-        selector: data.image
-        postProcess:
-          - replace:
-              - regex: ^/
-                with: https://assumethepositionstudios.com/
+        selector: '[data.producer.url,data.image]'
+        concat: "/"
       Performers:
         Name: data.models.#.name
       Studio:
@@ -35,9 +47,9 @@ jsonScrapers:
           selector: data.scene.description
           postProcess:
             - replace:
-                - regex: (.*?)([A-Z,'\s]+)\.?$
+                - regex: (.*?)([A-Z,/'\s]+)\.?$
                   with: $2
                 - regex: ',\s+'
                   with: ","
           split: ","
-# Last Updated October 13, 2022
+# Last Updated January 2, 2023


### PR DESCRIPTION
Assume The Position Studios (and a handful of other studios) use the same API.  This adds support for Worst Behavior Productions to the Assume The Position Studios scraper.

I also wanted a scrapeByFragment that can use the filename (which is basically studiocode_studio_bitrate) to find the correct url and scrape it.  This adds a python scraper to do the parsing and then it turns around and does a scrapeSceneURL to call the yml scraper.