### PR TITLE
Fix Putalocura Details

### DIFF
--- a/scrapers/Putalocura.yml
+++ b/scrapers/Putalocura.yml
@@ -19,7 +19,7 @@ xPathScrapers:
         postProcess:
           - parseDate: 02/01/2006
       Details:
-        selector: //p[@class="desc"]/following-sibling::p/text()
+        selector: //p[@class="desc"]/following-sibling::p
       # look like it's the same trashy tag everytime so don't think there are useful
       #Tags:
       #  Name: 


### PR DESCRIPTION
The details in the scenes on Putalocura usually include links to the performer and other scenes, so the current scraper using the text() function will stop parsing the contents of the details in the <p> tag when a link tag <a> is hit. Fix is to remove the text() specifier to allow the complete <p> tag to be automatically parsed. Issue can be seen with this link https://www.putalocura.com/en/spanish-glory-hole/his-first-glory-hole-la-sadica-vive 