### PR TITLE
Add performer and gallery scrapers to LetsDoeIt network scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -74,7 +74,7 @@ amateurallure.com|AmateurAllure.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x
 amateurav.com|Jhdv.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 amateurboxxx.com|AmateurBoxxx.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 amateure-xtreme.com|AmateureExtreme.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-amateureuro.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+amateureuro.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 amateursfrombohemia.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 amateurthroats.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 amazinganna.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
@@ -556,8 +556,8 @@ dlsite.com|DLsite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 dmmbus.lol|JavBus.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 doctortapes.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 doctortwink.com|CJXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
-doe-tv|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-doegirls.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+doe-tv|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
+doegirls.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 dogfartnetwork.com|Dogfartnetwork.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 doghousedigital.com|MileHighMedia_Straight/MileHighMedia_Straight.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 dollrotic.com|GymRotic.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -685,7 +685,7 @@ footfetishdaily.com|FootFetishDaily.yml|:heavy_check_mark:|:heavy_check_mark:|:x
 footsiebabes.com|Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 forbiddenfruitsfilms.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 forbiddenseductions.com|Adultime.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-
-forbondage.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+forbondage.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 forgivemefather.com|Deviante/Deviante.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 fostertapes.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fourfingerclub.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1028,7 +1028,7 @@ lanesisters.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lasublimexxx.com|Lasublime.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lasvegasamateurs.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 latinaabuse.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-latinamilf.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+latinamilf.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 latinleche.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 latinoguysporn.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 laughingasians.com|CJXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -1046,7 +1046,7 @@ lethalhardcore.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:
 lethalhardcorevr.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 lethallipstick.com|Glamose.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lethalpass.com|lethalpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-letsdoeit.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+letsdoeit.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 letstryanal.com|Mofos/Mofos.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 letthemwatch.com|LetThemWatch.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 lewood.com|EvilAngel|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-
@@ -1090,7 +1090,7 @@ maggiegreenlive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 maketeengape.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 maledigital.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 malefeet4u.com|Williamhiggins.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
-mamacitaz.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+mamacitaz.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 mandyflores.com|Mandyflores.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 manojob.com|FinishesTheJob.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 manroyale.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -1814,7 +1814,7 @@ transangels.com|TransAngels/TransAngels.yml|:heavy_check_mark:|:heavy_check_mark
 transangelsnetwork.com|TransAngels/TransAngels.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|Trans
 transationalfantasies.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Trans
 transatplay.com|Trans500.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
-transbella.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+transbella.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|Trans
 transcest.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|FTM
 transerotica.com|Transerotica.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
 transexdomination.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
@@ -1898,7 +1898,7 @@ vinaskyxxx.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 vintagegaymovies.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 vip4k.com|Vip4K.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 vipissy.com|Vipissy.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-vipsexvault.com|LetsDoeIt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+vipsexvault.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 virtualpee.com|VirtualPee.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Fetish
 virtualporn.com|BangBros.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 virtualrealamateurporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -1,7 +1,7 @@
-name: "LetsDoeIt"
+name: LetsDoeIt
 sceneByURL:
   - action: scrapeXPath
-    url:
+    url: &URLs 
       - amateureuro.com
       - dirtycosplay.com
       - doegirls.com
@@ -12,48 +12,135 @@ sceneByURL:
       - mamacitaz.com
       - transbella.com
       - vipsexvault.com
-    queryURL: "{url}"
-    queryURLReplace:
-      url:
-        - regex: doe-tv\.com
-          with: letsdoeit.com
-
     scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url: *URLs
+    scraper: performerScraper
+
+galleryByURL:
+  - action: scrapeXPath
+    url: *URLs
+    scraper: galleryScraper
+
 xPathScrapers:
   sceneScraper:
     common:
       $actors: //div[@class="actors" or @class="-mvd-grid-actors"]
       $details: //div[@class="row sides-xs"]
       $letsdoeit: //div[@class="-mvd-grid-more"]//span/a[@class="-mvd-list-url"]
-    scene:
-      Title:
-        selector: //title/text()
+    scene: 
+      Title: //meta[@property='og:title']/@content
+      Details: //div[@class='-mvd-description']/text()
+      Date: 
+        selector: //meta[@itemprop='uploadDate']/@content
         postProcess:
