### PR TITLE
Fix: error catching for MissaX date parsing issues, site bug

### DIFF
--- a/scrapers/MissaX/MissaX.py
+++ b/scrapers/MissaX/MissaX.py
@@ -59,9 +59,13 @@ def scrape_scene_page(url): #scrape the main url
     tree = html.fromstring(tree) #parse html
     title = tree.xpath('//p[@class="raiting-section__title"]/text()')[0].strip() #title scrape
     log.debug(f'Title:{title}')
-    date = tree.xpath('//p[@class="dvd-scenes__data" and contains(text(), " Added:")]/text()[1]')[0] #get date
-    date = re.sub(r"(?:.+Added:\s)([\d\/]*).+", r'\g<1>', date).strip() #date cleanup
-    date = datetime.datetime.strptime(date, "%m/%d/%Y").strftime("%Y-%m-%d") #date parse
+    date = ''
+    try:
+        date = tree.xpath('//p[@class="dvd-scenes__data" and contains(text(), " Added:")]/text()[1]')[0] #get date
+        date = re.sub(r"(?:.+Added:\s)([\d\/]*).+", r'\g<1>', date).strip() #date cleanup
+        date = datetime.datetime.strptime(date, "%m/%d/%Y").strftime("%Y-%m-%d") #date parse
+    except:
+        log.error("failed to parse date")
     log.debug(f'Date:{date}')
     studio = tree.xpath('//base/@href')[0].strip() #studio scrape
     studio = studio.replace("www.", "")


### PR DESCRIPTION
MissaX scene pages currently have unhandled exceptions in the code that handles the duration/date section.  I added some error catching in the scraper to catch parsing errors until MissaX fixes their site.  The scraper won't get the scene date, but it won't fail hard either.  I'm not savvy enough with Python to just hunt for the `Added:` text.  This has been broken for a few weeks, on their end.

Example from: `https://missax.com/tour/trailers/I-Need-You.html`
```Runtime:
Deprecated: Implicit conversion from float 42.50098333333334 to int loses precision in /home/httpd/html/admin.missax.com/public_html/cms_admin/phptemplate/site0_missax/customstuff/photo_movie_counts_short.tpl on line 17

Deprecated: Implicit conversion from float 2550.059 to int loses precision in /home/httpd/html/admin.missax.com/public_html/cms_admin/phptemplate/site0_missax/customstuff/photo_movie_counts_short.tpl on line 18
42:30 | Added: 01/23/2024 
```