### PR TITLE
fix/improve VirtualReal network scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -2304,11 +2304,11 @@ vipsexvault.com|LetsDoeIt.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_c
 virtualpee.com|VirtualPee.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Fetish
 virtualporn.com|BangBros.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 virtualrealamateurporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
-virtualrealgay.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
-virtualrealjapan.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
-virtualrealpassion.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
-virtualrealporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
-virtualrealtrans.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
+virtualrealgay.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+virtualrealjapan.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+virtualrealpassion.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+virtualrealporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+virtualrealtrans.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
 virtualtaboo.com|VirtualTaboo.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
 visit-x.net|Visit-X.yml|:heavy_check_mark:|:x:|:x:|:x:|CDP|-
 vivid.com|Vivid.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-

--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -2305,7 +2305,7 @@ virtualpee.com|VirtualPee.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Fetish
 virtualporn.com|BangBros.yml|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|Python|-
 virtualrealamateurporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
 virtualrealgay.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
-virtualrealjapan.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
+virtualrealjapan.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:x:|-|VR
 virtualrealpassion.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
 virtualrealporn.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR
 virtualrealtrans.com|VirtualRealPorn.yml|:heavy_check_mark:|:x:|:heavy_check_mark:|:heavy_check_mark:|-|VR

--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -135,7 +135,8 @@ xPathScrapers:
       Instagram: //div[@id="social"]//a[contains(@class, "instagram")]/@href
       Birthdate:
         selector: //section[@id="about"]//tr/th[text()="Date of birth"]//following-sibling::td/text()
-        parseDate: 02/01/2006
+        postProcess:
+          - parseDate: 02/01/2006
       Country: //section[@id="about"]//tr/th[text()="Country"]//following-sibling::td/text()
       HairColor: //section[@id="about"]//tr/th[text()="Hair color"]//following-sibling::td/text()
       EyeColor: //section[@id="about"]//tr/th[text()="Eyes color"]//following-sibling::td/text()

--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -46,28 +46,40 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: &titleDef
-        selector: //h1[@class="titleVideo"]/text()
+        selector: //div[@class="header_video"]//h1
         postProcess:
           - replace:
               - regex: VR [\s\w]+? video$
                 with: ""
       Date: &dateAttr
-        selector: //div[@class="video-date"]/span
+        selector: //div[@class="featured_data"]/text()[2]
         postProcess:
+          - replace:
+              - regex: '.* (\w+ \d+, \d{4}).*'
+                with: $1
           - parseDate: Jan 2, 2006
       Details: &detailsSel
-        selector: //div[@class="g-cols onlydesktop"]/p
+        selector: //div[@class="description_container"]/p
         concat: "\n\n"
       Tags:
-        Name: //div[@class="metaHolder"]//a/span/text()
-      Performers:
         Name:
-          selector: //h1[@class="titleVideo"]/following-sibling::p
+          selector: //div[@class="metaHolder"]//a/span/text()|//script[@type="application/ld+json"][contains(text(),"genre")]/text()
           postProcess:
-            - replace:
-                - regex: \s&\s
-                  with: ", "
-          split: ", "
+            - javascript: |
+                if (value && value.length && value.startsWith('{')) {
+                  // parse JSON
+                  return JSON.parse(value)
+                    .genre
+                    .split(', ')
+                    // can only return one tag, find or default
+                    .find(v => v.toLowerCase() === 'virtual reality')
+                        ?? 'Virtual Reality'
+                } else {
+                  // return (text of tag) as-is
+                  return value
+                }
+      Performers:
+        Name: //div[@class="performers_section"]//div[@class="model-box"]/a/img/@alt
       Studio:
         Name: &studioName
           selector: //meta[@property="og:site_name"]/@content
@@ -96,4 +108,4 @@ xPathScrapers:
         Name: *studioName
       Synopsis: *detailsSel
       FrontImage: *imageSel
-# Last Updated November 25, 2022
+# Last Updated June 26, 2024

--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -42,6 +42,11 @@ movieByURL:
     url: *urlSel
     scraper: movieScraper
 
