### PR TITLE
Fix RawAttack, and possibly other Spizoo sites, performer name scraping.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,5 @@
     "yaml.schemas": {
         "validator/scraper.schema.json": "*.yml"
     },
-    "python.analysis.typeCheckingMode": "basic",
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "master"
-    ]
+    "python.analysis.typeCheckingMode": "basic"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
     "yaml.schemas": {
         "validator/scraper.schema.json": "*.yml"
     },
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
 }

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -92,4 +92,4 @@ driver:
         Domain: ".mrluckylife.com"
         Path: "/"
         Value: ""
-# Last Updated August 1, 2024
+# Last Updated August 11, 2024

--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -52,7 +52,7 @@ xPathScrapers:
           - parseDate: 2006-01-02
       Details: $scene_info//p[@class="description"] | $scene_info//p
       Performers:
-        Name: $scene_info//a[@class="model-name"]/@title
+        Name: $scene_info//a[@class="model-name"]/@title | $scene_info//a[contains(@href,"/model")]/@title
       Tags:
         Name: $scene_info//a[contains(@href,"/categories")] | $scene_info//a[contains(@href,"/category")] | //div[contains(@class, "categories-holder")]/a
       Studio:


### PR DESCRIPTION
Apparently I either didn't test RawAttack as closely as I'd thought before [this PR](https://github.com/stashapp/CommunityScrapers/pull/1954), or their page formatting is inconsistent, because the updated performer name selector does not always work on RawAttack pages.

This change re-adds the original `$scene_info//a[contains(@href,"/model")]/@title` selector for performer names as a secondary alternative / fallback to the  newer performer name selector.