### PR TITLE
Aylo API: add script dir resolving helper

### DIFF
--- a/scrapers/AyloAPI/scrape.py
+++ b/scrapers/AyloAPI/scrape.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import sys
 import difflib
@@ -6,6 +7,9 @@ import requests
 from datetime import datetime
 from typing import Any, Callable
 from urllib.parse import urlparse
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 import py_common.log as log
 from py_common.util import dig, guess_nationality, scraper_args


### PR DESCRIPTION
# problem

The `py_common` folder up one level was not being resolved, resulting in errors logged, e.g.

```
2024-02-21 14:53:48
Error   
scrapeSceneURL: input: scrapeSceneURL could not unmarshal json from script output: EOF
2024-02-21 14:53:48
Error   
could not unmarshal json from script output: EOF
2024-02-21 14:53:48
Error   
[Scrape / TransAngels] ModuleNotFoundError: No module named 'py_common'
2024-02-21 14:53:48
Error   
[Scrape / TransAngels]     import py_common.log as log
2024-02-21 14:53:48
Error   
[Scrape / TransAngels]   File "/root/.stash/scrapers/TransAngels/../AyloAPI/scrape.py", line 10, in <module>
2024-02-21 14:53:48
Error   
[Scrape / TransAngels] Traceback (most recent call last):
```

# solution

This just adds the current script directory to the `sys.path` to allow `py_common` to be found.