### PR TITLE
Adding thepovgod.com to the Nubiles network scraper

### DIFF
--- a/SCRAPERS-LIST.md
+++ b/SCRAPERS-LIST.md
@@ -2159,6 +2159,7 @@ thelesbianexperience.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x
 thelifeerotic.com|SARJ-LLC.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|Python|-
 thenude.com|TheNude.yml|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|-|-
 thepantyhosesite.com|AdultDoorway.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
+thepovgod.com|Nubiles.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 therapydick.com|PaperStreetMedia.yml|:heavy_check_mark:|:x:|:x:|:x:|-|Gay
 thetabutales.com|NewSensationsNetworkSites.yml|:heavy_check_mark:|:x:|:x:|:x:|-|-
 theyeslist.com|Adultime.yml|:heavy_check_mark:|:x:|:x:|:x:|Python|-

--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -64,6 +64,7 @@ sceneByURL:
       - nfbusty.com/video/watch/
       - nubiles.net/video/watch/
       - smashed.xxx/video/watch/
+      - thepovgod.com/video/watch/
 
 galleryByURL:
   # Nubiles Porn sites
@@ -248,4 +249,4 @@ xPathScrapers:
       Performers: *performersAttr
       Tags: *tagsAttr
       Studio: *studioFromTitleAttr
-# Last Updated June 14, 2024
+# Last Updated July 14, 2024


### PR DESCRIPTION
This is a pretty new site (first scene is March 5, 2024) and is one of the standalone sites of the Nubiles network. It doesn't have galleries/photos, so I'm enabling the scene URL scraper for this site.