### PR TITLE
Update Hentaied.yml

### DIFF
--- a/scrapers/Hentaied.yml
+++ b/scrapers/Hentaied.yml
@@ -6,6 +6,8 @@ sceneByURL:
       - futanari.xxx
       - hentaied.com
       - parasited.com
+      - defeatedsexfight.com
+      - somegore.com
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
@@ -19,7 +21,8 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Performers:
-        Name: //div[@class="left-top-part"]//div[contains(@class,"tagsmodels")]//a
+        Name: //div[@class="left-top-part"]//div[contains(@class,"tagsmodels singletag")]//a
+      Director:  //div[contains(@class, "director")]//span
       Tags:
         Name:
           selector: //ul[@class="post-categories"]//a
@@ -41,6 +44,10 @@ xPathScrapers:
           selector: //meta[@property="og:site_name"]/@content
           postProcess:
             - map:
-                Real Life Hentai: Hentaied
-
-# Last Updated December 2, 2023
+                Real Life Hentai | Tentacle Porn: Hentaied
+                Freeze - Time Freeze Porn Videos: Freeze
+                Parasited                       : Parasited
+                Futanari XXX                    : Futanari XXX
+                Lesbian Sex Fight               : Defeated Sex Fight
+                Bloody                          : Somegore
+# Last Updated January 20, 2024


### PR DESCRIPTION
Expanded out to include initial support for Defeated Sex Fight & SomeGore - Only thing I couldn't get working is pulling description as it comes from a different place - meta property="og:description" - ideally I'd have included that as fall back a) because that's the only place that works for DSF! B) it's included on all sites so would still pull a description as a backup.

Improved mapping of all 6 network sites to make it look pretty!

And final change is with the help of Maista, performers and directors are correctly identified and populated in the correct places!