### PR TITLE
Add scene scraper for EmoNetwork (emonetwork.com)

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -531,6 +531,7 @@ edwardjames.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 elegantangel.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 elitebabes.com|EliteBabes.yml|:x:|:x:|:x:|:heavy_check_mark:|-|Babes
 emilybloom.com|EmilyBloom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+emonetwork.com|EmoNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 englishlads.com|EnglishLads.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|Gay
 enzorimenez.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 eporner.com|Eporner.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/EmoNetwork.yml
+++ b/scrapers/EmoNetwork.yml
@@ -1,0 +1,38 @@
+name: "EmoNetwork"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - emonetwork.com
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //div[@class="trailer"]//img/@alt
+      Details:
+        selector: //div[@class="videoContainer"]//p/text()
+      Performers:
+        Name:
+          selector: //h2[contains(text(),'Models')]/a/text()
+      Image:
+        selector: //div[@class="trailer"]//img/@src
+      Date:
+        selector: //h1
+        postProcess:
+          - replace:
+              - regex: ^([^-]+).+
+                with: $1
+          - parseDate: January 02, 2006
+      Tags:
+        Name:
+          selector: //h4[contains(text(),'Search Tags')]/a/text()
+      Studio:
+        Name:
+          selector: //h3[contains(text(),'Site')]/a/text()
+          postProcess:
+            - map:
+                EmoTwinks: "Emo Twinks"
+                ExposedEmos: "Exposed Emos"
+                HomoEmo: "Homo Emo"
+                HomoScene: "Homo Scene"
+# Last Updated March 23, 2024


### PR DESCRIPTION
New scene scraper for EmoNetwork (emonetwork.com) and their sub-studios.

While the sub studios each have their own URLs it seems that the scene data is only available from the emonetwork.com site.  Their sub-studio URLs all lead to a "join" page when clicking on a scene.