### PR TITLE
Add URL scene scraper for sites in PPVNetwork

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -237,6 +237,7 @@ bbwhighway.com|BBWHighway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bbwxxxadventures.com|MyMemberSite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
 bdsm-tickling.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bdsmkinkyplay.com|MyMemberSite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
+bearboxxx.com|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 bearfilms.com|MarsMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 beatmeup.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 beauty-angels.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
@@ -403,6 +404,7 @@ burningangel.com|BurningAngel.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 bushybushy.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bustyamateurboobs.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 bustybeauties.com|Hustler.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
+butchbear.tv|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 buttman.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 cadinot.fr|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 calicarter.com|bellapass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -582,6 +584,7 @@ danidaniels.com|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 danni.com|Danni.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 dannyoceansadventures.com|InnOfSin.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 daredorm.com|RealityKings/RealityKings.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
+darkalleyxt.com|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 darkcruising.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 darkdreams.xxx|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 darkroomvr.com|DarkRoomVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -1723,12 +1726,15 @@ ramjetvideo.com|CJXXX.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 randyblue.com|RandyBlue.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 raunchybastards.com|AdultSiteRunner.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 ravenswallowzxxx.com|Andomark.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+rawandrough.com|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 rawattack.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 rawcouples.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 rawfuck.com|PornsiteManager.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 rawfuckboys.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 rawfuckclub.com|RawFuckClub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+rawnastyfuckers.com|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 rawroadnation.com|OLBMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+rawtop.tv|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 reaganfoxx.com|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|MILF
 realagent.xxx|ModelCentroAPI.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-
 realbikinigirls.com|WankItNow.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
@@ -2168,6 +2174,7 @@ tranzvr.com|POVR.yml|:heavy_check_mark:|:x:|:x:|:x:|-|VR
 trashbagbondage.com|Shopmaker.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 traxxx.me|Traxxx.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 treasureislandmedia.com|TreasureIslandMedia.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
+treasureislandmedia.tv|PPVNetwork.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|Gay
 trentonducati.com|NakedSword.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|Gay
 trickymasseur.com|TeenMegaWorld.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 trickyoldteacher.com|OldGoesYoung.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/PPVNetwork.yml
+++ b/scrapers/PPVNetwork.yml
@@ -45,50 +45,42 @@ driver:
     - Key: User-Agent
       Value: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0)
   cookies:
-    - CookieURL: https://barebackbox.com
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.barebackbox.com
           Value: Y
           Path: /
-    - CookieURL: https://bearboxxx.com
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.bearboxxx.com
           Value: Y
           Path: /
-    - CookieURL: https://butchbear.tv
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.butchbear.tv
           Value: Y
           Path: /
-    - CookieURL: https://darkalleyxt.com
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.darkalleyxt.com
           Value: Y
           Path: /
-    - CookieURL: https://rawandrough.com
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.rawandrough.com
           Value: Y
           Path: /
-    - CookieURL: https://rawnastyfuckers.com
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.rawnastyfuckers.com
           Value: Y
           Path: /
-    - CookieURL: https://rawtop.tv
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.rawtop.tv
           Value: Y
           Path: /
-    - CookieURL: https://treasureislandmedia.tv
-      Cookies:
+    - Cookies:
         - Name: CONSENT
           Domain: www.treasureislandmedia.tv
           Value: Y

--- a/scrapers/PPVNetwork.yml
+++ b/scrapers/PPVNetwork.yml
@@ -1,0 +1,97 @@
+name: PPVNetwork
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - barebackbox.com/video
+      - bearboxxx.com/video
+      - butchbear.tv/video
+      - darkalleyxt.com/video
+      - rawandrough.com/video
+      - rawnastyfuckers.com/video
+      - rawtop.tv/video
+      - treasureislandmedia.tv/video
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h3
+      Details: //p[@id='watch_description']
+      Date: //p[@class='addedDate']
+      Tags:
+        Name:
+          selector:  //base/@href | //div[@id='watch_categories_items']//a
+          concat: ','
+          postProcess:
+            - replace:
+                - regex: ^[^,]+
+                  with: 'Gay'
+          split: ','
+      Performers:
+        Name: //div[@id='watch_actors_items']//a
+      Image:
+        selector: //script[contains(.,'splash')]
+        postProcess:
+          - replace:
+              - regex: .+?splash:\s*'([^']+).+
+                with: $1
+      Studio:
+        Name: //p[@class='studio']//a
+
+driver:
+  # Requires CDP to get by the "consent" screen, along with a "CONSENT" cookie with a value of "Y" for each top level URL
+  useCDP: true
+  headers:
+    - Key: User-Agent
+      Value: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0)
+  cookies:
+    - CookieURL: https://barebackbox.com
+      Cookies:
+        - Name: CONSENT
+          Domain: www.barebackbox.com
+          Value: Y
+          Path: /
+    - CookieURL: https://bearboxxx.com
+      Cookies:
+        - Name: CONSENT
+          Domain: www.bearboxxx.com
+          Value: Y
+          Path: /
+    - CookieURL: https://butchbear.tv
+      Cookies:
+        - Name: CONSENT
+          Domain: www.butchbear.tv
+          Value: Y
+          Path: /
+    - CookieURL: https://darkalleyxt.com
+      Cookies:
+        - Name: CONSENT
+          Domain: www.darkalleyxt.com
+          Value: Y
+          Path: /
+    - CookieURL: https://rawandrough.com
+      Cookies:
+        - Name: CONSENT
+          Domain: www.rawandrough.com
+          Value: Y
+          Path: /
+    - CookieURL: https://rawnastyfuckers.com
+      Cookies:
+        - Name: CONSENT
+          Domain: www.rawnastyfuckers.com
+          Value: Y
+          Path: /
+    - CookieURL: https://rawtop.tv
+      Cookies:
+        - Name: CONSENT
+          Domain: www.rawtop.tv
+          Value: Y
+          Path: /
+    - CookieURL: https://treasureislandmedia.tv
+      Cookies:
+        - Name: CONSENT
+          Domain: www.treasureislandmedia.tv
+          Value: Y
+          Path: /
+
+# Last Updated May 13, 2024


### PR DESCRIPTION
New URL scene scraper for sites using the "PPVNetwork 2.0" template:
- bearboxxx.com
- butchbear.tv
- darkalleyxt.com
- rawandrough.com
- rawnastyfuckers.com
- rawtop.tv
- treasureislandmedia.tv

Added sites to scrapers list using PPVNetwork.yml.

Scraper requires CDP and a simple cookie to pass consent verification.  All sites host exclusively gay content.