### PR TITLE
Add support for mrluckylife.com and parsing its titles

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -1450,6 +1450,7 @@ movieporn.com|Czechav.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mplstudios.com|MPLStudios.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|-|-
 mrbigfatdick.com|MrBigFatDick.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrhappyendings.com|MyMemberSite.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|Python|-
+mrluckylife.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrluckypov.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrluckyraw.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 mrluckyvip.com|Spizoo.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -6,6 +6,7 @@ sceneByURL:
       - drdaddypov.com/updates/
       - firstclasspov.com/updates/
       - gothgirlfriends.com/updates/
+      - mrluckylife.com/updates/
       - mrluckypov.com/updates/
       - mrluckyraw.com/updates/
       - mrluckyvip.com/updates/
@@ -38,7 +39,7 @@ xPathScrapers:
       $video_section: (//section[@id="trailer-video" or @id="scene" or @id="scene-video"] | //div[contains(@class, "videoHolder")])
     scene:
       Title:
-        selector: //div[@class="title" or @class="row"]//h1 | //h2[contains(@class, "titular")] | //title
+        selector: //div[@class="title" or @class="row"]//h1 | //div[@class="title-trailer"]//h2 | //h2[contains(@class, "titular")] | //title
         postProcess:
           # RawAttack titles have a trailing dash and space
           - replace:


### PR DESCRIPTION
Adds support for `mrluckylife.com` to the Spizoo scraper. Adds an additional case for capturing scene titles in order to avoid scraping title as `MORE MR.LUCKY LIFE VIDEOS` for all scenes. Verified that titles still are scraped correctly for other Spizoo sites that I can test.