### PR TITLE
New sites and performer scrapers for KBProductions

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1062,7 +1062,7 @@ jerkaoke.com|ModelMediaUS.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jessicajaymesxxx.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jessroyan.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 jimweathersarchives.com|JimWeathersArchives.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
-jizzaddiction.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+jizzaddiction.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|Gay
 jizzbomb.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jizzorgy.com|Men/Men.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|Gay
 jnrc.fr|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
@@ -1072,7 +1072,7 @@ jocobo.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jocoboclips.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jodiwest.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
 joeperv.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-joeschmoevideos.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+joeschmoevideos.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|Gay
 joethepervert.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 johnnygoodluck.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 johnnyrapid.com|Johnnyrapid.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Gay
@@ -1186,7 +1186,7 @@ lustreality.com|SLRoriginals.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-
 lustylina.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 lustyxxxfamily.com|MMP_Network.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 m3ndr3ams.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-machofactory.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+machofactory.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|Gay
 mackmovies.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mackstudio.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 madeincanada.xxx|MadeInCanada.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1062,6 +1062,7 @@ jerkaoke.com|ModelMediaUS.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jessicajaymesxxx.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jessroyan.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 jimweathersarchives.com|JimWeathersArchives.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
+jizzaddiction.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 jizzbomb.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jizzorgy.com|Men/Men.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|Gay
 jnrc.fr|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
@@ -1071,6 +1072,7 @@ jocobo.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jocoboclips.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jodiwest.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
 joeperv.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+joeschmoevideos.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 joethepervert.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 johnnygoodluck.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 johnnyrapid.com|Johnnyrapid.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Gay
@@ -1184,6 +1186,7 @@ lustreality.com|SLRoriginals.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-
 lustylina.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 lustyxxxfamily.com|MMP_Network.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 m3ndr3ams.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+machofactory.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
 mackmovies.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mackstudio.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 madeincanada.xxx|MadeInCanada.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -231,7 +231,7 @@ def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
     elif (weight_nounits := raw_performer.get("weight")) and (
         w := re.match(r"^([\d\.]+)$", weight_nounits)
     ):
