### PR TITLE
Fix blank url at RandyBlue.yml

### DIFF
--- a/scrapers/RandyBlue.yml
+++ b/scrapers/RandyBlue.yml
@@ -26,7 +26,7 @@ xPathScrapers:
       Performers:
         Name: $titleArea/ul[@class="scene-models-list"]/li/a
       Image: //meta[@itemprop="thumbnailUrl"]/@content
-      URL: //link[@rel="canonical"]/@href
+      URL: //link[@hreflang="x-default"]/@href
       Studio:
         Name:
           fixed: Randy Blue


### PR DESCRIPTION
Scraper adds url field to "/", fixed that by getting url from different field.