### PR TITLE
Fix scraping scenes with multiple performers Pure Media

### DIFF
--- a/scrapers/PureMedia.yml
+++ b/scrapers/PureMedia.yml
@@ -22,7 +22,7 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Performers:
-        Name: $main//h5[contains(.,"Featuring")]/following-sibling::ul
+        Name: $main//h5[contains(.,'Featuring')]/following-sibling::ul//a
       Studio:
         Name: //meta[@name='author']/@content
       Tags:
@@ -32,6 +32,6 @@ xPathScrapers:
         concat: '|'
         postProcess:
           - replace:
-              - regex: "(^[^|]+)\\|.*/tour/([^\\.]+\\.jpg).*"
-                with: $1$2
-# Last Updated February 5, 2024
+              - regex: (?:/tour/\|)
+                with:
+# Last Updated August 10, 2024


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

[Scene URL](https://www.pure-bbw.com/tour/trailers/HOT-threesome-with-Samantha-38g-and-Karen-Fisher-tagteaming-a-lucky-cock.html)
[Scene URL](https://pure-ts.com/tour/trailers/post-cheating-threesome.html)
[Scene URL](https://www.pure-xxx.com/tour/trailers/bringing-her-trans-girlfriend-home-for-some-fun.html)
[Scene URL](https://sissypov.com/tour/trailers/crossdressing-girlfriends-get-down-on-a-big-dick.html)

## Short description

Fixed scraping scenes with multiple performers. Previously it scraped both performers as one, eg ``performer1 performer2``
Simplified the regex for the image 