### PR TITLE
Update GIGA.yml

### DIFF
--- a/scrapers/GIGA.yml
+++ b/scrapers/GIGA.yml
@@ -105,7 +105,7 @@ xPathScrapers:
       Director:
         selector: //*[@id="works_txt"]/ul/li[5]/dl/dd
       Image:  
-        selector: //*[@id="works_pic"]/ul/li[1]/img/@src
+        selector: //*[@id="works_pic"]/ul/li[1]/a/@href
         postProcess:
           - replace:
             - regex: pac_s.jpg
@@ -132,4 +132,4 @@ driver:
           Domain: ".www.akiba-web.com"
           Value: "yes"
           Path: "/"
-# Last Updated February 14, 2024
+# Last Updated February 27, 2024

--- a/scrapers/GIGA.yml
+++ b/scrapers/GIGA.yml
@@ -105,7 +105,7 @@ xPathScrapers:
       Director:
         selector: //*[@id="works_txt"]/ul/li[5]/dl/dd
       Image:  
-        selector: //*[@id="works_pic"]/ul/li[1]/a/@href
+        selector: //*[@id="works_pic"]/ul/li[1]/a/@href | //*[@id="works_pic"]/ul/li[1]/img/@src
         postProcess:
           - replace:
             - regex: pac_s.jpg


### PR DESCRIPTION
Currently GIGA (Akiba-web) lists older releases cover / image differently on their release page:

### **Recent release**

URL:
https://www.akiba-web.com/product/index.php?product_id=7197

Image XPATH required:
`//*[@id="works_pic"]/ul/li[1]/a/@href
`

### **Older releases**

URL:
https://www.akiba-web.com/product/index.php?product_id=2843

Image XPATH equired for older releases:
`//*[@id="works_pic"]/ul/li[1]/img/@src
`

Besides going the python scraper route see no clear XPATH fix for this and welcome to other ideas.
Would rather make it work for all recent releases as this only affects manual scrape via scene page.