### PR TITLE
Fix for issue #1583 TeamSkeet HTML markup in Description

### DIFF
--- a/scrapers/IncestFlix.yml
+++ b/scrapers/IncestFlix.yml
@@ -1,0 +1,34 @@
+name: IncestFlix
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - incestflix.com/watch/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Studio:
+        Name:
+          fixed: "IncestFlix"
+      Title:
+        selector: //div[@id = 'incflix-videowrap']//h2
+      Tags:
+        Name: //div[@id = 'videotags']//a[contains(@class, 'studiolink')]
+      Performers:
+        Name: 
+          selector: //div[@id = 'incflix-videowrap']//h2
+          postProcess:
+            - replace:
+              - regex: ( - .*)
+                with:
+            - replace:
+              - regex: (\s*)(,)(\s*)
+                with: $2
+          split: ","
+      Image:
+        selector: //video[@id='incflix-player']/@poster
+        postProcess:
+          - replace:
+            - regex: (.*)
+              with: http:$1
+# Last Updated January 10, 2024

--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -115,7 +115,11 @@ if dt:
     dt = re.sub(r'T.+', '', dt)
     date = datetime.strptime(dt, '%Y-%m-%d')
     scrape['date'] = str(date.date())
-scrape['details'] = scene_api_json.get('description')
+
+#fix for TeamKseet including HTML tags in Description
+CLEANR = re.compile('<.*?>') 
+cleandescription = re.sub(CLEANR,'',scene_api_json.get('description'))
+scrape['details'] = cleandescription
 scrape['studio'] = {}
 scrape['studio']['name'] = scene_api_json['site'].get('name')
 scrape['performers'] = [{"name": x.get('modelName')}


### PR DESCRIPTION
I added some regex to strip HTML tags from the TeamSkeet Description field.  Tested on both example URL's noted in the issue, both with expected clean outputs into Stash.