### PR TITLE
Update boy fun.yml

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -346,7 +346,7 @@ boxtrucksex.com|BoxTruckSex.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 boycrush.com|BoyCrush.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boyforsale.com|CarnalPlus.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boyfriendsharing.com|Mypervmom.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-boyfun.com|BoyFun.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
+boyfun.com|BoyFun.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
 boygusher.com|BluMedia.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
 boysatcamp.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 boysdestroyed.com|AMAMultimedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
@@ -1128,6 +1128,7 @@ javhub.com|JavHub.yml|:heavy_check_mark:|:x:|:x:|:x:|-|JAV Uncensored
 javlibrary.com|JavLibrary.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|JAV
 javlibrary.com|JavLibrary_python.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|JAV
 jawbreakerz.com|TugPass.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+jawked.com|BoyFun.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|Gay
 jaxslayher.com|JaxSlayher.yml|:heavy_check_mark:|:x:|:x:|:heavy_check_mark:|-|-
 jaysinxxx.com|GammaEntertainment.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 jayspov.net|AdultEmpireCash.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/BoyFun.yml
+++ b/scrapers/BoyFun.yml
@@ -3,28 +3,83 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - boyfun.com/video
+      - jawked.com/video
     scraper: sceneScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - boyfun.com/model
+      - jawked.com/model
+    scraper: performerScraper
 xPathScrapers:
   sceneScraper:
-    common:
-      $perf: //span[@class="models"]/span[@class="content"]/a
     scene:
-      Title: //span[@class="title"]
+      Title: //span[@class='title']/text()
       Image: //video/@poster | //div[@class="video-poster"]/img/@src
       Date:
-        selector: //span[@class="date"]/span[@class="content"]
+        selector: //*[span[@class='heading' and contains(.,'Added')]]/span[@class='content']
         postProcess:
           - replace:
               - regex: (st|[nr]d|th)
                 with: ""
           - parseDate: Jan 2, 2006
       Details:
-        selector: //div[@class="heading"]/following-sibling::text()
-        concat: "\n\n"
+        selector: //div[@class='content-information-description']/p/text()
       Performers:
-        Name: $perf/text()
-        URL: $perf/@href
+        Name: //*[span[@class='heading' and contains(.,'Starring')]]/span[@class='content']/a
+        URL: //*[span[@class='heading' and contains(.,'Starring')]]/span[@class='content']/a/href()
       Studio:
         Name:
-          fixed: BoyFun
-# Last Updated March 19, 2023
+          selector: //div[@class='logo-holder']/a/@href
+          postProcess:
+            - replace:
+                - regex: .+?\.([^\.]+).+
+                  with: $1
+            - map:
+                boyfun: BoyFun
+                jawked: Jawked
+
+  performerScraper:
+    performer:
+      Name: //section[@class='model-section']//img/@alt
+      Image: //section[@class='model-section']//img/@src
+      Country: //li[span[contains(.,'Nationality')]]/span[@class='value']
+      Height:
+        selector: //li[span[contains(.,'Height')]]/span[@class='value']
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*cm.+
+                with: $1
+      Weight:
+        selector: //li[span[contains(.,'Weight')]]/span[@class='value']
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*kg.+
+                with: $1
+      PenisLength:
+        selector: //li[span[contains(.,'Dick Size')]]/span[@class='value']
+        postProcess:
+          - replace:
+              - regex: ^
+                with: "0."
+          - feetToCm: true
+      Circumcised: //li[span[contains(.,'Cut/Uncut')]]/span[@class='value']
+      Tags:
+        Name: //li[span[contains(.,'Role')]]/span[@class='value']
+
+driver:
+  cookies:
+    - CookieURL: https://www.boyfun.com
+      Cookies:
+        - Name: warningHidden
+          Value: "hide"
+          Domain: "www.boyfun.com"
+          Path: "/"
+    - CookieURL: https://www.jawked.com
+      Cookies:
+        - Name: warningHidden
+          Value: "hide"
+          Domain: "www.jawked.com"
+          Path: "/"
+
+# Last Updated May 22, 2024


### PR DESCRIPTION
Updated BoyFun.yml:
- Added cookies necessary to allow scraping.
- Added jawked.com as supported site.
- Modified for latest layout, and to allow for small differences that jawked uses.
- Added performer URL scraper.

Updated Scrapers-list.md:
- Added performer check for boyfun.com.
- Added jawked.com, using BoyFun.com.