### PR TITLE
Add movie scraping support for Biphoria (biphoria.com)

### DIFF
--- a/scrapers/Algolia/Algolia.py
+++ b/scrapers/Algolia/Algolia.py
@@ -57,6 +57,7 @@ MAIN_CHANNELS_AS_STUDIO_FOR_SCENE = [
 # a dict with sites having movie sections
 # used when populating movie urls from the scene scraper
 MOVIE_SITES = {
+    "biphoria.com": "https://www.biphoria.com/en/movie",
     "devilsfilm": "https://www.devilsfilm.com/en/dvd",
     "devilstgirls": "https://www.devilstgirls.com/en/dvd",
     "diabolic": "https://www.diabolic.com/en/movie",

--- a/scrapers/Biphoria/Biphoria.yml
+++ b/scrapers/Biphoria/Biphoria.yml
@@ -37,4 +37,14 @@ galleryByURL:
       - ../Algolia/Algolia.py
       - biphoria
       - gallery
-# Last Updated February 07, 2023
+movieByURL:
+  - action: script
+    url:
+      - biphoria.com/en/movie/
+    script:
+      - python
+      - ../Algolia/Algolia.py
+      - biphoria
+      - movie
+# Last Updated April 24, 2024
+


### PR DESCRIPTION
This change allows for scraping of movies from the Biphoria studio:
- URL movie scraping from the "movies" page
- Creating / linking movie during a scene URL scrape when the scene is determined as belonging to a movie.