### PR TITLE
Add scraper for DE Media sites

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -243,6 +243,7 @@ blackph.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 blacksonblondes.com|Dogfartnetwork.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 blacksoncougars.com|Dogfartnetwork.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 blacksondaddies.com|AdultSiteRunner.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+blackpayback.com|DEMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 blacktgirlshardcore.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|Trans
 blackvalleygirls.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 blackwhitefuckfest.com|Vivid.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1385,6 +1386,7 @@ r18.dev|R18.dev.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|JAV
 rachel-steele.com|RachelSteele.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
 rachelaldana.com|PinupDollars.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rachelstormsxxx.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+radicaljizzlam.com|DEMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 ragingstallion.com|RagingStallion.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 randyblue.com|RandyBlue.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 raunchybastards.com|AdultSiteRunner.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay

--- a/scrapers/DEMedia.yml
+++ b/scrapers/DEMedia.yml
@@ -1,0 +1,29 @@
+name: DEMedia 
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - blackpayback.com/tour/
+      - radicaljizzlam.com/tour/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //h1
+      Details: //div[contains(@class,"videoDetails ")]/p
+      Image:
+        selector: //base/@href | //script[contains(.,'poster=')]
+        concat: '__SEP__'
+        postProcess:
+          - replace:
+              - regex: ^(https:.+(\.com)).+?poster="([^"]+).+
+                with: $1$3
+      Tags:
+        Name: //li/a[contains(@href,'/categories/')]/text()
+      Studio:
+        Name:
+          selector: //meta[@name="author"]/@content
+          postProcess:
+            - map:
+                BlackPayBack: "Black Payback"
+# Last Updated March 28, 2024


### PR DESCRIPTION
New YML scene scraper for DE Media sites blackpayback.com and radicaljizzlam.com.

These sites are owned by the same company that operates the AdultDoorway network, but these two sites use a very different layout.  Instead of complicating the AdultDoorway scraper I've elected to give them their own.