### PR TITLE
Add Trix Video sites (and a couple of others) to Andomark scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -322,6 +322,7 @@ boundlife.com|Boundlife.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boundstudio.de|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boundtwinks.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 bountyhunterporn.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
+boxofporn.info|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boxtrucksex.com|BoxTruckSex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boycrush.com|BoyCrush.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boyforsale.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -539,6 +540,7 @@ daddygetslucky.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 daddysasians.com|CJXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 daddyslilangel.com|Nubiles.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 daggi-exclusive.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+dallasdiamondz.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 damnthatsbig.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 damselsgagged.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 damselsinperil.com|Glamose.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -607,6 +609,7 @@ dirtyflix.com|DirtyFlix.yml|:heavy_check_mark:|-|-|-|-|-
 dirtyscout.com|CzechHunter/CzechHunter.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|Gay
 disruptivefilms.com|disruptivefilms.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|Gay
 divine-dd.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+dixiestrailerpark.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dlsite.com|DLsite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 dmmbus.lol|JavBus.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 doctortapes.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -876,6 +879,7 @@ goldenslut.com|SmutPuppet.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 goonmuse.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 gostuckyourself.net|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 gotfilled.com|KBProductions.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+grannycumshere.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 grannyghetto.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Granny
 grannyvsbbc.com|SmutPuppet.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 grooby-archives.com|GroobyNetwork-Partial.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
@@ -1319,6 +1323,7 @@ mrluckypov.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrluckyraw.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrluckyvip.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrpov.com|FinishesTheJob.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+msparisandfriends.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 muchaslatinas.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 mugfucked.com|ThirdRockEnt.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 musclebearporn.com|OLBMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -1826,6 +1831,7 @@ studiofow.com|StudioFOW.yml|:heavy_check_mark:|:x:|:x:|:x:|-|3D Animation
 stuffintwats.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 stunning18.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
 subbyhubby.com|SubbyHubby.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+suburbantaboo.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 submissivex.com|SubmissiveX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 subspaceland.com|SubspaceLand.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 suckmevr.com|Baberotica.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|VR
@@ -1847,6 +1853,7 @@ sweetheartvideo.com|MileHighMedia_Straight/MileHighMedia_Straight.yml|:heavy_che
 sweetsinner.com|MileHighMedia_Straight/MileHighMedia_Straight.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 sweetyx.com|SweetyX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swinger-blog.xxx|SwingerBlog.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+swingingbicouples|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swizztramplefeet.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 swnude.com|Williamhiggins.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 tabooadventures.elxcomplete.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1859,6 +1866,7 @@ tainaworld.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 takevan.com|TakeVan.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 taliashepard.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tamedteens.com|PerfectGonzo.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|Python|-
+tampahousewives.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 tandaamateurs.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 tandaasians.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 tandablondes.com|ChickPass.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
@@ -2141,6 +2149,7 @@ wetandpuffy.com|PuffyNetworkSite.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 wetvr.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 whiteghetto.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 whiteteensblackcocks.com|Teencoreclub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+whorebaithals.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 whorecraftvr.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Fantasy VR
 whynotbi.com|WhyNotBi/WhyNotBi.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 wicked.com|WickedFilms.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:x:|Python|-

--- a/scrapers/Andomark.yml
+++ b/scrapers/Andomark.yml
@@ -2,11 +2,6 @@ name: "Andomark"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - charmmodels.net/updates/
-      - domingoview.com/updates/
-      - feelmevr.com/updates/
-      - letstryhard.com/updates/
-      - test-shoots.com/updates/
       - american-pornstar.com/updates/
       - ariellynn.com/tour/updates/
       - ashley4k.com/updates/
@@ -15,18 +10,25 @@ sceneByURL:
       - bigbouncybabes.com/updates/
       - bigtoyxxx.com/updates/
       - bondagelegend.com/updates/
+      - boxofporn.info/tour/updates/      
       - bradsterling.elxcomplete.com/updates/
       - britstudio.xxx/updates/
       - brittanyandrewsxxx.com/updates/
       - brittanysbubbles.com/updates/
+      - charmmodels.net/updates/      
       - charlieforde.com/updates/
       - chocolatepov.com/updates/
       - collectivecorruption.com/updates/
+      - dallasdiamondz.com/tour/
       - datingapphookup.com/updates/
       - dirtroadwarriors.com/updates/
+      - dixiestrailerpark.com/tour/
+      - domingoview.com/updates/      
       - dreamgirlsclips.com/updates/
       - dreamorgan.com/updates/
