### PR TITLE
Fix GroobyVR scene description scraping

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -69,8 +69,9 @@ xPathScrapers:
                 with: content/
               - regex: __SEPARATOR__
                 with: ''
-      Tags: &tags
-        Name: //div[@class="set_tags"]/ul/li//a/text()
+      Tags:
+        Name:
+          selector: &tagsSel //div[@class="set_tags"]/ul/li/text()|//div[@class="set_tags"]/ul/li//a/text()
   galleryScraper:
     gallery:
       Title: *title
@@ -78,7 +79,8 @@ xPathScrapers:
       Details: *details
       Performers: *performers
       Studio: *studio
-      Tags: *tags
+      Tags:
+        Name: *tagsSel
   sceneScraperGroobyVR:
     scene:
       Title: *title
@@ -100,5 +102,10 @@ xPathScrapers:
                 with: content/
               - regex: ^/
                 with: https://www.groobyvr.com/
-      Tags: *tags
+      Tags:
+        Name:
+          selector: *tagsSel
+          postProcess:
+            - map:
+                Tags for This Scene: Virtual Reality
 # Last Updated June 27, 2024

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -86,7 +86,7 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details:
-        selector: //div[@class="trailerblock"]/p[not(@class)]/text()
+        selector: //div[@class="trailerblock"]/p[not(@class)]/text()|//div[@class="trailerblock"]/p[not(@class)]//span/text()
         concat: "\n\n"
       Performers:
         Name: //div[@class="trailer_toptitle_left"]//a/text()
@@ -101,4 +101,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.groobyvr.com/
       Tags: *tags
-# Last Updated July 27, 2023
+# Last Updated June 27, 2024

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -87,7 +87,7 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details:
-        selector: //div[@class="trailerblock"]/p[not(@class)]/text()|//div[@class="trailerblock"]/p[not(@class)]//span/text()
+        selector: //div[@class="trailerblock"]/p[not(@class)]/descendant-or-self::*/text()
         concat: "\n\n"
       Performers:
         Name: //div[@class="trailer_toptitle_left"]//a/text()

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: "GroobyNetwork-Partial"
 sceneByURL:
   - action: scrapeXPath

--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -98,7 +98,6 @@ xPathScrapers:
           - replace:
               - regex: content// # errant double slash
                 with: content/
-          - replace:
               - regex: ^/
                 with: https://www.groobyvr.com/
       Tags: *tags


### PR DESCRIPTION
# Fixes

## sceneByURL

This adjusts the `Details` selector Xpath to include nested `span` tags within the `p` in order to get the paragraphs following the first one.

### Example URLs

- https://www.groobyvr.com/tour/trailers/I-Spent-My-Sugardaddys-Allowance.html
- https://www.groobyvr.com/tour/trailers/I-Just-Fucked-Fernanda-Moraes.html
- https://www.groobyvr.com/tour/trailers/I-Like-It-In-My-Butt.html
- https://www.groobyvr.com/tour/trailers/Reach-Out-And-Take-The-Cherry.html