### PR TITLE
Rule34Video: Fix video description sometimes not getting read properly

### DIFF
--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -41,7 +41,9 @@ xPathScrapers:
     scene:
       URL: //link[@rel='canonical']/@href
       Title: //div[@class="heading"]//h1
-      Details: (//div[@class="info row"]/following-sibling::div)[1]
+      Details: 
+        selector: (//div[@id='tab_video_info']/div[@class="row"]/div[@class="label"])[1]//text()
+        concat: "\n"
       Date:
         selector: //script[@type="application/ld+json"]
         postProcess:
@@ -85,4 +87,4 @@ driver:
           ValueRandom: 43
           Domain: .rule34video.com
           Path: /
-# Last Updated July 20, 2024
+# Last Updated Aug 7, 2024

--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -87,4 +87,4 @@ driver:
           ValueRandom: 43
           Domain: .rule34video.com
           Path: /
-# Last Updated Aug 7, 2024
+# Last Updated August 7, 2024


### PR DESCRIPTION
Fixed an issue where the video description would miss line breaks and would read wrong elements when the description is empty.  Would've wanted to insert correct line break ammount for mirroring the correct formating off of the site (e.g. multiple line breaks directly after one-and-other), but my skills are too limited for that
