### PR TITLE
Add studio code for Oldje and Oldje-3some

### DIFF
--- a/scrapers/Oldje.yml
+++ b/scrapers/Oldje.yml
@@ -33,7 +33,14 @@ xPathScrapers:
         postProcess:
           - replace:
               - regex: movie-
-                with:    
+                with:   
+      Code:
+        selector: //div[@id="content" or @id="prev_m"]/a[1]/img/@src
+        postProcess:
+          # Extract the studio code from the image URL as it is always in format /sets/nnn/ where nnn is code.
+          - replace:
+            - regex: .*sets\/(\d+).*
+              with: E$1 
   oldje3someScraper:
     scene:
       Studio:
@@ -55,4 +62,11 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: "https://www.oldje-3some.com/"
-# Last Updated July 18, 2024
+      Code:
+        selector: //img[@class="img-responsive" and contains(@src,"/view/")]/@src
+        postProcess:
+          # Extract the studio code from the partial image URL as it is always in format /photoCover/nnn where nnn is code.
+          - replace:
+            - regex: .*photoCover\/(\d+).*
+              with: E$1
+# Last Updated July 19, 2024


### PR DESCRIPTION
Studio codes for Oldje and Oldje-3some are contained in the image URLs, these have been extracted and set into format Ennn where nnn is studio code (e.g E872), it is prefixed with E as the studio download filenames follow this format and 99% of the StashDB studio codes are also in this format.