### PR TITLE
Fix for Algolia scraper scene details

### DIFF
--- a/scrapers/Algolia/Algolia.py
+++ b/scrapers/Algolia/Algolia.py
@@ -167,6 +167,14 @@ def clean_text(details: str) -> str:
         details = re.sub(r"<\s*/?br\s*/?\s*>", "\n",
                          details)  # bs.get_text doesnt replace br's with \n
         details = bs(details, features='html.parser').get_text()
+        # Remove leading/trailing/double whitespaces
+        details = '\n'.join(
+            [
+                ' '.join([s for s in x.strip(' ').split(' ') if s != ''])
+                for x in ''.join(details).split('\n')
+            ]
+        )
+        details = details.strip()
     return details
 
 


### PR DESCRIPTION
Added small fix to remove leading/trailing/double whitespaces in the scene description. 
Since StashDB already removes leading/trailing whitespaces, it's bugging the hell out of me why the description is different, only to find out later it was a trailing whitespace.

## Examples to test

[scene url](https://tabooheat.com/en/video/tabooheat/Cory-Chase-in-Caught-During-the-Storm-with-Step-Mom/216240)
[scene url](https://tabooheat.com/en/video/tabooheat/Cory-Chase-in-BBC-Championship-Season---Gym-Motivation/227915)
[scene url](https://tabooheat.com/en/video/tabooheat/Ivy-Andrews-in-BBC-Championship-Season---Horny-Step-Daughter-Part-2/251761)
