### PR TITLE
Support Family Sinners series mapping with Movie URL scraper

### DIFF
--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -58,6 +58,7 @@ movieByURL:
       - sweetheartvideo.com/movie/
       - sweetsinner.com/movie/
       - transsensual.com/movie/
+      - familysinners.com/series/
     scraper: movieScraper
 
 performerByURL:
@@ -241,7 +242,8 @@ xPathScrapers:
                 transsensual: TransSensual
                 kinkyspa: Kinky Spa
                 SweetSinner: Sweet Sinner
-                sweetsinner: Sweet Sinner                
+                sweetsinner: Sweet Sinner   
+                familysinners: Family Sinners             
       FrontImage: $section//picture/img[@alt]/@src
 
   performerScraper:
@@ -380,4 +382,4 @@ xPathScrapers:
       Performers: *performers
       Tags: *tags
       Studio: *studio
-# Last Updated January 08, 2024
+# Last Updated January 10, 2024


### PR DESCRIPTION
Added ability to scrape Movie via "Series" for this site.  This ppart didn't require a separate config for Scene scraping, but that'd be needed if we wanted to get this logic into scene scrapes due to the DOM differences "Movie Info" vs. "Series Info".  I didn't want to un-wire that much of this for an edge feature like Movies, though.