### PR TITLE
Update KBProductions scraper to include LucidFlix

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -886,6 +886,7 @@ loveherfeet.com|LoveHerFilms.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-
 loveherfilms.com|LoveHerFilms.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 lubed.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lucasentertainment.com|LucasEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+lucidflix.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 lustcinema.com|LustCinema.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lustery.com|Lustery.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Amateur
 lustreality.com|SLRoriginals.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -26,7 +26,7 @@ except ModuleNotFoundError:
 
 def get_from_url(url_to_parse):
     m = re.match(
-        r'https?:\/\/(?:www\.)?((\w+)\.com)(?:\/tour)?\/(?:videos|upcoming|models)\/?(\d+)?\/([a-z0-9-]+)',
+        r'https?:\/\/(?:www\.)?((\w+)\.com)(?:\/tour)?\/(?:videos|episodes|upcoming|models)\/?(\d+)?\/([a-z0-9-]+)',
         url_to_parse)
     if m is None:
         return None, None, None, None
@@ -72,12 +72,17 @@ def scrape_scene(page_json, studio):
         sys.exit(1)
 
     scene = page_json.get("props").get("pageProps").get("content")
+    studioMap = {
+        "Lucid flix": "LucidFlix"
+    }
 
     scrape = {}
     if scene.get('site'):
         scrape['studio'] = {'name': scene['site']}
     else:
         scrape['studio'] = {'name': studio}
+    if scrape['studio']['name'] in studioMap:
+        scrape['studio']['name'] = studioMap[scrape['studio']['name']]
     if scene.get('title'):
         scrape['title'] = scene['title']
     if scene.get('publish_date'):

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -22,6 +22,7 @@ performerByURL:
   - url:
       - inserted.com/tour/models/
       - inserted.com/models/
+      - lucidflix.com/models/
       - rickysroom.com/models/
       - sidechick.com/models/
     action: script

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -9,6 +9,7 @@ sceneByURL:
       - inserted.com/upcoming/
 
       - inserted.com/videos/
+      - lucidflix.com/episodes/
       - rickysroom.com/videos/
       - sidechick.com/videos/
 


### PR DESCRIPTION
LucidFlix is a new site under the KB Productions umbrella.  It has some unique characteristics, but with some small modifications the existing KBProductions scraper works just fine with it.

Modified SCRAPERS-LIST.md for the new URL
Modified KBProductions.yml file to add LucidFlix URLs for scenes and models
Modified KBProductions.py to account for unique characteristics of LucidFlix