### PR TITLE
Fix for actor scraper on IFM scraper

### DIFF
--- a/scrapers/IFeelMyself/IFeelMyself.py
+++ b/scrapers/IFeelMyself/IFeelMyself.py
@@ -181,7 +181,10 @@ def extract_PerformerInfo(table,browser,cover_url=None):
     performer = str(performer)
     debugPrint(f"Extracting info for performer: {performer}")
     if cover_url == None:
-        cover_url=str(table.find("img")['src'])
+        if table.find('video'): #New scenes use the video tag
+            cover_url=str(table.find("video")['poster'])
+        elif table.find('img'): #old scenes still use the old format of a img tag
+            cover_url=str(table.find("img")['src'])
     debugPrint(cover_url)
     artist_id = re.search(r"\/((f|m)\d{4,5})",cover_url,re.I).group(1)
     artist_img = (f"https://bcdn.ifeelmyself.com/artists/" + artist_id + ".jpg")


### PR DESCRIPTION
Added an if statement to check for the video tag instead of img. And fall back to img for older actors. IFM is now using JS for img tags which is the cause of the error