### PR TITLE
Grab correct "studio" value for Evil Angel scenes scraped by Algolia scraper.

### DIFF
--- a/scrapers/Algolia/Algolia.py
+++ b/scrapers/Algolia/Algolia.py
@@ -119,6 +119,7 @@ SITES_USING_OVERRIDE_AS_STUDIO_FOR_SCENE = {
 SITES_USING_SITENAME_AS_STUDIO_FOR_SCENE = [
     "ChaosMen",
     "Devil's Film",
+    "Evil Angel",
     "GenderXFilms",
     "Give Me Teens",
     "Hairy Undies",


### PR DESCRIPTION
Fix for the problem mentioned in [Issue 1701](https://github.com/stashapp/CommunityScrapers/issues/1701)

Added "Evil Angel" to SITES_USING_SITENAME_AS_STUDIO_FOR_SCENE list, so that the studio name is scraped instead of the "serie_name" value.