+      - feelmevr.com/updates/      
       - furrychicks.elxcomplete.com/updates/
+      - grannycumshere.com/tour/
       - hollyhotwife.elxcomplete.com/updates/
       - houseofyre.com/updates/
       - humiliation4k.com/updates/
@@ -36,8 +38,10 @@ sceneByURL:
       - justgoodsex.com/updates/
       - justpov.com/tour/updates/
       - lasvegasamateurs.com/tour/updates/
+      - letstryhard.com/updates/      
       - mackmovies.com/updates/
       - melaniehicksxxx.com/updates/
+      - msparisandfriends.com/tour/updates/
       - nicefeelings.com/updates/
       - nylons4k.com/updates/
       - oldsexygrannies.com/updates/
@@ -53,11 +57,15 @@ sceneByURL:
       - secretsusan.com/updates/
       - sheseducedme.com/updates/
       - sofiemariexxx.com/updates/
+      - suburbantaboo.com/tour/
       - tabooadventures.elxcomplete.com/updates/
+      - tampahousewives.com/tour/
+      - test-shoots.com/updates/      
       - texaspattiusa.com/updates/
       - thatfetishgirl.com/updates/
       - tmfetish.com/updates/
       - vanillapov.com/updates/
+      - whorebaithals.com/tour/
       - willtilexxx.com/updates/
       - xevunleashed.com/updates/
       - xxxcellentadventures.com/updates/
@@ -163,7 +171,7 @@ xPathScrapers:
         Name: $scene//span[contains(@class, "update_tags")]/a
       Studio:
         Name:
-          selector: //link[@rel="canonical"]/@href
+          selector: //link[@rel="canonical"]/@href | //base/@href
           postProcess: &studioPostProcess
             - replace:
                 - regex: https://(w{3}?\.?)?(.+?)(\..+)
@@ -177,6 +185,7 @@ xPathScrapers:
                 bigbouncybabes: Big Bouncy Babes
                 bigtoyxxx: Big Toy XXX
                 bondagelegend: Bondage Legend
+                boxofporn: Box of Porn
                 bradsterling: Brad Sterling
                 britstudio: Brit Studio
                 brittanyandrewsxxx: Britttany Andrews
@@ -185,14 +194,17 @@ xPathScrapers:
                 charmmodels: Charm Models
                 chocolatepov: ChocolatePOV
                 collectivecorruption: Collective Corruption
+                dallasdiamondz: Dallas Diamondz
                 datingapphookup: Dating App Hook Ups
                 dirtroadwarriors: Dirt Road Warriors
+                dixiestrailerpark: Dixie's Trailer Park
                 domingoview: DomingoView
                 dreamgirlsclips: DreamGirls Clips
                 dreammorgan: Drea Morgan
                 feelmevr: FeelMeVR
                 furrychicks: Furry Chicks
                 goonmuse: GoonMuse
+                grannycumshere: Granny Cums Here
                 hollyhotwife: HollyHotWife
                 houseofyre: House of Fyre
                 humiliation4k: Humiliation 4K
@@ -206,6 +218,7 @@ xPathScrapers:
                 letstryhard: Let's Try Hard
                 mackmovies: Mack Movies
                 melaniehicksxxx: Melanie Hicks XXX
+                msparisandfriends: Ms Paris and Friends
                 nicefeelings: Nice Feelings
                 nylons4k: Nylons 4K
                 oldsexygrannies: OldSexyGrannies
@@ -220,7 +233,10 @@ xPathScrapers:
                 secretsusan: Secret Susan
                 sheseducedme: She Seduced Me
                 sofiemariexxx: Sofie Marie XXX
+                suburbantaboo: Suburban Taboo
+                swingingbicouples: Swinging Bi Couples
                 tabooadventures: Taboo Adventures
+                tampahousewives: Tampa Housewives
                 terapatrick: Terra Patrick
                 test-shoots.com: Test Shoots
                 texaspattiusa: TexasPattiUSA


### PR DESCRIPTION
Added sites from the Trix family of sites, as well as a couple others that use the template, to the Andomark URL scene scraper.  

Added to selector for studio to accommodate new site.

Reaphabetized the scene URL list in Andomark.yml.

Updated scrapers list.

Sites added:
boxofporn.info
dallasdiamondz.com
dixiestrailerpark.com
grannycumshere.com
msparisandfriends.com
suburbantaboo.com
swingingbicouples
tampahousewives.com
whorebaithals.com