### PR TITLE
Fix `publicagent.com` --> `publicpickups.com` for Mofos scraper

### DIFF
--- a/scrapers/Mofos/Mofos.yml
+++ b/scrapers/Mofos/Mofos.yml
@@ -1,13 +1,13 @@
 name: Mofos
 # requires: py_common, AyloAPI
-# scrapes: Busted Babysitters, Don't Break Me, Drone Hunter, Girls Gone Pink, I Know That Girl, In Gang We Bang, Latina Sex Tapes, Let's Post It, Let's Try Anal, Milfs Like It Black, Mofos B Sides, MOFOS Lab, Mofos World Wide, Pervs On Patrol, Pornstar Vote, Project RV, Pubic Pickups, Real Slut Party, Share My BF, She's A Freak, Stranded Teens, The Sex Scout
+# scrapes: Busted Babysitters, Don't Break Me, Drone Hunter, Girls Gone Pink, I Know That Girl, In Gang We Bang, Latina Sex Tapes, Let's Post It, Let's Try Anal, Milfs Like It Black, Mofos B Sides, MOFOS Lab, Mofos World Wide, Pervs On Patrol, Pornstar Vote, Project RV, Public Pickups, Real Slut Party, Share My BF, She's A Freak, Stranded Teens, The Sex Scout
 galleryByURL:
   - action: script
     url:
       - mofos.com/scene/
       - mofosnetwork.com/scene/
       - iknowthatgirl.com/scene/
-      - publicagent.com/scene/
+      - publicpickups.com/scene/
       - letstryanal.com/scene/
     script:
       - python
@@ -25,7 +25,7 @@ sceneByURL:
       - mofos.com/scene/
       - mofosnetwork.com/scene/
       - iknowthatgirl.com/scene/
-      - publicagent.com/scene/
+      - publicpickups.com/scene/
       - letstryanal.com/scene/
     script:
       - python
@@ -61,7 +61,7 @@ performerByURL:
       - mofos.com/model/
       - mofosnetwork.com/model/
       - iknowthatgirl.com/model/
-      - publicagent.com/model/
+      - publicpickups.com/model/
       - letstryanal.com/model/
     script:
       - python
@@ -79,16 +79,16 @@ movieByURL:
       - mofos.com/movie/
       - mofosnetwork.com/movie/
       - iknowthatgirl.com/movie/
-      - publicagent.com/movie/
+      - publicpickups.com/movie/
       - letstryanal.com/movie/
       # Since scenes link to the movie we can scrape movies from scenes
       - mofos.com/scene/
       - mofosnetwork.com/scene/
       - iknowthatgirl.com/scene/
-      - publicagent.com/scene/
+      - publicpickups.com/scene/
       - letstryanal.com/scene/
     script:
       - python
       - Mofos.py
       - movie-by-url
-# Last Updated January 14, 2024
+# Last Updated June 01, 2024


### PR DESCRIPTION
Replace `publicagent.com` with `publicpickups.com` in `Mofos.yml`. Public Agent is a FakeHub studio and is already in `FakeHub.yml`. Public Pickups is a Mofos studio.


Replace `Pubic Pickups` with `Public Pickups` in `Mofos.yml`. Public Pickups is a Mofos studio. **Pubic** Pickups is *probably* not a studio.