### PR TITLE
Get correct Oldje scene cover

### DIFF
--- a/scrapers/Oldje.yml
+++ b/scrapers/Oldje.yml
@@ -30,6 +30,10 @@ xPathScrapers:
         selector: //p[@class='text']|//div[@class="preview_desc"]
       Image:
         selector: //div[@id="content" or @id="prev_m"]/a[1]/img/@src
+        postProcess:
+          - replace:
+              - regex: movie-
+                with:    
   oldje3someScraper:
     scene:
       Studio:
@@ -51,4 +55,4 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: "https://www.oldje-3some.com/"
-# Last Updated February 25, 2023
+# Last Updated July 18, 2024


### PR DESCRIPTION
Oldje used to have 2 types of scene cover, the montage and the poster, the poster was large, portrait and made up of multiple pictures, whereas the montage is normal size and landscape all in one jpg. 99% of Oldje scenes on StashDB use the montage card format. Oldje have now dropped the poster and gone for a screen cap, but the montage is still used. This change will automatically pick up the montage in keeping with StashDB covers. Montage cover is same format with movie- removed from URL

Example
Screen cap : https://www.oldje.com/sets/898/movie-morning-exercise.jpg 
Montage : https://www.oldje.com/sets/898/morning-exercise.jpg