### PR TITLE
Fix for AyloAPI not returning scene details in some cases

### DIFF
--- a/scrapers/AyloAPI/scrape.py
+++ b/scrapers/AyloAPI/scrape.py
@@ -4,6 +4,7 @@ import sys
 import difflib
 import requests
 from datetime import datetime
+from html import unescape
 from typing import Any, Callable
 from urllib.parse import urlparse
 
@@ -353,10 +354,14 @@ def to_scraped_scene(scene_from_api: dict) -> ScrapedScene:
         log.error(f"Attempted to scrape a '{wrong_type}' (ID: {wrong_id}) as a scene.")
         raise ValueError("Invalid scene from API")
 
+    if (details := dig(scene_from_api, "description")) or (details := dig(scene_from_api, "parent", "description")):
+        details = unescape(details)
+        details = "\n".join([" ".join([s for s in x.strip(" ").split(" ") if s != ""]) for x in "".join(details).split("\n")])
+
     scene: ScrapedScene = {
         "title": scene_from_api["title"],
         "code": str(scene_from_api["id"]),
-        "details": dig(scene_from_api, "description"),
+        "details": details,
         "date": datetime.strptime(
             scene_from_api["dateReleased"], "%Y-%m-%dT%H:%M:%S%z"
         ).strftime("%Y-%m-%d"),


### PR DESCRIPTION
I noticed the AyloAPI scraper is not returning scene details in some cases (url scraping).
For example,  this [scene](https://www.brazzers.com/video/9408131/brazzers-house-4-episode-7) returns empty details, although the details exist in the json response, but under the ``parent`` key.
Added in a check, that if the default details is empty, lookup the details under the ``parent`` key.

Second, added html.**unescape** to convert all named and numeric character references (e.g. ``&gt;``, ``&amp;``) in the string to the corresponding Unicode characters, for example, this [scene](https://www.brazzers.com/video/3972491/a-wild-ride-before-the-wedding)
The **html** is already part of Standard Library that comes with Python 3.x, so it shouldn't cause any problems.

Third, added a small tweak, to get rid of double spaces(leading/middle/trailing), while preserving newlines, for example, this [scene](https://realitykings.com/scene/4451931/an-un-cucked-threesome)