### PR TITLE
Title and description fixes for Helix

### DIFF
--- a/scrapers/HelixStudios.yml
+++ b/scrapers/HelixStudios.yml
@@ -48,17 +48,13 @@ xPathScrapers:
       $info: //div[@class="text"]
     scene:
       Title:
-        selector: //title/text()
-        postProcess:
-          - replace:
-              - regex: \s*- Helix Studios.*$
-                with:
+        selector: //div[@class="video-info"]/span[1]/text()
       Date:
         selector: //div[@class="info-items"]/span[@class="info-item date"]/text()
         postProcess:
           - parseDate: January 2, 2006
       Details:
-        selector: //div[contains(@class, "description-content")]/p/text()
+        selector: //div[contains(@class, "description-content")]/p[node()]
         concat: "#LINEBREAK#"
         postProcess:
           - replace:
@@ -144,4 +140,4 @@ xPathScrapers:
           - replace:
               - regex: $
                 with: " "
-# Last Updated February 20, 2023
+# Last Updated January 14, 2024


### PR DESCRIPTION
This applies a couple of fixes to the Helix scraper needed due to recent site changes:

* The HTML title for scene pages is now what a regular person looking at the scene page would call the scene subtitle. This changes the scraper to pull the title that appears in the largest font on the scene page, which has historically been the scene title (which, prior to this site change, matched the HTML title).
* Helix added performer links to the scene description a while back, and the XPath query didn't account for them, omitting the text and adding spurious line breaks. This changes the scraper to use the entire contents of all non-empty `<p>` blocks.