### PR TITLE
Update X-artcom.yml

### DIFF
--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -3,7 +3,13 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - x-art.com/videos/
+      - x-art.com/members/videos/
     scraper: sceneScraper
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        - regex: members
+          with: ""
 
 galleryByURL:
   - action: scrapeXPath

--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -20,21 +20,23 @@ galleryByURL:
 xPathScrapers:
   sceneScraper:
     common:
+      $featuring: //h2[span[contains(.,'featuring')]]
     scene:
       Title: //div[@class="row info"]//h1
       Date:
-        selector: //h2[span[contains(.,'featuring')]]/preceding-sibling::h2[1]
+        selector: $featuring/preceding-sibling::h2[1]
         postProcess:
           - parseDate: Jan 02, 2006
       Details:
-        selector: reverse(//h2[span[contains(.,'featuring')]]/preceding-sibling::*[not(div)]//text())
+        selector: reverse($featuring/preceding-sibling::*[not(div)]//text())
         concat: "\n\n"
       Performers:
-        Name: //h2[span[contains(.,'featuring')]]/a
+        Name: $featuring/a
       Image: //div[@class="flex-video widescreen"]/a/img/@src
       Studio:
         Name:
           fixed: X-Art
+
 
   galleryScraper:
     common:

--- a/scrapers/X-artcom.yml
+++ b/scrapers/X-artcom.yml
@@ -14,18 +14,17 @@ galleryByURL:
 xPathScrapers:
   sceneScraper:
     common:
-      $sceneinfo: //div[@class="small-12 medium-12 large-12 columns info"]
     scene:
-      Title: //div[@class="row info"]/div[@class="small-12 medium-12 large-12 columns"]/h1
+      Title: //div[@class="row info"]//h1
       Date:
-        selector: $sceneinfo/h2[1]/text()
+        selector: //h2[span[contains(.,'featuring')]]/preceding-sibling::h2[1]
         postProcess:
           - parseDate: Jan 02, 2006
       Details:
-        selector: $sceneinfo/p
-        concat: " "
+        selector: reverse(//h2[span[contains(.,'featuring')]]/preceding-sibling::*[not(div)]//text())
+        concat: "\n\n"
       Performers:
-        Name: $sceneinfo/h2/a/text()
+        Name: //h2[span[contains(.,'featuring')]]/a
       Image: //div[@class="flex-video widescreen"]/a/img/@src
       Studio:
         Name:
@@ -51,4 +50,5 @@ xPathScrapers:
       Performers:
         Name: $gallery/h2/a
         URL: $gallery/h2/a/@href
-# Last Updated March 19, 2024
+
+# Last Updated May 24, 2024


### PR DESCRIPTION
Addressing points 2, 3, 4, and 5 from [Issue 1843](https://github.com/stashapp/CommunityScrapers/issues/1843)

Modified URL scene scraper so it reliably picks up date and gets all description text, preserving paragraphs.

Also, it now accepts /members/videos URLs, but maps them to /videos.

Simplified some selectors.