+performerByURL:
+  - action: scrapeXPath
+    url: *urlSel
+    scraper: performerScraper
+
 xPathScrapers:
   sceneScraper:
     scene:
@@ -108,4 +113,43 @@ xPathScrapers:
         Name: *studioName
       Synopsis: *detailsSel
       FrontImage: *imageSel
+  performerScraper:
+    performer:
+      Name:
+        selector: //div[@class="head_model"]//h1/text()
+        postProcess:
+          - replace:
+              - regex: ' +$'
+                with: ''
+      Gender:
+        selector: //section[@id="about"]//tr/th[text()="Gender"]//following-sibling::td/text()
+        postProcess:
+          - map:
+              Female Trans: transgender_female
+      Twitter:
+        selector: //div[@id="social"]//a[contains(@class, "twitter")]/@href
+        postProcess:
+          - replace:
+              - regex: twitter.com
+                with: x.com
+      Instagram: //div[@id="social"]//a[contains(@class, "instagram")]/@href
+      Birthdate:
+        selector: //section[@id="about"]//tr/th[text()="Date of birth"]//following-sibling::td/text()
+        parseDate: 02/01/2006
+      Country: //section[@id="about"]//tr/th[text()="Country"]//following-sibling::td/text()
+      HairColor: //section[@id="about"]//tr/th[text()="Hair color"]//following-sibling::td/text()
+      EyeColor: //section[@id="about"]//tr/th[text()="Eyes color"]//following-sibling::td/text()
+      Measurements:
+        selector: //section[@id="about"]//tr/th[text()="Bust"]//following-sibling::td/text()|//section[@id="about"]//tr/th[text()="Waist"]//following-sibling::td/text()|//section[@id="about"]//tr/th[text()="Hips"]//following-sibling::td/text()
+        concat: '-'
+        postProcess:
+          - javascript: |
+              // convert from metric to imperial
+              if (value && value.length) {
+                const cmPerInch = 2.54
+                let measurements = value.split('-')
+                return measurements.map(m => Math.round(m / cmPerInch)).join('-')
+              }
+              return value
+      Image: //div[@class="feature_img_model"]/img/@src
 # Last Updated June 26, 2024


### PR DESCRIPTION
# Fixes

## sceneByURL

Site layout has been updated on all network sites:

- virtualrealamateurporn.com
- virtualrealgay.com
- virtualrealjapan.com
- virtualrealpassion.com
- virtualrealporn.com
- virtualrealtrans.com

The existing `sceneScraper` has been adjusted to match.

### sceneByURL: Example URLs

- https://virtualrealamateurporn.com/vr-amateur-porn-video/hot-visit/
- https://virtualrealgay.com/vr-gay-porn-video/summer-ends/
- https://virtualrealjapan.com/vr-japanese-video/%e3%80%90part03%e3%80%91hq60fps-close-up-best-210min/
- https://virtualrealpassion.com/vr-female-pov-porn-video/polysex/
- https://virtualrealporn.com/vr-porn-video/massage-courses/
- https://virtualrealtrans.com/vr-trans-porn-video/garden-of-eden/

# Improvements

## performerByURL

Added `performerByURL` scraper

### performerByURL: Example URLs

- https://virtualrealgay.com/vr-models/andy-star/
- https://virtualrealpassion.com/vr-models/shrima-malati/
- https://virtualrealporn.com/vr-pornstars/lexi-dona/
- https://virtualrealtrans.com/vr-models/sabryna-petruthelly/

Note that virtualrealamateurporn.com does not have performer pages, and virtualrealjapan.com's performer pages (e.g. https://virtualrealjapan.com/vr-models/nozomi-mare/) only really have Gender as useful/scrapable. However, if these sites are updated in future to align with the performer page content of the other sites, then this performerByURL scraper will already work for those sites.

## sceneByURL

### Tags

The `Tags` scraper now includes a `Virtual Reality` tag in addition to the others, this is handy for VR-detection in the Stash app for viewing a projection in-browser.