-          - replace:
-              - regex: (.+)(?:\s\|.+)
-                with: $1
-              - regex: (\sExclusive\W+(\w+\W+)?Porn\W+Video)
-                with: ""
-      Date:
-        selector: //meta[@itemprop="uploadDate"]/@content
-        postProcess:
-          - replace:
-              - regex: (\d{4})-(\d{2})-(\d{2}).+
-                with: $1-$2-$3
-          - parseDate: 2006-01-02
-      Details:
-        selector: //meta[@itemprop="description"]/@content
-        postProcess:
-          - replace:
-              - regex: "&#039;"
-                with: "'"
-              - regex: (.*\.?\!?)(?:\s-\s\w.*-.*)$ # remove Studio name at the end of a description
-                with: $1
+          - parseDate: 2006-01-02T15:04:05-07:00
+      Image: //div[@class='video-container']//img/@src
       Tags:
-        Name: $details//div[@class="col"][4]//a/text()|$details//div[@class="col"][6]//a/text()|$letsdoeit
+        Name: //div[@class='-mvd-grid-more-title' and contains(text(),'Information')]/following-sibling::div//a
+      Studio: 
+        Name: $actors//a[contains(@href,'/channels/')]
       Performers:
-        Name: $actors//span/a[contains(@href,"/models/")]
+        URL: &performerURL $actors//a[contains(@href,'/models/')]/@href
+        Name: $actors//a[contains(@href,'/models/')]
+        Gender: 
+            # The performer pages don't have a Gender tag, so the best we can do is use the 
+            # Tits Type field, and where this is present assume "Female" and where it's not use "Male".
+            # This does, unfortunately, tag all Trans performers with a gender that, while accurate,
+            # is not as precise as many might wish.
+          selector: *performerURL
+          postProcess:
+            - subScraper: &performerGender
+                selector: //div(@class='-api-list-item' and contains(.,'Tits Type')]/span 
+                #selector: //meta/@charset
+                postProcess:
+                  - replace:
+                      - regex: .+?Tits.*$
+                        with: Female
+                      - regex: ^[^F].+
+                        with: Male
+        FakeTits: 
+          selector: *performerURL
+          postProcess:
+            - subScraper: &performerTits
+                selector: //div[@class='-api-list-item' and contains(.,'Tits Type')]/span
+                postProcess:
+                  - replace:
+                      - regex: ^.+?Enhanced.+$
+                        with: 'Yes'
+                      - regex: ^.+?Natural.+$
+                        with: 'No'
+        Country:
+          selector: *performerURL
+          postProcess:
+            - subScraper: &performerCountry
+                selector: //div[(contains(@class,'-api-list-item')) and contains(.,'Birth Place')]/span[@class='-api-list-text']/text()
+        Details:
+          selector: *performerURL
+          postProcess:
+            - subScraper: &performerDetails
+                selector: //read-even-more
+        Image:
+          selector: *performerURL
+          postProcess:
+            - subScraper: &performerImage
+                selector: //img[@class='-api-poster-thumb']/@src
+
+  performerScraper:
+    performer:
+      Name: //h1
+      Gender: *performerGender
+      Country: *performerCountry
+      FakeTits: *performerTits
+      Details: *performerDetails
+      Image: *performerImage
+
+  galleryScraper:
+    gallery:
+      Title: //meta[@property='og:title']/@content
+      Details: 
+        selector: //meta[@property='og:description']/@content
+        postProcess:
+          - replace:
+              - regex: '&amp;'
+                with: '&'
+      Date:
+        selector: //div[span[contains(.,'Published')]]
+        postProcess:
+          - replace:
+              - regex: .+(\w\w\w\s\d?\d,\s\d\d\d\d)$
+                with: $1
+          - parseDate: Jan 2, 2006
       Studio:
-        Name: $actors//a//text()
-      Image: //source[@type="image/webp"]/@srcset
-# Last Updated October 05, 2023
+        Name:
+          selector: //meta[@property='og:description']/@content | //title
+          concat: __TITLE__
+          postProcess:
+            - replace:
+                 # Amateur Euro, LetsDOeIt, Mamacitaz, TransBella and VIP Sex Vault substudios are often mentioned in the description. 
+                 # Broken across lines for readability.  Use 5 % characters as a token, because it's unlikely to exist naturally.
+                - regex: .+?((A Girl Knows)|(DoeGirls)|(Her Limit)|(Horny Hostel)|(Latina Milf)|(The White Boxxx)|(Trans Taboo)|(xChimera)).+
+                  with: '%%%%%$1'
+                - regex: .+?((Carne Del Mercado)|(Chicas Loca)|(Her Big Ass)|(Operación Limpieza)).+
+                  with: '%%%%%$1'
+                - regex: .+?((Exposed Casting)|(Fucked In Traffic)|(Hot Babes Plus)|(Los Consoladores)|(Pinup SexPinup Sex)|(PornDoe Pedia)).+
+                  with: '%%%%%$1'
+                 # If we've matched in the description the string will start with 5 % characters.  Trim these off
+                - regex: '[%]{5}(.*)'
+                  with:  $1
+                 # If we don't see the substudio mentioned in the description take it from the end of the TITLE (everything following | )
+                 # This leaves us with Amateur Euro, LetsDoeIt, Mamacitaz, TransBella or VIPSexVault
+                 # Add spaces between words based on capitalization
+                - regex: ([a-z])([A-Z])
+                  with: '$1 $2'
+                 # But remove them for LetsDoeIt
+                - regex: Lets Doe It
+                  with: LetsDoeIt
+                - regex: '^[^%]{5}.*?__TITLE__.+?\|(.+)'
+                  with:  $1
+      Performers:
+        Name: //div[span[contains(.,'Model')]//a[contains(@href,'/models/')]
+
+# Last Updated April 15, 2024

