### PR TITLE
Fix for kink.yml scene image scraping

### DIFF
--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -175,7 +175,7 @@ xPathScrapers:
           - replace:
               - regex: ^.*"posterUrl":"([^"]+).*$
                 with: $1
-              - regex: "?.*$"
+              - regex: "\\?.*$"
                 with: ""
       # Pages do not include canonical URL links as of 2024
       # but I'm leaving this in case they change that back
@@ -293,4 +293,4 @@ driver:
   headers:
     - Key: User-Agent
       Value: stash-scraper/1.0.0
-# Last Updated April 21, 2024
+# Last Updated April 22, 2024


### PR DESCRIPTION
Just noticed an error in the stash logs after scraping a kink [scene](https://www.kink.com/shoot/106108):
`Warning Error compiling regex '?.*$': error parsing regexp: missing argument to repetition operator: ?`

Which leads to not stripping the text after the ? in the image url, thus downsizing the scene image:
`[0][Image] = https://imgopt02.kink.com/imagedb/106087/indexImage/106087_indeximage_003_full.png?w=1200&s=b3086e3563ff916b0d6224e3ed65477f043f9ad148d34ead068f1eaf0941a31e`

Small fix so it strips out the part after ?:
`[0][Image] = https://imgopt02.kink.com/imagedb/106087/indexImage/106087_indeximage_003_full.png`