### PR TITLE
add docker validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ Specific scrapers can be checked using: `node validate.js scrapers/foo.yml scrap
 Instead of NodeJS being installed, Docker can be used to run the validator
 
 ```bash
-docker run -v .:/app node:alpine /bin/sh -c "cd /app/validator && yarn install --silent && cd .. && node validate.js --ci""
+docker run --rm -v .:/app node:alpine /bin/sh -c "cd /app/validator && yarn install --silent && cd .. && node validate.js --ci""
 ```

--- a/README.md
+++ b/README.md
@@ -97,3 +97,10 @@ First, install the validator's dependencies - inside the [`./validator`](./valid
 
 Then, to run the validator, use `node validate.js` in the root of the repository.  
 Specific scrapers can be checked using: `node validate.js scrapers/foo.yml scrapers/bar.yml`
+
+#### Docker option
+Instead of NodeJS being installed, Docker can be used to run the validator
+
+```bash
+docker run -v .:/app node:alpine /bin/sh -c "cd /app/validator && yarn install --silent && cd .. && node validate.js --ci""
+```


### PR DESCRIPTION
supercedes #1114 

This has the advantage of not needing a container built and it removes itself afterwards

Explanation:  
`-v` mounts the current directory (CommunityScrapers) to the docker container at `/app`
`--rm` removes the container once it exits  
`/bin/sh -c` takes us out of node-cli into a shell  
`cd /app/validator` moves us to the validator directory to install the dependencies  
`yarn install --silent` installs the dependencies needed for the validator  
`cd ..` takes us back out of the validator directory into `/app`
`node validate.js --ci` runs the validator