--- a/scrapers/LetsDoeIt.yml
+++ b/scrapers/LetsDoeIt.yml
@@ -3,11 +3,9 @@ sceneByURL:
   - action: scrapeXPath
     url: &URLs 
       - amateureuro.com
-      - dirtycosplay.com
       - doegirls.com
       - doe-tv.com
       - forbondage.com
-      - latinamilf.com
       - letsdoeit.com
       - mamacitaz.com
       - transbella.com
@@ -32,14 +30,19 @@ xPathScrapers:
       $letsdoeit: //div[@class="-mvd-grid-more"]//span/a[@class="-mvd-list-url"]
     scene: 
       Title: //meta[@property='og:title']/@content
-      Details: //div[@class='-mvd-description']/text()
+      Details: //div[@class='-mvd-description']/text() | //read-even-more/text()
       Date: 
-        selector: //meta[@itemprop='uploadDate']/@content
+        selector: //meta[@itemprop='uploadDate']/@content | //div[@class='-mvd-grid-stats']
         postProcess:
+          - replace:
+              - regex: .+(\w\w\w\s\d\d?,\s\d\d\d\d)$
+                with: $1
+          - parseDate: Jan 2, 2006
           - parseDate: 2006-01-02T15:04:05-07:00
       Image: //div[@class='video-container']//img/@src
       Tags:
-        Name: //div[@class='-mvd-grid-more-title' and contains(text(),'Information')]/following-sibling::div//a
+        #Name: //div[@class='-mvd-grid-more-title' and contains(text(),'Information')]/following-sibling::div//a
+        Name: //a[contains(@href,'/categories/')]
       Studio: 
         Name: $actors//a[contains(@href,'/channels/')]
       Performers:
@@ -120,14 +123,14 @@ xPathScrapers:
           postProcess:
             - replace:
                  # Amateur Euro, LetsDOeIt, Mamacitaz, TransBella and VIP Sex Vault substudios are often mentioned in the description. 
-                 # Broken across lines for readability.  Use 5 % characters as a token, because it's unlikely to exist naturally.
+                 # Broken across lines for readability.  Use 5 % characters as a token, since it's unlikely to exist naturally.
                 - regex: .+?((A Girl Knows)|(DoeGirls)|(Her Limit)|(Horny Hostel)|(Latina Milf)|(The White Boxxx)|(Trans Taboo)|(xChimera)).+
                   with: '%%%%%$1'
                 - regex: .+?((Carne Del Mercado)|(Chicas Loca)|(Her Big Ass)|(Operación Limpieza)).+
                   with: '%%%%%$1'
                 - regex: .+?((Exposed Casting)|(Fucked In Traffic)|(Hot Babes Plus)|(Los Consoladores)|(Pinup SexPinup Sex)|(PornDoe Pedia)).+
                   with: '%%%%%$1'
-                 # If we've matched in the description the string will start with 5 % characters.  Trim these off
+                 # If we've matched in the description the string will start with 5 % characters.  Trim these off.
                 - regex: '[%]{5}(.*)'
                   with:  $1
                  # If we don't see the substudio mentioned in the description take it from the end of the TITLE (everything following | )
@@ -143,4 +146,4 @@ xPathScrapers:
       Performers:
         Name: //div[span[contains(.,'Model')]//a[contains(@href,'/models/')]
 
-# Last Updated April 15, 2024
+# Last Updated April 16, 2024


### PR DESCRIPTION
Added support for gallery and performer URL scraping for sites in the LetsDoeIt network scraper.

Removed URLs for sites that no longer host their own content.

Updated scrapers list to indicate that the scraper supports gallery and performer scraping.