### PR TITLE
Add scrapers for AVMoo and AVSox

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -155,6 +155,8 @@ autumn-jade.com|TheScoreGroup.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 av69.tv|Jhdv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 avadawn.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 avanal.com|Jhdv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
+avmoo.online|AVMoo.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|JAV
+avsox.click|AVMoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 aventertainments.com|AVE.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Database
 avidolz.com|Baberotica.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|JAV Uncensored
 avjiali.com|AVJiali.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|JAV Uncensored

--- a/scrapers/AVMoo.xml
+++ b/scrapers/AVMoo.xml
@@ -1,0 +1,92 @@
+name: AVMoo
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - avmoo.online
+      - avsox.click
+    scraper: sceneScraper
+
+movieByURL:
+  - action: scrapeXPath
+    url:
+      - avmoo.online
+    scraper: movieScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - avmoo.online
+    scraper: performerScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: &title //title
+      Date: &date //p[span[contains(.,'Release Date:')]]/text()
+      Image: &image //a[@class='bigImage']/img/@src
+      Studio: &studio
+        Name: //p[contains(.,'Studio:')]/following-sibling::p
+        URL:
+          selector: //p[contains(.,'Studio:')]/following-sibling::p/a/@href
+          postProcess:
+            - replace:
+                - regex: '^'
+                  with: 'https:'
+      Code: //span[contains(.,'ID:')]/following-sibling::span
+      Tags:
+        Name: //span[@class="genre"]/a
+      Performers:
+        Name: //a[contains(@href,'/star/')]/span
+      Movies:
+        Name: *title
+        FrontImage: *image
+        Studio: *studio
+        Duration: &duration
+          selector: //p[span[contains(.,'Length:')]]/text()
+          postProcess:
+            - replace:
+                - regex: min
+                  with: ":00"
+        URL: &url
+          selector: //ul[@class="dropdown-menu"]//a[contains(.,'English')]/@href
+          postProcess:
+            - replace:
+                - regex: '^'
+                  with: 'https:'
+
+  movieScraper:
+    movie:
+      Name: *title
+      Date: *date
+      Duration: *duration
+      FrontImage: *image
+      Studio: *studio
+      URL: *url
+
+  performerScraper:
+    common:
+      $avatar: //div[@class='avatar-box']
+    performer:
+      Name: $avatar//span/text()
+      Image: $avatar//img/@src
+      Birthdate:
+        selector: $avatar//p[contains(.,'Birthday:')]
+        postProcess:
+          - replace:
+              - regex: '[^\d-]'
+                with: ''
+      Height:
+        selector: $avatar//p[contains(.,'Height')]
+        postProcess:
+          - replace:
+              - regex: '[^\d]'
+                with: ''
+      Measurements:
+        selector: $avatar//p[contains(.,'Bust:')] | $avatar//p[contains(.,'Waist:')] | $avatar//p[contains(.,'Hips:')]
+        concat: '-'
+        postProcess:
+          - replace:
+              - regex: '[^\d-]'
+                with: ''
+
+# Last Updated April 16, 2024


### PR DESCRIPTION
For avmoo.online as mentioned in [Issue 73](https://github.com/stashapp/CommunityScrapers/issues/73).  Included avsox.click, as that site uses the same layout.

New URL scene scraper for avmoo.online and avsox.click.
New URL movie and performer scrapers for avmoo.online.

avsox.click shares the same format as avmoo.online, except it doesn't appear to have longer length clips that would justify creating movies, nor does it appear that performer details are available at avsox.click (at least for those sampled when writing this scraper).

Anyone with more familiarity with the studios present on these sites are welcome to create studio maps for those with Japanese names, if such is desired.

Tested with the English versions of the URLs.