### PR TITLE
add alternate URL matcher for performer

### DIFF
--- a/scrapers/IAFD/IAFD.yml
+++ b/scrapers/IAFD/IAFD.yml
@@ -9,6 +9,7 @@ performerByName:
     - search
 performerByURL:
   - url:
+      - iafd.com/person.rme/id=
       - iafd.com/person.rme/perfid=
     action: script
     script:
@@ -31,4 +32,4 @@ movieByURL:
       - python3
       - IAFD.py
       - movie
-# Last Updated September 25, 2023
+# Last Updated April 30, 2024


### PR DESCRIPTION
# Improve existing scraper

This just adds an alternate URL matcher for IAFD performers

# Example URL

- https://www.iafd.com/person.rme/id=0d5fb04e-733f-42c5-967e-d2e6ef17d456