### PR TITLE
Add NYSeed to KBProductions scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1288,6 +1288,7 @@ nylonspunkjunkies.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nylonsweeties.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nylonup.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 nympho.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+nyseedxxx.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 ocreampies.com|karatmedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV
 officecock.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 officemsconduct.com|Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -1,6 +1,6 @@
 name: KB Productions
 # requires: py_common
-# scrapes: 2 Girls 1 Camera, All Anal, Alt Erotic, Amazing Films, Anal Only, Benefit Monkey, Big Gulp Girls, BJ Raw, Black Bull Challenge, Cougar Season, Creampie Thais, Deepthroat Sirens, Dirty Auditions, Divine-DD, Emo Network, Facials Forever, Freak Mob Media, Gay Life Network, Got Filled, Hoby Buchanon, Inked POV, Inserted, JAV888, Lady Sonia, LezKey, LucidFlix, Mean Feet Fetish, Monger In Asia, Nylon Perv, Nympho, Pounded Petite, Red-XXX, Ricky's Room, S3XUS, Seska, Sexy Modern Bull, She's Brand New, SIDECHICK, Suck This Dick, Swallowed, Top Web Models, True Anal, TWM Classics, Xful, Yes Girlz, Yummy Couple, Z-Filmz
+# scrapes: 2 Girls 1 Camera, All Anal, Alt Erotic, Amazing Films, Anal Only, Benefit Monkey, Big Gulp Girls, BJ Raw, Black Bull Challenge, Cougar Season, Creampie Thais, Deepthroat Sirens, Dirty Auditions, Divine-DD, Emo Network, Facials Forever, Freak Mob Media, Gay Life Network, Got Filled, HardWerk, Hoby Buchanon, Inked POV, Inserted, JAV888, Lady Sonia, LezKey, LucidFlix, Mean Feet Fetish, Monger In Asia, Nylon Perv, Nympho, Pounded Petite, Red-XXX, Ricky's Room, S3XUS, Seska, Sexy Modern Bull, She's Brand New, SIDECHICK, Suck This Dick, Swallowed, Top Web Models, True Anal, TWM Classics, Xful, Yes Girlz, Yummy Couple, Z-Filmz
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -26,6 +26,7 @@ sceneByURL:
       - freakmobmedia.com/videos
       - gogobarauditions.com/trailers
       - gotfilled.com/videos
+      - hardwerk.com/films
       - hobybuchanon.com/behind-the-scenes
       - hobybuchanon.com/suck-this-dick
       - hobybuchanon.com/updates
@@ -34,10 +35,12 @@ sceneByURL:
       - inserted.com/videos
       - jav888.com/videos
       - lady-sonia.com/scenes
+      - legendaryx.com/videos
       - lezkey.com/scenes
       - lucidflix.com/episodes
       - meanfeetfetish.com/videos
       - mongerinasia.com/trailers
+      - nyseedxxx.com/video
       - nylonperv.com/videos
       - red-xxx.com/scenes
       - rickysroom.com/videos
@@ -151,4 +154,4 @@ xPathScrapers:
                 HomoScene: "Homo Scene"
                 LollipopTwinks: "Lollipop Twinks"
                 Twinklight: "Twink Light"
-# Last Updated March 29, 2024
+# Last Updated April 19, 2024


### PR DESCRIPTION
For nyseedxxx.com (NYSeed), as mentioned in [Issue 73](https://github.com/stashapp/CommunityScrapers/issues/73).

NYSeed is a KBProductions site, but uses a different format than those already handled by the scraper.  

Added a new JSON processing routine for the "video" element that's in use by this studio where previous studios used "content".  As this is the first site known to use this format this routine may be under a great deal of flux as additional sites are found that use the "video" element instead of "content".

Renamed existing JSON processing routine to reflect that it's fed from the "content" element.

Added nyseedxxx.com to screne URLs in YML.

Added api.nyseedxxx.com to Python studio map.

Added nyseedxxx.com to Scrapers List, referencing KBProductions.yml.