### PR TITLE
New sites for Czechav.yml scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -519,6 +519,7 @@ czechbangbus.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechbiporn.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechbitch.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechboobs.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechcabins.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechcasting.com|czechcasting.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechcouples.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechdeviant.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -526,6 +527,7 @@ czechdungeon.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechescortgirls.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechestrogenolit.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechexecutor.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechexperiment.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechfantasy.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechfirstvideo.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechgame.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
@@ -549,10 +551,14 @@ czechmassage.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechmegaswingers.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechorgasm.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechparties.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechpawnshop.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechpool.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechrealdolls.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechsauna.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechsexcasting.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechsexparty.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
-czechshemale.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+czechshemale.com|PornCZ.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Trans
+czechsnooper.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechsolarium.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechspy.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 czechstreets.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Czechav.yml
+++ b/scrapers/Czechav.yml
@@ -6,9 +6,11 @@ sceneByURL:
       - czechamateurs.com/
       - czechbangbus.com/
       - czechbitch.com/
+      - czechcabins.com/
       - czechcouples.com/
       - czechdungeon.com/
       - czechestrogenolit.com/
+      - czechexperiment.com/
       - czechfantasy.com/
       - czechfirstvideo.com/
       - czechgame.com/
@@ -28,6 +30,10 @@ sceneByURL:
       - czechmegaswingers.com/
       - czechorgasm.com/
       - czechparties.com/
+      - czechpawnshop.com/
+      - czechpool.com/
+      - czechsauna.com/
+      - czechsnooper.com/
       - czechsolarium.com/
       - czechspy.com/
       - czechstreets.com/
@@ -46,7 +52,7 @@ xPathScrapers:
     common:
       $studio: //h1/img/@alt
     scene:
-      Title: 
+      Title:
         selector: //div/h1[@class='nice-title']
         postProcess:
           - replace:
@@ -68,4 +74,4 @@ xPathScrapers:
               - regex: .+(?:"uploadDate":\s*")([^T]+).+
                 with: $1
           - parseDate: 2006-01-02
-# Last Updated February 17, 2024
+# Last Updated May 23, 2024


### PR DESCRIPTION
Additional sites from this network added to scraper:
- czechcabins.com
- czechexperiment.com
- czechpawnshop.com
- czechpool.com
- czechsauna.com
- czechsnooper.com

Updated scrapers list for the above sites.

Made an obvious change to the scrapers list entry for chzechshemale.com