### PR TITLE
Minanno-AV: Account for edge case in determining career start

### DIFF
--- a/scrapers/Minnano-AV/Minnano-AV.py
+++ b/scrapers/Minnano-AV/Minnano-AV.py
@@ -48,7 +48,8 @@ REGEXES = {
     "alias": r"(?P<kanji>[^\x29\uFF09]+?)(?P<studio>[\x28\uFF08\u3010][^\x29\uFF09\u3011]+(?:[\x29\uFF09\u3011]))?\s[\x28\uFF08](?P<katakana>\w+)?\s+/\s(?P<romanized>[a-z-A-Z ]+)?[\x29\uFF09]",
     "id": r"\d+",
     "birthdate": r"[0-9-]+",
-    "career": (r"(?P<start>\d+)年?(?:\d+月)? ?(?:\d+)?日?[-~]? ?(?:(?P<end>\d+)?)?年?"),
+    # https://regex101.com/r/FSqv0L/1
+    "career": (r"(?P<start>\d{4})年?(?:\d+月)? ?(?:\d+)?日?[-~]? ?(?:(?P<end>\d+)?)?年?"),
     "measurements": (
         r"(?<=T)(?P<height>\d+)? / B(?P<bust>\d+)\([^=]+=(?P<cup>\w+)\) / W(?P<waist>\d+) / H(?P<hip>\d+)"
     ),

--- a/scrapers/Minnano-AV/Minnano-AV.yml
+++ b/scrapers/Minnano-AV/Minnano-AV.yml
@@ -16,4 +16,4 @@ performerByName:
     - python
     - Minnano-AV.py
     - performer_by_name
-# Last Updated December 16, 2023
+# Last Updated January 11, 2024


### PR DESCRIPTION
Fix for https://www.minnano-av.com/actress967297.html returning "3" as career start because of this block of text:

```
顔出し！女子大生限定 マジックミラー号 寝取り！嫉妬！羞恥からの興奮と快感！！ Wデート中の大学生カップル◆初めての同室スワッピング！！3 in池袋（2015年06月 06日）
```

I've just set the the regex to look for exactly 4 digits. If we find an occurence of double-digit years let's revise it further.