### PR TITLE
Updated scene scraper for Data18 to drop ' #1' from movie title series

### DIFF
--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -52,7 +52,12 @@ xPathScrapers:
         Name: $studio
         URL: $studio/@href
       Movies:
-        Name: $movie/text()
+        Name:
+          selector: $movie/text()
+          postProcess:
+            - replace:
+                - regex: '\s#1$'
+                  with:
         URL: $movie/@href
       Image: //img[@id="playpriimage"]/@src
   movieScraper:


### PR DESCRIPTION
If a movie is a part of a movie series the first title doesn't have a number appended to the title but in the scene scrapper it is added.  I updated the scraper to drop that trailing #1.