### PR TITLE
Update x confessions image selectors

### DIFF
--- a/scrapers/XConfessions.yml
+++ b/scrapers/XConfessions.yml
@@ -19,14 +19,14 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-              - regex: .*release_date."([^\s]+).*
+            - regex: .*release_date."([^\s]+).*
                 with: $1
           - parseDate: 2006-01-02
       Details: &details
         selector: $script
         postProcess:
           - replace:
-           - regex: .+synopsis_clean="(?P<full>[^"]+).+short_synopsis_clean="(?P<short>[^"]+).+
+            - regex: .+synopsis_clean="(?P<full>[^"]+).+short_synopsis_clean="(?P<short>[^"]+).+
                 with: |
                   $short
 

--- a/scrapers/XConfessions.yml
+++ b/scrapers/XConfessions.yml
@@ -12,7 +12,6 @@ movieByURL:
 xPathScrapers:
   sceneScraper:
     common: &com
-      $info: //div[@class="w-full tablet:w-1/3 text-base tablet:text-sm mr-6"]
       $script: //script[contains(.,"window.__NUXT")]/text()
     scene:
       Title: &title //h1
@@ -20,46 +19,61 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-              - regex: .*production_date."(\d+-\d+-\d+)T.*
+              - regex: .*release_date."([^\s]+).*
                 with: $1
           - parseDate: 2006-01-02
       Details: &details
-        selector: //div[@class="my-2 tablet:my-0 w-full tablet:w-3/5"]/*[local-name()="h2" or local-name()="span"]
-        concat: "\n\n"
+        selector: $script
+        postProcess:
+          - replace:
+              - regex: .+?\.synopsis_clean="([^"]+).+?\.short_synopsis_clean="([^"]+).+
+                with: $2  $1
       Performers:
         Name:
-          selector: $info/p[contains(.,"Performers:")]//a
+          selector: //p[span[contains(.,"Performers:")]]//a
           concat: " & "  # some performers are joined
           split: " & "  # with &
+      Director: &director //p[span[contains(.,"Director:")]]//a
       Tags:
-        Name: $info/p[contains(.,"Tags:")]//a
-      Image:
-        selector: //div[@class="negativex"]//@data-srcset
-        postProcess: &pp
+        Name:
+          selector: //div/a[contains(@href,'/categories/')] | //button/@data-test
+          postProcess:
+            - replace:
+                - regex: 'profile-'
+                  with: ''
+      Image: &image
+        selector: $script
+        postProcess:
           - replace:
-              - regex: ^([^?]+)\?.*
+              - regex: .+?cover_title_picture[=:]"([^"]+).+
                 with: $1
+              - regex: '\\u002F'
+                with: '/'
       Studio: &studio
         Name:
           fixed: XConfessions
+      Movies:
+        Name: *title
+        Director: *director
+        Duration: &duration
+          selector: $script
+          postProcess:
+            - replace:
+                - regex: .+?.length="([^"]+).+
+                  with: $1
+        Date: *date
+        Synopsis: *details
+        Studio: *studio
+        FrontImage: *image
 
   movieScraper:
     common: *com
     movie:
       Name: *title
-      Director:
-        selector: $info/p[contains(.,"Director:")]/a
-        concat: ", "
-      Duration:
-        selector: $script
-        postProcess:
-          - replace:
-              - regex: .*w\.length."(\d{2}:\d{2}:\d{2})".*
-                with: $1
+      Director: *director
+      Duration: *duration
       Date: *date
       Synopsis: *details
       Studio: *studio
-      FrontImage:
-        selector: //div[@class="w-1/3 hidden tablet:block"]//@data-srcset
-        postProcess: *pp
-# Last Updated May 31, 2021
+      FrontImage: *image
+# Last Updated April 11, 2024

--- a/scrapers/XConfessions.yml
+++ b/scrapers/XConfessions.yml
@@ -19,14 +19,14 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-            - regex: .*release_date."([^\s]+).*
+              - regex: .*release_date."([^\s]+).*
                 with: $1
           - parseDate: 2006-01-02
       Details: &details
         selector: $script
         postProcess:
           - replace:
-            - regex: .+synopsis_clean="(?P<full>[^"]+).+short_synopsis_clean="(?P<short>[^"]+).+
+              - regex: .+synopsis_clean="(?P<full>[^"]+).+short_synopsis_clean="(?P<short>[^"]+).+
                 with: |
                   $short
 
@@ -38,7 +38,7 @@ xPathScrapers:
           split: " & "  # with &
       Director: &director //p[span[contains(.,"Director:")]]//a
       Tags:
-        Name:
+        Name: 
           selector: //div/a[contains(@href,'/categories/')] | //button/@data-test
           postProcess:
             - replace:
@@ -46,7 +46,7 @@ xPathScrapers:
                   with: ''
       Image: &image
         selector: $script
-        postProcess:
+        postProcess: 
           - replace:
               - regex: .+?cover_title_picture[=:]"([^"]+).+
                 with: $1
@@ -73,10 +73,10 @@ xPathScrapers:
     common: *com
     movie:
       Name: *title
