### PR TITLE
Fix MovieScraper studio for Sweet Sinner

### DIFF
--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -240,7 +240,8 @@ xPathScrapers:
                 digitalplayground: "Digital Playground"
                 transsensual: TransSensual
                 kinkyspa: Kinky Spa
-
+                SweetSinner: Sweet Sinner
+                sweetsinner: Sweet Sinner                
       FrontImage: $section//picture/img[@alt]/@src
 
   performerScraper:

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -380,4 +380,4 @@ xPathScrapers:
       Performers: *performers
       Tags: *tags
       Studio: *studio
-# Last Updated December 27, 2023
+# Last Updated January 08, 2024


### PR DESCRIPTION
The original has a map when doing a scene scrape but doesn't do the same map when doing a movie scrape.  Movie scrap would be "sweetsinner" but scene scrape would be "Sweet Sinner".  Made that consistent.