### PR TITLE
Add Domingo Network sites to Andomark scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -401,6 +401,7 @@ cfnmeu.com|Williamhiggins.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 chaosmen.com|ChaosMen.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|Gay
 charleechaselive.com|VNAGirls.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 charlieforde.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+charmmodels.net|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 chastitybabes.com|chastitybabes.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 cheatingsis.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 cherrypimps.com|CherryPimps.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
@@ -618,6 +619,7 @@ dollsporn.com|Wtfpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dom-team.club|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 domai.com|SARJ-LLC.yml|:x:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
 dominated-men.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+domingoview.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dontbreakme.com|Mofos/Mofos.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 dorcelclub.com|DorcelClub.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
 dorcelvision.com|DorcelVision.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|-
@@ -713,6 +715,7 @@ fantasyflipflop.com|FFCSH.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fantasyhd.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 fantasymassage.com|FantasyMassage.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
 faphouse.com|Faphouse.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+feelmevr.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 feetishpov.com|ItsPOV.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 femanic.com|Femanic.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 femdomempire.com|FemdomEmpire.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
@@ -1149,6 +1152,7 @@ lethallipstick.com|Glamose.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 lethalpass.com|lethalpass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 letsdoeit.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 letstryanal.com|Mofos/Mofos.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
+letstryhard.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 letthemwatch.com|LetThemWatch.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 lewood.com|EvilAngel|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-
 lewrubens.com|LewRubens.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1898,6 +1902,7 @@ teenytaboo.com|TeenyTaboo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tenshigao.com|Tenshigao.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Jav
 terapatrick.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tessafowler.com|PinupDollars.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+test-shoots.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 texasbukkake.com|TexasBukkake.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 texaspattiusa.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tgirl40.com|GroobyClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans

--- a/scrapers/Andomark.yml
+++ b/scrapers/Andomark.yml
@@ -2,6 +2,11 @@ name: "Andomark"
 sceneByURL:
   - action: scrapeXPath
     url:
+      - charmmodels.net/updates/
+      - domingoview.com/updates/
+      - feelmevr.com/updates/
+      - letstryhard.com/updates/
+      - test-shoots.com/updates/
       - american-pornstar.com/updates/
       - ariellynn.com/tour/updates/
       - ashley4k.com/updates/
@@ -177,12 +182,15 @@ xPathScrapers:
                 brittanyandrewsxxx: Britttany Andrews
                 brittanysbubbles: Brittany Andrews
                 charlieforde: Charlie Forde
+                charmmodels: Charm Models
                 chocolatepov: ChocolatePOV
                 collectivecorruption: Collective Corruption
                 datingapphookup: Dating App Hook Ups
                 dirtroadwarriors: Dirt Road Warriors
+                domingoview: DomingoView
                 dreamgirlsclips: DreamGirls Clips
-                dreamorgan: Drea Morgan
+                dreammorgan: Drea Morgan
+                feelmevr: FeelMeVR
                 furrychicks: Furry Chicks
                 goonmuse: GoonMuse
                 hollyhotwife: HollyHotWife
@@ -195,6 +203,7 @@ xPathScrapers:
                 justpov: Just POV
                 lasvegasamateurs: Las Vegas Amateurs
                 laurenphillips: Lauren Phillips
+                letstryhard: Let's Try Hard
                 mackmovies: Mack Movies
                 melaniehicksxxx: Melanie Hicks XXX
                 nicefeelings: Nice Feelings
@@ -213,6 +222,7 @@ xPathScrapers:
                 sofiemariexxx: Sofie Marie XXX
                 tabooadventures: Taboo Adventures
                 terapatrick: Terra Patrick
+                test-shoots.com: Test Shoots
                 texaspattiusa: TexasPattiUSA
                 thatfetishgirl: ThatFetishGirl
                 tmfetish: TMFetish
@@ -301,4 +311,4 @@ driver:
           Domain: sheseducedme.com
           ValueRandom: 36
           Path: /
-# Last Updated April 26, 2024
+# Last Updated April 30, 2024


### PR DESCRIPTION
The sites in the Domingo network are compatible with the Andomark URL scene scraper.  The following sites have been added to the Andomark scraper, and entries in the scrapers list created:

      - charmmodels.net
      - domingoview.com
      - feelmevr.com
      - letstryhard.com
      - test-shoots.com