### PR TITLE
Add AlexLegend Scraper

### DIFF
--- a/scrapers/AlexLegend/AlexLegend.yml
+++ b/scrapers/AlexLegend/AlexLegend.yml
@@ -25,7 +25,7 @@ xPathScrapers:
         selector: //script[contains(text(),"myFluidPlayer")]
         postProcess:
           - replace:
-            - regex: ^.*posterImage\s?:\s?'(.*?)'.*
+            - regex: .+posterImage\s?:\s?'(.*?)'.+
               with: $1
       Studio:
         Name:
@@ -36,15 +36,13 @@ xPathScrapers:
           split: ", "
           postProcess:
             - replace:
-              - regex: ^Tags:(.+)
-                with: $1
+              - regex: 'Tags:'
       Performers:
         Name:
           selector: //div[contains(concat(" ", normalize-space(@class), " "), " main__models ")]
           split: ","
           postProcess:
             - replace:
-              - regex: ^Models:(.+)
-                with: $1
+              - regex: 'Models:'
 
 # Last Updated September 06, 2024

--- a/scrapers/AlexLegend/AlexLegend.yml
+++ b/scrapers/AlexLegend/AlexLegend.yml
@@ -8,21 +8,23 @@ sceneByURL:
 
 xPathScrapers:
   sceneScraper:
+    common:
+      $sceneWrapper: //section[contains(concat(" ", normalize-space(@class), " "), " content-sec ")]
     scene:
-      Title: //div[contains(concat(" ", normalize-space(@class), " "), " content-title ")]/h1
+      Title: $sceneWrapper//div[contains(concat(" ", normalize-space(@class), " "), " content-title ")]/h1
       Code:
-        selector: //link[@rel="canonical"]/@href
+        selector: /link[@rel="canonical"]/@href
         postProcess:
           - replace:
             - regex: .+-(\d+)\..+
               with: $1
-      Details: //div[contains(concat(" ", normalize-space(@class), " "), " content-desc ")][2]
+      Details: $sceneWrapper//div[contains(concat(" ", normalize-space(@class), " "), " content-desc ")][2]
       Date:
-        selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-date ")]/div[contains(concat(" ", normalize-space(@class), " "), " label ")]
+        selector: $sceneWrapper//div[contains(concat(" ", normalize-space(@class), " "), " content-date ")]/div[contains(concat(" ", normalize-space(@class), " "), " label ")]
         postProcess:
           - parseDate: 02.01.2006
       Image:
-        selector: //script[contains(text(),"myFluidPlayer")]
+        selector: $sceneWrapper//script[contains(text(),"myFluidPlayer")]
         postProcess:
           - replace:
             - regex: .+posterImage\s?:\s?'(.+?)'.+
@@ -32,13 +34,9 @@ xPathScrapers:
           fixed: AlexLegend
       Tags:
         Name:
-          selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-tags ")]/a
+          selector: $sceneWrapper//div[contains(concat(" ", normalize-space(@class), " "), " content-tags ")]/a
       Performers:
         Name:
-          selector: //div[contains(concat(" ", normalize-space(@class), " "), " main__models ")]
-          split: ","
-          postProcess:
-            - replace:
-              - regex: 'Models:'
+          selector: $sceneWrapper//div[contains(concat(" ", normalize-space(@class), " "), " main__models ")]/a[@title]
 
-# Last Updated September 06, 2024
+# Last Updated September 08, 2024

--- a/scrapers/AlexLegend/AlexLegend.yml
+++ b/scrapers/AlexLegend/AlexLegend.yml
@@ -32,11 +32,7 @@ xPathScrapers:
           fixed: AlexLegend
       Tags:
         Name:
-          selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-tags ")]
-          split: ", "
-          postProcess:
-            - replace:
-              - regex: 'Tags:'
+          selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-tags ")]/a
       Performers:
         Name:
           selector: //div[contains(concat(" ", normalize-space(@class), " "), " main__models ")]

--- a/scrapers/AlexLegend/AlexLegend.yml
+++ b/scrapers/AlexLegend/AlexLegend.yml
@@ -1,0 +1,50 @@
+name: AlexLegend
+
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - alexlegend.com/video/
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[contains(concat(" ", normalize-space(@class), " "), " content-title ")]/h1
+      Code:
+        selector: //link[@rel="canonical"]/@href
+        postProcess:
+          - replace:
+            - regex: .+-(\d+)\..+
+              with: $1
+      Details: //div[contains(concat(" ", normalize-space(@class), " "), " content-desc ")][2]
+      Date:
+        selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-date ")]/div[contains(concat(" ", normalize-space(@class), " "), " label ")]
+        postProcess:
+          - parseDate: 02.01.2006
+      Image:
+        selector: //script[contains(text(),"myFluidPlayer")]
+        postProcess:
+          - replace:
+            - regex: ^.*posterImage\s?:\s?'(.*?)'.*
+              with: $1
+      Studio:
+        Name:
+          fixed: AlexLegend
+      Tags:
+        Name:
+          selector: //div[contains(concat(" ", normalize-space(@class), " "), " content-tags ")]
+          split: ", "
+          postProcess:
+            - replace:
+              - regex: ^Tags:(.+)
+                with: $1
+      Performers:
+        Name:
+          selector: //div[contains(concat(" ", normalize-space(@class), " "), " main__models ")]
+          split: ","
+          postProcess:
+            - replace:
+              - regex: ^Models:(.+)
+                with: $1
+
+# Last Updated September 06, 2024

--- a/scrapers/AlexLegend/AlexLegend.yml
+++ b/scrapers/AlexLegend/AlexLegend.yml
@@ -25,7 +25,7 @@ xPathScrapers:
         selector: //script[contains(text(),"myFluidPlayer")]
         postProcess:
           - replace:
-            - regex: .+posterImage\s?:\s?'(.*?)'.+
+            - regex: .+posterImage\s?:\s?'(.+?)'.+
               with: $1
       Studio:
         Name:

--- a/scrapers/VNAGirls.yml
+++ b/scrapers/VNAGirls.yml
@@ -2,7 +2,6 @@ name: VNAGirls
 sceneByURL:
   - action: scrapeXPath
     url:
-      - alexlegend.com
       - angelinacastrolive.com
       - bestoftealconrad.com
       - blownbyrone.com
@@ -82,4 +81,4 @@ xPathScrapers:
               - regex: (\d+)(st|nd|rd|th)
                 with: "$1"
           - parseDate: January 2 2006
-# Last Updated March 25, 2022
+# Last Updated September 06, 2024


### PR DESCRIPTION
Adds a sceneByURL xPathScraper for AlexLegend.com

## Scraper type(s)

- [x] sceneByURL


## Examples to test

[Recent Scene](https://alexlegend.com/video/skylar-snow-black-lingerie-surprise-sex-behind-the-scenes-1074.html)
[Popular Scene](https://alexlegend.com/video/bg-caitlin-bell-xmas-roommates-740.html)
[Old Scene](https://alexlegend.com/video/alex-grey-first-ir-dp-gangbang-288.html)


## Short description

Break out alexlegend.com from VNAGirls scraper. New site design that does not conform to VNA template.
