### PR TITLE
Added ExCoGigirls site as scene URL in ExplotedX Scraper

### DIFF
--- a/scrapers/ExploitedX.yml
+++ b/scrapers/ExploitedX.yml
@@ -8,6 +8,7 @@ sceneByURL:
       - blackambush.com/trailers/
       - hotmilfsfuck.com/trailers/
       - exploitedcollegegirls.com/trailers/
+      - excogigirls.com/trailers/
     scraper: sceneScraper
   - action: scrapeXPath
     url:


### PR DESCRIPTION
Noticed it wasn't available as a URL to scrape, confirmed it uses the same base template and can be scraped.
Tested and works as expected.