### PR TITLE
fix: adjust Arx scraper to updated graphql API

### DIFF
--- a/scrapers/Arx/Arx.py
+++ b/scrapers/Arx/Arx.py
@@ -281,6 +281,7 @@ def get_scene(url):
     ret['image'] = result.get('primaryPhotoUrl')
     ret['date'] = result.get('availableAt') and result.get('availableAt')[:10] \
         or result.get('createdAt') and result.get('createdAt')[:10]
+    ret['code'] = str(result.get('id'))
 
     return ret
 

--- a/scrapers/Arx/Arx.py
+++ b/scrapers/Arx/Arx.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from py_common.graphql import GRAPHQL_INTROSPECTION
+
 # Static definition, used in the GraphQL request
 site_ids = {
     'japanlust.com': 2,
@@ -21,98 +23,6 @@ API_TIMEOUT = 10
 
 # GraphQL API endpoint
 ENDPOINT = "https://arwest-api-production.herokuapp.com/graphql"
-
-# GraphQL introspection
-GRAPHQL_INTROSPECTION = """
-    fragment FullType on __Type {
-    kind
-    name
-    fields(includeDeprecated: true) {
-        name
-        args {
-        ...InputValue
-        }
-        type {
-        ...TypeRef
-        }
-        isDeprecated
-        deprecationReason
-    }
-    inputFields {
-        ...InputValue
-    }
-    interfaces {
-        ...TypeRef
-    }
-    enumValues(includeDeprecated: true) {
-        name
-        isDeprecated
-        deprecationReason
-    }
-    possibleTypes {
-        ...TypeRef
-    }
-    }
-    fragment InputValue on __InputValue {
-    name
-    type {
-        ...TypeRef
-    }
-    defaultValue
-    }
-    fragment TypeRef on __Type {
-    kind
-    name
-    ofType {
-        kind
-        name
-        ofType {
-        kind
-        name
-        ofType {
-            kind
-            name
-            ofType {
-            kind
-            name
-            ofType {
-                kind
-                name
-                ofType {
-                kind
-                name
-                ofType {
-                    kind
-                    name
-                }
-                }
-            }
-            }
-        }
-        }
-    }
-    }
-    query IntrospectionQuery {
-    __schema {
-        queryType {
-        name
-        }
-        mutationType {
-        name
-        }
-        types {
-        ...FullType
-        }
-        directives {
-        name
-        locations
-        args {
-            ...InputValue
-        }
-        }
-    }
-    }
-"""
 
 # Request headers
 headers = {

--- a/scrapers/Arx/Arx.py
+++ b/scrapers/Arx/Arx.py
@@ -22,6 +22,98 @@ API_TIMEOUT = 10
 # GraphQL API endpoint
 ENDPOINT = "https://arwest-api-production.herokuapp.com/graphql"
 
+# GraphQL introspection
+GRAPHQL_INTROSPECTION = """
+    fragment FullType on __Type {
+    kind
+    name
+    fields(includeDeprecated: true) {
+        name
+        args {
+        ...InputValue
+        }
+        type {
+        ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+    }
+    inputFields {
+        ...InputValue
+    }
+    interfaces {
+        ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+        name
+        isDeprecated
+        deprecationReason
+    }
+    possibleTypes {
+        ...TypeRef
+    }
+    }
+    fragment InputValue on __InputValue {
+    name
+    type {
+        ...TypeRef
+    }
+    defaultValue
+    }
+    fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+        kind
+        name
+        ofType {
+        kind
+        name
+        ofType {
+            kind
+            name
+            ofType {
+            kind
+            name
+            ofType {
+                kind
+                name
+                ofType {
+                kind
+                name
+                ofType {
+                    kind
+                    name
+                }
+                }
+            }
+            }
+        }
+        }
+    }
+    }
+    query IntrospectionQuery {
+    __schema {
+        queryType {
+        name
+        }
+        mutationType {
+        name
+        }
+        types {
+        ...FullType
+        }
+        directives {
+        name
+        locations
+        args {
+            ...InputValue
+        }
+        }
+    }
+    }
+"""
+
 # Request headers
 headers = {
     "Accept-Encoding": "gzip, deflate, br",
@@ -69,6 +161,10 @@ def read_json_input():
 
 
 def call_graphql(query, variables=None):
+    # if the graphQL API changes, uncomment the following to discover available
+    # API fields, queries, etc.
+    # query = GRAPHQL_INTROSPECTION
+
     graphql_json = {'query': query}
     if variables is not None:
         graphql_json['variables'] = variables
@@ -81,7 +177,7 @@ def call_graphql(query, variables=None):
         log_debug(json.dumps(result))
 
         if result.get("errors", None):
-            for error in result["errors"]["errors"]:
+            for error in result["errors"]:
                 raise Exception("GraphQL error: {}".format(error))
         if result.get("data", None):
             return result.get("data")
@@ -97,7 +193,7 @@ def get_scene(url):
     query = """
         query 
             Scene($id: Int!, $siteId: Int) {  
-                scene(id: $id, siteId: $siteId) 
+                legacyScene(id: $id, siteId: $siteId) 
                 {    
                     ...sceneFullFields    
                     __typename  
@@ -173,7 +269,7 @@ def get_scene(url):
         log_error(e)
         return None
 
-    result = result.get('scene')
+    result = result.get('legacyScene')
 
     ret = {}
 

--- a/scrapers/Arx/Arx.yml
+++ b/scrapers/Arx/Arx.yml
@@ -15,4 +15,4 @@ sceneByURL:
       - Arx.py
       - scrapeByURL
 
-# Last Updated April 24, 2023
+# Last Updated February 27, 2024

--- a/scrapers/py_common/graphql.py
+++ b/scrapers/py_common/graphql.py
@@ -16,6 +16,102 @@ api_key =
 )
 
 
+# GraphQL introspection
+#
+# if a graphQL API changes, you can use this as the query string value to
+# discover available API fields, queries, etc.
+GRAPHQL_INTROSPECTION = """
+    fragment FullType on __Type {
+    kind
+    name
+    fields(includeDeprecated: true) {
+        name
+        args {
+        ...InputValue
+        }
+        type {
+        ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+    }
+    inputFields {
+        ...InputValue
+    }
+    interfaces {
+        ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+        name
+        isDeprecated
+        deprecationReason
+    }
+    possibleTypes {
+        ...TypeRef
+    }
+    }
+    fragment InputValue on __InputValue {
+    name
+    type {
+        ...TypeRef
+    }
+    defaultValue
+    }
+    fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+        kind
+        name
+        ofType {
+        kind
+        name
+        ofType {
+            kind
+            name
+            ofType {
+            kind
+            name
+            ofType {
+                kind
+                name
+                ofType {
+                kind
+                name
+                ofType {
+                    kind
+                    name
+                }
+                }
+            }
+            }
+        }
+        }
+    }
+    }
+    query IntrospectionQuery {
+    __schema {
+        queryType {
+        name
+        }
+        mutationType {
+        name
+        }
+        types {
+        ...FullType
+        }
+        directives {
+        name
+        locations
+        args {
+            ...InputValue
+        }
+        }
+    }
+    }
+"""
+
+
 def callGraphQL(query: str, variables: dict | None = None):
     api_key = config.api_key
     url = config.url


### PR DESCRIPTION
# problem

The GraphQL API has changed slightly in one of the query field names, and the response structure is one level less for errors.

# fix

This fixes those issues by using the changed field name `legacyScene` instead of `scene`, and using the first level `errors` instead of second level.

# extra

A general GraphQL introspection query variable `GRAPHQL_INTROSPECTION` is added that can be used again in future to discover API fields, queries, etc. This was used temporarily this time to find the changed field name.

Studio code scraping is now added, using the scene's `id` field.