-        performer["weight"] = lbs_to_kb(w.group(1)) if raw_performer["site_domain"] in STUDIO_USES_IMPERIAL else str(w.group(1))
+        performer["weight"] = lbs_to_kg(w.group(1)) if raw_performer["site_domain"] in STUDIO_USES_IMPERIAL else str(w.group(1))
 
     if (penis_nounits:= raw_performer.get("dick size")) and (
         s := re.match(r"^([\d\.]+)$", penis_nounits)

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -39,10 +39,13 @@ studio_map = {
     "inkedpov.com": "Inked POV",
     "inserted.com": "Inserted",
     "jav888.com": "JAV888",
+    "jizzaddiction.com": "Jizz Addiction",
+    "joeschmoevideos.com": "Joe Schmoe Videos",
     "lady-sonia.com": "Lady Sonia",
     "legendaryx.com": "Legendary X",
     "lezkey.com": "LezKey",
     "lucidflix.com": "LucidFlix",
+    "machofactory.com": "Macho Factory",
     "meanfeetfetish.com": "Mean Feet Fetish",
     "members.hobybuchanon.com": "Hoby Buchanon",
     "mongerinasia.com": "Monger In Asia",
@@ -161,53 +164,105 @@ def get_studio(site: str) -> ScrapedStudio:
 
 
 def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
+    # Convert dict keys to lower case because, of couse, they can come in differently depending on studio.
+    raw_performer = {key.lower():value for key,value in raw_performer.items()}
+    
+    # Studios that do not use units for measurements, but are obviously not metric.
+    STUDIO_USES_IMPERIAL = [
+        "joeschmoevideos.com",
+        "jizzaddiction.com",
+    ]
+
     performer: ScrapedPerformer = {
         "name": raw_performer["name"],
         "gender": raw_performer["gender"],
         "url": make_performer_url(raw_performer["slug"], raw_performer["site_domain"]),
+        "tags": [],
     }
 
     if image := raw_performer.get("thumb"):
         performer["image"] = image
+    elif image := raw_performer.get("thumbnail"):
+        image = re.sub(r'^//','https://',image)
+        performer["image"] = image
 
-    if bio := raw_performer.get("Bio"):
+    if bio := raw_performer.get("bio"):
         performer["details"] = strip_tags(bio)
 
-    if (birthdate := raw_performer.get("Birthdate")) and birthdate != "1969-12-31":
+    if (birthdate := raw_performer.get("birthdate")) and birthdate != "1969-12-31":
         performer["birthdate"] = birthdate
 
-    if measurements := raw_performer.get("Measurements"):
+    if measurements := raw_performer.get("measurements"):
         performer["measurements"] = measurements
 
-    if eye_color := raw_performer.get("Eyes"):
+    if eye_color := raw_performer.get("eyes"):
         performer["eye_color"] = eye_color
 
-    if ethnicity := raw_performer.get("Ethnicity"):
+    if ethnicity := raw_performer.get("ethnicity"):
+        performer["ethnicity"] = ethnicity
+    elif ethnicity := raw_performer.get("race"):
         performer["ethnicity"] = ethnicity
 
-    if (height_ft := raw_performer.get("Height")) and (
+    if (height_ft := raw_performer.get("height")) and (
         h := re.match(r"(\d+)\D+(\d+).+", height_ft)
     ):
-        height_cm = round((float(h.group(1)) * 12 + float(h.group(2))) * 2.54)
+        height_cm = feetinches_to_cm(h.group(1),h.group(2))
+        performer["height"] = str(height_cm)
+    elif (height_m := raw_performer.get("height")) and (
+        h := re.match(r"^(\d\.\d\d)$", height_m)
+    ):
+        height_cm = float(h.group(1)) * 100
         performer["height"] = str(height_cm)
 
-    if (weight_lb := raw_performer.get("Weight")) and (
+    elif (height_cm := raw_performer.get("height")) and (
+        h := re.match(r"^(\d)+$", height_m)
+    ):
+        performer["height"] = str(height_cm)
+
+    if (weight_lb := raw_performer.get("weight")) and (
         w := re.match(r"(\d+)\slbs", weight_lb)
     ):
         weight_kg = round(float(w.group(1)) / 2.2046)
         performer["weight"] = str(weight_kg)
+    elif (weight_kg := raw_performer.get("weight")) and (
+        w := re.match(r"(\d+)\skg", weight_kg)
+    ):
+        performer["weight"] = str(w.group(1))
+    elif (weight_nounits := raw_performer.get("weight")) and (
+        w := re.match(r"^([\d\.]+)$", weight_kg)
+    ):
+        performer["weight"] = lbs_to_kb(w.group(1)) if raw_performer["site_domain"] in STUDIO_USES_IMPERIAL else str(w.group(1))
 
-    if hair_color := raw_performer.get("Hair"):
+    if (penis_nounits:= raw_performer.get("dick size")) and (
+        s := re.match(r"^([\d\.]+)$", penis_nounits)
+    ):
+        performer["penis_length"] = feetinches_to_cm(0,s.group(1)) if raw_performer["site_domain"] in STUDIO_USES_IMPERIAL else str(s.group(1))
+
+    if circumcised := raw_performer.get("cut / uncut"):
+        performer["circumcised"] = circumcised.capitalize()
+
+    if hair_color := raw_performer.get("hair"):
         performer["hair_color"] = hair_color
 
-    if country := raw_performer.get("Born"):
+    if country := raw_performer.get("born"):
         performer["country"] = guess_nationality(country)
 
-    if twitter := raw_performer.get("Twitter", "").removeprefix("@"):
+    if twitter := raw_performer.get("wwitter", "").removeprefix("@"):
         performer["twitter"] = f"https://twitter.com/{twitter}"
 
-    if instagram := raw_performer.get("Instagram", "").removeprefix("@"):
+    if instagram := raw_performer.get("instagram", "").removeprefix("@"):
         performer["instagram"] = f"https://www.instagram.com/{instagram}"
+
+    if "orientation" in raw_performer:
+        performer["tags"].append({"name": raw_performer["orientation"]})
+    if "sexual positions" in raw_performer:
+        log.debug("positions!")
+        for x in raw_performer["sexual positions"].split(" "):
+            performer["tags"].append({"name": x})
+    if "body" in raw_performer:
+        performer["tags"].append({"name": raw_performer["body"]})
+    if "pubic" in raw_performer:
+        performer["tags"].append({"name": raw_performer["pubic"] + " Pubes"})
 
     return performer
 
@@ -342,6 +397,14 @@ def scrape_performer(url: str) -> ScrapedPerformer | None:
         return None
 
     return to_scraped_performer(props["model"])
+
+
+def feetinches_to_cm(feet,inches):
+    return(str(round((float(feet) * 12 + float(inches)) * 2.54)))
+
+
+def lbs_to_kg(lbs):
+    return(str(round(float(lbs) / 2.2046)))
 
 
 if __name__ == "__main__":

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -215,7 +215,7 @@ def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
         performer["height"] = str(height_cm)
 
     elif (height_cm := raw_performer.get("height")) and (
-        h := re.match(r"^(\d)+$", height_m)
+        h := re.match(r"^(\d)+$", height_cm)
     ):
         performer["height"] = str(height_cm)
 

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -229,7 +229,7 @@ def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
     ):
         performer["weight"] = str(w.group(1))
     elif (weight_nounits := raw_performer.get("weight")) and (
-        w := re.match(r"^([\d\.]+)$", weight_kg)
+        w := re.match(r"^([\d\.]+)$", weight_nounits)
     ):
         performer["weight"] = lbs_to_kb(w.group(1)) if raw_performer["site_domain"] in STUDIO_USES_IMPERIAL else str(w.group(1))
 

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -1,6 +1,5 @@
 name: KB Productions
 # requires: py_common
-# scrapes: 2 Girls 1 Camera, All Anal, Alt Erotic, Amazing Films, Anal Only, Bemefi, Benefit Monkey, Big Gulp Girls, BJ Raw, Black Bull Challenge, Cannon Productions, Cougar Season, Creampie Thais, Deepthroat Sirens, Dirty Auditions, Divine-DD, Emo Network, Facials Forever, Freak Mob Media, Gay Life Network, Got Filled, HardWerk, Hoby Buchanon, Inked POV, Inserted, JAV888, Lady Sonia, LezKey, LucidFlix, Mean Feet Fetish, Monger In Asia, Nylon Perv, Nympho, NYSeed, Pounded Petite, Red-XXX, Ricky's Room, S3XUS, Seska, Sexy Modern Bull, She's Brand New, SIDECHICK, Suck This Dick, Swallowed, Top Web Models, True Anal, TWM Classics, Xful, Yes Girlz, Yummy Couple, Z-Filmz
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -36,10 +35,13 @@ sceneByURL:
       - inserted.com/tour/videos
       - inserted.com/videos
       - jav888.com/videos
+      - jizzaddiction.com/scenes
+      - joeschmoevideos.com/scenes
       - lady-sonia.com/scenes
       - legendaryx.com/videos
       - lezkey.com/scenes
       - lucidflix.com/episodes
+      - machofactory.com/scenes
       - meanfeetfetish.com/videos
       - mongerinasia.com/trailers
       - nyseedxxx.com/video
@@ -89,6 +91,8 @@ performerByURL:
       # /models redirects to /hobyshotties
       - hobybuchanon.com/models
       - hobybuchanon.com/hobyshotties
+      - jizzaddiction.com/models
+      - joeschmoevideos.com/models
       - inkedpov.com/models
       - inserted.com/models
       - inserted.com/tour/models
@@ -96,6 +100,7 @@ performerByURL:
       # lady-sonia.com has no model pages
       - lezkey.com/models
       - lucidflix.com/models
+      - machofactory.com/models
       - meanfeetfetish.com/models
       - nylonperv.com/models
       - tour.nympho.com/models
@@ -156,4 +161,4 @@ xPathScrapers:
                 HomoScene: "Homo Scene"
                 LollipopTwinks: "Lollipop Twinks"
                 Twinklight: "Twink Light"
-# Last Updated April 23, 2024
+# Last Updated April 29, 2024


### PR DESCRIPTION
Added new sites to studio and performer scrapers and scrapers list:
jizzaddiction.com
joeschmoevideos.com
machofactory.com

Removed "scrapes these sites" comment from YML file, as it is becoming cumbersome and provided little utility that can't be gleaned from the URL lists.

Updated performer scraper to account for sites that provide the performer JSON with lowercase key names.  Added more performer values to performer scrapes, including male-specific items.

Added some utility routines to convert imperial measures to metric.