### PR TITLE
add scrape of numerical studio codes from Wtfpass sites

### DIFF
--- a/scrapers/Wtfpass.yml
+++ b/scrapers/Wtfpass.yml
@@ -37,5 +37,11 @@ xPathScrapers:
       Performers:
         Name: $content//div[@class="data-row data-actress"]/a/text()
         URL: $content//div[@class="data-row data-actress"]/a/@href
+      Code:
+        selector: //link[@rel="canonical"]/@href
+        postProcess:
+          - replace:
+            - regex: ".*\\/videos\\/([0-9]+).*"
+              with: $1
 
-# Last Updated November 30, 2020
+# Last Updated February 24, 2024


### PR DESCRIPTION
Currently there is no scraping of the studio codes of the WTFPass sites. The adjusted scraper will include the numerical code from their sites. The studo-related code is not present for every scene