### PR TITLE
bibian-av.yml: Fix javascript variable declaration

### DIFF
--- a/scrapers/bibian-av.yml
+++ b/scrapers/bibian-av.yml
@@ -39,7 +39,7 @@ xPathScrapers:
         postProcess:
           - javascript: |
               if (value && value.length) {
-                vals = value.split(" ");
+                var vals = value.split(" ");
                 vals[0] = vals[0].replace(/(\D+)(\d+)/, "$1-$2")
                 return "["+vals[0]+"] "+vals.slice(1).join(" ");
               }


### PR DESCRIPTION
Is Stash 0.26 this doesn't work anymore. Apparently, JavaScript engine is more strict in this version.