### PR TITLE
Data18 movie name tweak

### DIFF
--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -57,8 +57,9 @@ xPathScrapers:
           selector: $movie/@title
           postProcess:
             - replace:
-                - regex: (.+?)(?:\s#1)?$
-                  with: $1
+#                - regex: (.+?)(?:\s#1)?$
+                - regex: (.+?)(?:(?:\s#1)?$|(\s)#(\d+))
+                  with: $1$2$3
         URL: $movie/@href
       Image: //img[@id="playpriimage"]/@src
   movieScraper:
@@ -73,6 +74,8 @@ xPathScrapers:
           - replace:
               - regex: (.+?)(?:\s\(\d{4}\))?(?:\sPorn)?(?:\sMovie)?\s\|\sDATA18
                 with: $1
+              - regex: (.+?)(?:(?:\s#1)?$|(\s)#(\d+))
+                with: $1$2$3
       Duration:
         selector: $movieInfo//b[contains(text(),"Length")]/following-sibling::span|$movieInfo//b[contains(text(),"Length")]/following-sibling::text()
         postProcess:

--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -57,7 +57,6 @@ xPathScrapers:
           selector: $movie/@title
           postProcess:
             - replace:
-#                - regex: (.+?)(?:\s#1)?$
                 - regex: (.+?)(?:(?:\s#1)?$|(\s)#(\d+))
                   with: $1$2$3
         URL: $movie/@href


### PR DESCRIPTION
I did not make changes to what can be scrapped.  I only updated RegEx to remove the "#" inserted in movie titles that aren't typically included in other sites.

Example: My Neighbor Is A Sexy MILF 6
URL: https://www.lethalhardcore.com/en/movie/title/120401

Scene from data18 would extract movie title "My Neighbor is a Sexy Milf #6" 
URL: https://www.data18.com/scenes/3124736

Alternate source AdultEmpire Example URL: https://www.adultempire.com/4676320/my-neighbor-is-a-sexy-milf-6-porn-videos.html