### PR TITLE
Add '.org' TLD support to Pornhub

### DIFF
--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -7,11 +7,13 @@ performerByURL:
   - action: scrapeXPath
     url:
       - pornhub.com
+      - pornhub.org
     scraper: performerScraper
 sceneByURL:
   - action: scrapeXPath
     url:
       - pornhub.com/view_video.php?viewkey=
+      - pornhub.org/view_video.php?viewkey=
     scraper: sceneScraper
 sceneByFragment:
   action: scrapeXPath
@@ -171,4 +173,4 @@ driver:
           Domain: ".pornhub.com"
           Value: "1"
           Path: "/"
-# Last Updated July 23, 2024
+# Last Updated August 19, 2024


### PR DESCRIPTION
Pornhub changed their top level domain to `.org` - `.com` still works too.