### PR TITLE
Move vivid.com to Adultime scraper

### DIFF
--- a/scrapers/Adultime/Adultime.yml
+++ b/scrapers/Adultime/Adultime.yml
@@ -53,6 +53,7 @@ sceneByURL:
       - transgressivefilms.com/en/video/
       - trickyspa.com/en/video/
       - truelesbian.com/en/video/
+      - vivid.com/en/video/      
       - webyoung.com/en/video/
       - welikegirls.com/en/video/
       - wolfwagner.com/en/video/

--- a/scrapers/Vivid.yml
+++ b/scrapers/Vivid.yml
@@ -10,7 +10,6 @@ sceneByURL:
       - nastystepfamily.com
       - orgytrain.com
       - petited.com
-      - vivid.com
       - vividclassic.com
     scraper: sceneScraper
 xPathScrapers:


### PR DESCRIPTION
The Vivid network is now under the Adultime family, and the vivid.com scenes scrapable by the Adultime scraper.  This change moves the vivid.com URL Scene Scraper from the Vivid.yml scraper and adds it to Adultime.yml.

While all the remaining URLs in the Vivid.yml scraper now redirect to vivid.com, links to individual scenes (as found on StashDB) are still serving data and are scrapable by Vivid.yml.  As such Vivid.yml will remain behind with those URLs until scraping breaks.