### PR TITLE
Fix for MindGeek to scrape movie from sites that use "Series Info"

### DIFF
--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -90,7 +90,7 @@ xPathScrapers:
     common:
       $section: //div[contains(@class,"tg5e7m")]/ancestor::section
       $canonicalUrl: &canonicalUrl //link[@rel="canonical"]/@href
-      $movieUriPath: &movieUriPath //a[text()="Movie Info"]/@href
+      $movieUriPath: &movieUriPath //a[text()="Movie Info" or text()="Series Info"]/@href
     scene:
       Title: $section//h1/text()|$section//h2/text()
       Date:

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -150,6 +150,15 @@ xPathScrapers:
                 with: $1
             - subScraper:
                 selector: //h1/text()|//h2/text()
+        FrontImage:
+          selector: $canonicalUrl|$movieUriPath
+          concat: '__SEPARATOR__'
+          postProcess:
+            - replace:
+              - regex: '^(https://[^/]+).+__SEPARATOR__'
+                with: $1
+            - subScraper:
+                selector: //section//picture/img/@src
       Code: &sceneCode
         selector: $canonicalUrl
         postProcess:
@@ -244,7 +253,7 @@ xPathScrapers:
                 SweetSinner: Sweet Sinner
                 sweetsinner: Sweet Sinner   
                 familysinners: Family Sinners             
-      FrontImage: $section//picture/img[@alt]/@src
+      FrontImage: //section//picture/img/@src
 
   performerScraper:
     performer:

--- a/scrapers/MindGeek.yml
+++ b/scrapers/MindGeek.yml
@@ -391,4 +391,4 @@ xPathScrapers:
       Performers: *performers
       Tags: *tags
       Studio: *studio
-# Last Updated January 10, 2024
+# Last Updated January 15, 2024


### PR DESCRIPTION
When doing a scene scrape by URL, Movie wouldn't populate properly if the site releases as Series instead of as Movies.  Family Sinners is an example of Series, vs. Sweet Sinner being an example of Movies.  The result is that Series-based sites now get the Movie as the Series Name, instead of just copying the Scene Name to the Movie Name.