### PR TITLE
Add DickHDDaily to KBProductions URL scene scraper

### DIFF
--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -28,6 +28,7 @@ studio_map = {
     "cougarseason.com": "Cougar Season",
     "creampiethais.com": "Creampie Thais",
     "deepthroatsirens.com": "Deepthroat Sirens",
+    "dickhddaily.com": "DickHDDaily",
     "diredesires.com": "Dire Desires",
     "dirtyauditions.com": "Dirty Auditions",
     "divine-dd.com": "Divine-DD",

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -21,6 +21,7 @@ sceneByURL:
       - cougarseason.com/scenes
       - creampiethais.com/videos
       - deepthroatsirens.com/scenes
+      - dickhddaily.com/videos
       - diredesires.com/scenes
       - dirtyauditions.com/scenes
       - divine-dd.com/videos


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] sceneByURL

## Examples to test

https://dickhddaily.com/videos/nerdy-booty
https://dickhddaily.com/videos/baddie-taming-extended
https://dickhddaily.com/videos/big-ass-to-take-extended

## Short description

Added dickhddaily.com (DickHDDaily) to KBProductions URL scene scraper and studio map.
