### PR TITLE
Improve Premium Bukkake

### DIFF
--- a/scrapers/PremiumBukkake/PremiumBukkake.yml
+++ b/scrapers/PremiumBukkake/PremiumBukkake.yml
@@ -7,4 +7,4 @@ sceneByURL:
       - python
       - PremiumBukkake.py
       - query
-# Last Updated October 11, 2021
+# Last Updated July 02, 2024


### PR DESCRIPTION
Premium Bukkake has 2 sites, free version - https://free.premiumbukkake.com/  and paywalled - https://premiumbukkake.com/tour2. The current scraper uses the free versions URL and extracts some details, then modifies the URL and scrapes image, tags and performer from the paywalled site. The image has not worked correctly for a while picking up the model image not the scene cover after changes to the site. More recent updates to the paywalled site have also caused the scraper not to work in some scenes as it no longer follows assumptions made in scraper, https://free.premiumbukkake.com/updates/Rocio-1-Bukkake.html is a good example, as she does not have a performers section in her scene, the scraper fails on performer and tags. So have refactored for reliability.

Changes
1. Get cover image from free site, not paywalled site
2. Get tags and performers for paywalled site by heading reference not index location in list
3. Add fallback for performer if does not exist in paywalled site, they are available in free site
4. Add fallback for tags, paywalled site has a full list but if they do not exist use classification tag in free site