### PR TITLE
Fix hanime scraping

### DIFF
--- a/scrapers/hanime.yml
+++ b/scrapers/hanime.yml
@@ -4,7 +4,7 @@ sceneByFragment:
   queryURL: https://hanime.tv/videos/hentai/{filename}
   queryURLReplace:
     filename:
-      - regex: ^([a-z\-0-9]+)(\-[0-9]{3,4}p)?.*
+      - regex: ^([a-z\-0-9]+?)(\-[0-9]{3,4}p)?\..+$
         with: $1
   scraper: sceneScraper
 sceneByURL:
@@ -42,4 +42,4 @@ xPathScrapers:
                 with: "static-assets.droidbuzz.top"
               - regex: "https://"
                 with: "https://i1.wp.com/"
-# Last Updated June 25, 2024
+# Last Updated August 4, 2024


### PR DESCRIPTION
the current regex tries to match group 1 greedily which causes the resolution of the file to be appended to the url mistakenly.
`15-bishoujo-hyouryuuki-1-720p.mp4` -> https://hanime.tv/videos/hentai/15-bishoujo-hyouryuuki-1-720p

this patch makes the first group lazy to correctly build the desired url, which should work for the both files with or without the resolution.
`15-bishoujo-hyouryuuki-1.mp4` -> https://hanime.tv/videos/hentai/15-bishoujo-hyouryuuki-1
`15-bishoujo-hyouryuuki-1-720p.mp4` -> https://hanime.tv/videos/hentai/15-bishoujo-hyouryuuki-1