### PR TITLE
Adds gallery and scene parsing for MyNakedDolls (mndmag.com, mynakeddolls.com)

### DIFF
--- a/scrapers/MyNakedDolls.yml
+++ b/scrapers/MyNakedDolls.yml
@@ -1,0 +1,39 @@
+name: MyNakedDolls
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - mndmag.com/updates/
+      - mynakeddolls.com/updates/
+    scraper: sceneAndGalleryScraper
+
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - mndmag.com/updates/
+      - mynakeddolls.com/updates/
+    scraper: sceneAndGalleryScraper
+
+xPathScrapers:
+  sceneAndGalleryScraper:
+    common:
+      $titleBase: //div[2]/div/div[@class='card-header custom-header card-outline-secondary']
+    gallery:
+      Title: //h2[@class='page-title']
+      Details: //h3[@class='page-subtitle']
+      # Unfortunately proper dates are only provided in the model's portfolio.
+      # Parsing would probably end up being complex and require at least two http requestes per item,
+      # might give it a shot some time in the future.
+      # Date:
+      #   selector: 
+      #   postProcess:
+      #     - parseDate: Jan 02, 2006
+      Tags:
+        Name:
+          selector: //a[@rel='tag']
+      Studio:
+        Name:
+          fixed: My Naked Dolls
+      Performers:
+        Name: $titleBase/ul[@class='nav nav-tabs']/li|$titleBase/div[@class='custom-header-title']/h3
+        # URL: Not implemented, since performer related HTML seems sketchy, and URL is only provided for single performer galleries
+# Last Updated April 26, 2024

--- a/scrapers/MyNakedDolls.yml
+++ b/scrapers/MyNakedDolls.yml
@@ -17,7 +17,7 @@ xPathScrapers:
   sceneScraper:
     common:
       $titleBase: //div[2]/div/div[@class='card-header custom-header card-outline-secondary']
-    gallery:
+    scene:
       Title: //h2[@class='page-title']
       Details: //h3[@class='page-subtitle']
       # Unfortunately proper dates are only provided in the model's portfolio.

--- a/scrapers/MyNakedDolls.yml
+++ b/scrapers/MyNakedDolls.yml
@@ -4,27 +4,26 @@ sceneByURL:
     url:
       - mndmag.com/updates/
       - mynakeddolls.com/updates/
-    scraper: sceneAndGalleryScraper
+    scraper: sceneScraper
 
 galleryByURL:
   - action: scrapeXPath
     url:
       - mndmag.com/updates/
       - mynakeddolls.com/updates/
-    scraper: sceneAndGalleryScraper
+    scraper: galleryScraper
 
 xPathScrapers:
-  sceneAndGalleryScraper:
+  sceneScraper:
     common:
       $titleBase: //div[2]/div/div[@class='card-header custom-header card-outline-secondary']
     gallery:
       Title: //h2[@class='page-title']
       Details: //h3[@class='page-subtitle']
       # Unfortunately proper dates are only provided in the model's portfolio.
-      # Parsing would probably end up being complex and require at least two http requestes per item,
-      # might give it a shot some time in the future.
+      # Parsing would probably end up being complex and require at least two http requestes per item
       # Date:
-      #   selector: 
+      #   selector:
       #   postProcess:
       #     - parseDate: Jan 02, 2006
       Tags:
@@ -35,5 +34,27 @@ xPathScrapers:
           fixed: My Naked Dolls
       Performers:
         Name: $titleBase/ul[@class='nav nav-tabs']/li|$titleBase/div[@class='custom-header-title']/h3
-        # URL: Not implemented, since performer related HTML seems sketchy, and URL is only provided for single performer galleries
+        # URL: Not implemented, since performer related HTML seems sketchy, URL is only provided for single performer galleries
+
+  galleryScraper:
+    common:
+      $titleBase: //div[2]/div/div[@class='card-header custom-header card-outline-secondary']
+    gallery:
+      Title: //h2[@class='page-title']
+      Details: //h3[@class='page-subtitle']
+      # Unfortunately proper dates are only provided in the model's portfolio.
+      # Parsing would probably end up being complex and require at least two http requestes per item
+      # Date:
+      #   selector:
+      #   postProcess:
+      #     - parseDate: Jan 02, 2006
+      Tags:
+        Name:
+          selector: //a[@rel='tag']
+      Studio:
+        Name:
+          fixed: My Naked Dolls
+      Performers:
+        Name: $titleBase/ul[@class='nav nav-tabs']/li|$titleBase/div[@class='custom-header-title']/h3
+        # URL: Not implemented, since performer related HTML seems sketchy, URL is only provided for single performer galleries
 # Last Updated April 26, 2024


### PR DESCRIPTION
Unfortunately I had to skip scraping performer URLs and item dates.

Performer URLs are only provided for single performer galleries/scenes, also the link is hidden and not clickable on the website, doesn't seem reliable at all.

Dates are only provided on the performer's portfolio and are nowhere to be found on the detail-view of the gallery/scene.
I might try to implement a subScraper to get to the dates with a second request in the future.