### PR TITLE
Support scraping Mr. LuckyLIFE members' pages

### DIFF
--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -51,7 +51,6 @@ xPathScrapers:
         postProcess:
           - parseDate: 2006-01-02
       Details: $scene_info//p[@class="description"] | $scene_info//p
-      # Details: $scene_info//p
       Performers:
         Name: $scene_info//a[@class="model-name"]/@title
       Tags:

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -85,10 +85,10 @@ xPathScrapers:
                 with:
 driver:
   cookies:
-  - CookieURL: "https://www.mrluckylife.com"
+  - CookieURL: "https://www.mrluckylife.com/"
     Cookies:
-      # Replace this cookie to scrape members area links
-      - Name: "pcar%5xxxxxxxxxxxxxxxxxxxxxxx"
+      # Set this cookie name to the one beginning with `pcar[...]` to scrape the members' pages.
+      - Name: ""
         Domain: ".mrluckylife.com"
         Path: "/"
         Value: ""

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -7,6 +7,7 @@ sceneByURL:
       - firstclasspov.com/updates/
       - gothgirlfriends.com/updates/
       - mrluckylife.com/updates/
+      - mrluckylife.com/members/
       - mrluckypov.com/updates/
       - mrluckyraw.com/updates/
       - mrluckyvip.com/updates/
@@ -49,11 +50,12 @@ xPathScrapers:
         selector: $scene_info//p[@class="date"]
         postProcess:
           - parseDate: 2006-01-02
-      Details: $scene_info//p
+      Details: $scene_info//p[@class="description"] | $scene_info//p
+      # Details: $scene_info//p
       Performers:
-        Name: $scene_info//a[contains(@href,"/model")]/@title
+        Name: $scene_info//a[@class="model-name"]/@title
       Tags:
-        Name: $scene_info//a[contains(@href,"/categories")] | //div[contains(@class, "categories-holder")]/a
+        Name: $scene_info//a[contains(@href,"/categories")] | $scene_info//a[contains(@href,"/category")] | //div[contains(@class, "categories-holder")]/a
       Studio:
         Name:
           # Scenes on Spizoo can have an <i id="site"> element with the studio name, others we get from the base URL
@@ -67,6 +69,7 @@ xPathScrapers:
                 drdaddypov: Dr. Daddy POV
                 firstclasspov: First Class POV
                 gothgirlfriends: Goth Girlfriends
+                mrluckylife: Mr. LuckyLIFE
                 mrluckypov: Mr. LuckyPOV
                 mrluckyraw: Mr. LuckyRaw
                 mrluckyvip: Mr. LuckyVIP
@@ -81,4 +84,13 @@ xPathScrapers:
               # Remove any resizing parameters for the image, we want the original
               - regex: "[?&]img(?:q|w|h)=[^&]+"
                 with:
-# Last Updated June 05, 2024
+driver:
+  cookies:
+  - CookieURL: "https://www.mrluckylife.com"
+    Cookies:
+      # Replace this cookie to scrape members area links
+      - Name: "pcar%5xxxxxxxxxxxxxxxxxxxxxxx"
+        Domain: ".mrluckylife.com"
+        Path: "/"
+        Value: ""
+# Last Updated August 1, 2024


### PR DESCRIPTION
Mr. LuckyLIFE doesn't show tags when the user is logged out, but does show them to members. In the interest of scraping tags, this change:
* Adds a place to set a logged-in cookie.
* Modifies some selectors to handle the page structure of the Mr. LuckyLIFE members' site.
* Adds a mapping for studio name `mrluckylife: Mr. LuckyLIFE`. This is technically unrelated, but ought to be fixed.
* Has been tested to not break support for the logged-out case on Mr. LuckyLIFE and all other Spizoo network sites.