### PR TITLE
Add Spytug.com and CumClinic.com

### DIFF
--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -4,6 +4,8 @@ sceneByURL:
     url:
       - gloryholeswallow.com
       - cumpsters.com
+      - spytug.com
+      - cumclinic.com
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
@@ -29,17 +31,23 @@ xPathScrapers:
       Tags:
         Name: $info//p[contains(text(),'Tags')]//a/text()
       Image:
-        selector: //base/@href | //div[@id='fakeplayer']//img/@src0_1x
+        # Newer vids use img/@src0_1x, older use img/@src, combining both will pickup from both old and new scenes
+        selector: //base/@href | //div[@id='fakeplayer']//img/@src | //div[@id='fakeplayer']//img/@src0_1x
         concat: "SEP"
         postProcess:
+          # Spytug only studio that uses full path for images, so remove
+          - replace:
+            - regex: https:\/\/spytug.com\/SEP
+              with: ""
           # Base for Gloryhole swallow includes /tour, which is also included in partial image path, remove this duplicate and sepertor
           - replace:
               - regex: \/tour\/SEP
                 with: ""
-          # Will remove SEP for Cumpsters which is a complete URL
+          # Will remove SEP for rest of sites as it is a complete URL
           - replace:
               - regex: \/SEP
                 with: ""
+          
       Studio:
         Name:
           selector: //base/@href
@@ -50,5 +58,7 @@ xPathScrapers:
             - map:
                 cumpsters: Cumpsters
                 gloryholeswallow: Gloryhole Swallow
+                spytug: SpyTug
+                cumclinic: CumClinic
       URL: //link[@rel='canonical']/@href
-# Last Updated July 31, 2024
+# Last Updated August 01, 2024


### PR DESCRIPTION
Add support for the other 2 sister sites of Gloryhole Swallow, SpyTug and CumClinic. This scraper now supports all 4 Titan Media Inc sites. Also added modification to ensure images from older scenes were being picked up correctly.