### PR TITLE
Replace data-mxptext in Pornhub.yml

### DIFF
--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -127,7 +127,7 @@ xPathScrapers:
       Tags:
         Name: $videowrap//div[contains(concat(" ",normalize-space(@class)," ")," categoriesWrapper ")]/a/text()|$videowrap//div[contains(concat(" ",normalize-space(@class)," ")," tagsWrapper ")]/a/text()
       Performers:
-        Name: $videowrap//div[contains(concat(" ",normalize-space(@class)," ")," pornstarsWrapper ")]/a/@data-mxptext
+        Name: $videowrap//div[contains(concat(" ",normalize-space(@class)," ")," pornstarsWrapper ")]/a[@data-label="pornstar"]/text()
       Image: //meta[@property="og:image"]/@content
       Studio:
         Name: $videowrap//div[contains(concat(" ",normalize-space(@class)," ")," usernameWrap ")]//a/text()


### PR DESCRIPTION
The pornstar anchors no longer seem to have a `data-mxptext` attribute. Replace this with the `text()` value(s) of anchors which have the `data-label="pornstar"` attribute and value.