### PR TITLE
Add studio map for Hitzefrei.yml

### DIFF
--- a/scrapers/Hitzefrei.yml
+++ b/scrapers/Hitzefrei.yml
@@ -37,8 +37,8 @@ xPathScrapers:
                 familyaffairs: Family Affairs
                 fanalarm: Fanalarm
                 fuckonarrival: Fuck On Arrival
-                milfhunters: Milf Hunters
-                pattisanals: Milf Hunters
+                milfhunters: MILF Hunters
+                pattisanals: Patti's Anals
                 tour: Hitzefrei
                 unleashed: Unleashed
   performerScraper:

--- a/scrapers/Hitzefrei.yml
+++ b/scrapers/Hitzefrei.yml
@@ -26,7 +26,21 @@ xPathScrapers:
         selector: //video[@id="ypp-player"]/@poster
       Studio:
         Name:
-          fixed: Hitzefrei
+          selector: //link[@rel="alternate"]/@href
+          postProcess:
+            - replace:
+                - regex: .+/([^\.]+).+
+                  with: $1
+            - map:
+                citycheck: City Check
+                cuffemall: Cuff 'em All
+                familyaffairs: Family Affairs
+                fanalarm: Fanalarm
+                fuckonarrival: Fuck On Arrival
+                milfhunters: Milf Hunters
+                pattisanals: Milf Hunters
+                tour: Hitzefrei
+                unleashed: Unleashed
   performerScraper:
     common:
       $stat: p[@class="stat-value"]
@@ -54,4 +68,4 @@ xPathScrapers:
           - feetToCm: true
       HairColor: //div[p[text()="Hair"]]/$stat
       EyeColor: //div[p[text()="Eyes"]]/$stat
-# Last Updated April 27, 2021
+# Last Updated April 7, 2024


### PR DESCRIPTION
The studio has several sub-studios / series for their content, each with a subdomain URL from hitzefrei.com, and one of which at this time is present in StashDB as a sub-studio of Hitzefrei.  This change adds a studio map to the scraper which will provide the series name as the studio when scraping from the series' URLs.  The content is also available from the hitzefrei.com URL and use the 'tour' subdomain, but unfortunately there is at present no indication of the series when viewed this way.  Thus scenes scraped directly from hitzefrei.com will be given the Hitzefrei studio.

Studio map:
          citycheck: City Check
          cuffemall: Cuff 'em All
          familyaffairs: Family Affairs
          fanalarm: Fanalarm
          fuckonarrival: Fuck On Arrival
          milfhunters: Milf Hunters
          pattisanals: Milf Hunters
          tour: Hitzefrei
          unleashed: Unleashed