-      Director: *director
+      Director: *director 
       Duration: *duration
       Date: *date
       Synopsis: *details
       Studio: *studio
       FrontImage: *image
-# Last Updated April 11, 2024
+# Last Updated April 12, 2024

--- a/scrapers/XConfessions.yml
+++ b/scrapers/XConfessions.yml
@@ -12,7 +12,7 @@ movieByURL:
 xPathScrapers:
   sceneScraper:
     common: &com
-      $script: //script[contains(.,"window.__NUXT")]/text()
+      $script: //script[contains(.,'window.__NUXT')]/text()
     scene:
       Title: &title //h1
       Date: &date
@@ -33,10 +33,10 @@ xPathScrapers:
                   $full
       Performers:
         Name:
-          selector: //p[span[contains(.,"Performers:")]]//a
-          concat: " & "  # some performers are joined
-          split: " & "  # with &
-      Director: &director //p[span[contains(.,"Director:")]]//a
+          selector: //p[span[contains(.,'Performers:')]]//a
+          concat: ' & '  # some performers are joined
+          split: ' & '  # with &
+      Director: &director //p[span[contains(.,'Director:')]]//a
       Tags:
         Name: 
           selector: //div/a[contains(@href,'/categories/')] | //button/@data-test
@@ -48,8 +48,26 @@ xPathScrapers:
         selector: $script
         postProcess: 
           - replace:
-              - regex: .+?cover_title_picture[=:]"([^"]+).+
+                    # Most scenes have a cover_title_picture value in the script
+              - regex: .+?cover_title_picture="([^"]+).+
                 with: $1
+                    # Some without the cover_title_picture will have twi consecutive images
+                    # with a UID.  The first is the movie poster, the second is the scene cover image
+              - regex: .+,"(https:[^"]+?-[^"]+?)","(https:[^"]+?-[^"]+)".*
+                with: $2
+                    # Some without the UID-style images instead have a sequence of images after
+                    # a time stamp.  The first is th movie poster, the second is the scene image
+              - regex: .+"\d\d\d\d-\d\d-\d\d\s+\d\d:\d\d:\d\d"[0-9a-zA-Z,"]*"(https:[^"]+?)","(https:[^"]+)".*
+                with: $2
+                    # Some don't have any of the above, but have a confession_cover_image value
+                    # that is pretty good, but doesn't have the scene name on it.
+              - regex: .+?confession_cover_image:"([^"]+).+
+                with: $1
+                    # If nothing above matches, take the last image in the script.  Often this
+                    # is the scene image, but it's not 100% reliable.
+              - regex: .+(https:[^"]+).*$
+                with: $1
+                    # Clean up UTF-8 coded slashes for real ones
               - regex: '\\u002F'
                 with: '/'
       Studio: &studio
@@ -67,7 +85,8 @@ xPathScrapers:
         Date: *date
         Synopsis: *details
         Studio: *studio
-        FrontImage: *image
+        URL: &url //link[@rel='canonical']/@href
+        FrontImage: &frontImage //article//div[contains(@class,'134px')]//img[contains(@sizes,'200px') or contains(@src,'jpeg') or contains(@src,'jpg')]/@src
 
   movieScraper:
     common: *com
@@ -78,5 +97,6 @@ xPathScrapers:
       Date: *date
       Synopsis: *details
       Studio: *studio
-      FrontImage: *image
-# Last Updated April 12, 2024
+      URL: *url
+      FrontImage: *frontImage
+# Last Updated April 13, 2024

--- a/scrapers/XConfessions.yml
+++ b/scrapers/XConfessions.yml
@@ -26,8 +26,11 @@ xPathScrapers:
         selector: $script
         postProcess:
           - replace:
-              - regex: .+?\.synopsis_clean="([^"]+).+?\.short_synopsis_clean="([^"]+).+
-                with: $2  $1
+           - regex: .+synopsis_clean="(?P<full>[^"]+).+short_synopsis_clean="(?P<short>[^"]+).+
+                with: |
+                  $short
+
+                  $full
       Performers:
         Name:
           selector: //p[span[contains(.,"Performers:")]]//a


### PR DESCRIPTION
The previous scraper had issues with some scenes, where it would suggest an image that's not related to the scene being scraped.  This change modifies the image selector to attempt several methods to find a suitable picture:

- First, look in the script for a cover_title_picture value.   
- If that's not present, look for two consecutive images with UIDs in the URL.  The first is the movie poster, the second is the scene image. 
- If that's not present, look for a time stamp followed closely by two images.  Again the first is the movie version, the second is the image. 
- If we still don't have a match, look for a confession_cover_image value.  These are pretty good, but won't have the scene name. 
- Finally, if nothing matches, try the last image in the script.  It's often the right one.

Yeah...I know...weird.  But this reliably snags a suitable image for the scene, though often it will be the vertical movie poster instead of a horizontal scene image.  A solution to improve this may yet present itself in the future.

Other changes: 

Modified movie Front Image selector to grab the vertical image more suitable for movie poster images.

Passing along the URL when creating movies when scenes are scraped.

Replaced " for ' for strings, for consistency.