### PR TITLE
remove normalize-space chains

### DIFF
--- a/scrapers/AdultDvdMarketPlace.yml
+++ b/scrapers/AdultDvdMarketPlace.yml
@@ -40,7 +40,7 @@ xPathScrapers:
 
   sceneSearch:
     common:
-      $selection: //div[contains(concat(' ',normalize-space(@class),' '),' product-col ')]
+      $selection: //div[contains(@class, "product-col")]
     scene:
       Title: $selection//h4/a
       URL:

--- a/scrapers/Boundhoneys.yml
+++ b/scrapers/Boundhoneys.yml
@@ -9,7 +9,7 @@ xPathScrapers:
     scene:
       Title: //div[@class="updateVideoTitle"]
       Details:
-        selector: //div[@class="updateDescription"]/b/text()[normalize-space(.)]
+        selector: //div[@class="updateDescription"]/b/text()
         concat: "\n\n"
       Image: //meta[@name="twitter:image"]/@content
       Studio:

--- a/scrapers/CherryPimps.yml
+++ b/scrapers/CherryPimps.yml
@@ -46,7 +46,7 @@ xPathScrapers:
           - parseDate: January 2, 2006
       Performers: &perfAttr
         Name: //div[@class='update-info-block models-list-thumbs']//span/text()
-      Details: &detailsSel //h4[normalize-space('Description:')]/following-sibling::p/text()
+      Details: &detailsSel //h4[contains(text(),"Description:")]/following-sibling::p/text()
       Tags: &tagsAttr
         Name:
           selector: //ul[@class='tags']/li/a/text()

--- a/scrapers/Dickdrainers.yml
+++ b/scrapers/Dickdrainers.yml
@@ -9,7 +9,7 @@ xPathScrapers:
     scene:
       Title: //div[@class="videoDetails clear"]//h3
       Details:
-        selector: //div[@class="videoDetails clear"]/p//text()[normalize-space(.)]
+        selector: //div[@class="videoDetails clear"]/p//text()
         concat: "\n\n"
       Date:
         selector: //span[contains(text(), "Date Added")]/following-sibling::text()
@@ -29,6 +29,6 @@ xPathScrapers:
       Tags:
         Name: //li[@class="label"][contains(text(),"Tags:")]/following-sibling::li/a/text()
       Performers:
-        Name: //li[@class="update_models"]//a/text()[normalize-space(.)]
+        Name: //li[@class="update_models"]//a/text()
 
 # Last Updated January 08, 2021

--- a/scrapers/EuroPornstar/EuroPornstar.yml
+++ b/scrapers/EuroPornstar/EuroPornstar.yml
@@ -152,7 +152,7 @@ xPathScrapers:
                 with: ""
 
       Details:
-        selector: //div[contains(concat(" ",normalize-space(@class)," ")," about-desc ")]//span/text()|//div[contains(concat(" ",normalize-space(@class)," ")," about-desc ")]//p/text()
+        selector: //div[contains(@class,"about-desc")]//span/text()|//div[contains(@class,"about-desc")]//p/text()
         concat: "\n"
         postProcess:
           - replace:

--- a/scrapers/FreeonesCommunity.yml
+++ b/scrapers/FreeonesCommunity.yml
@@ -66,12 +66,12 @@ xPathScrapers:
     scene:
       Title: //h1
       URL: //link[@rel="alternate"][1]/@href
-      Details: $commonRoot//div[contains(concat(' ',normalize-space(@class),' '),' pb-2 ')]
+      Details: $commonRoot//div[contains(@class,"pb-2")]/text()
       Studio:
         Name: $commonRoot//span[@data-test="link_span_Studio"]
       Director: $commonRoot//span[@data-test="link_span_Director"]
       Date:
-        selector: //div[contains(concat(' ',normalize-space(@class),' '),' mid-content-pr-past-date ')]
+        selector: //div[contains(@class,"uploaded-date")]/text()
         postProcess:
           - replace:
             - regex: .+?(\w+\s\d{1,2},\s\d{4}).+
@@ -97,13 +97,13 @@ xPathScrapers:
       $performerName: //a[@data-test="link_Cast"]
     movie:
       Name: //h1
-      Synopsis: $commonRoot//div[contains(concat(' ',normalize-space(@class),' '),' pb-2 ')]
+      Synopsis: $commonRoot//div[contains(@class,"pb-2")]
       Duration: $commonRoot//span[@data-test="link_span_Duration"]
       Studio:
         Name: $commonRoot//span[@data-test="link_span_Studio"]
       Director: $commonRoot//span[@data-test="link_span_Director"]
       Date:
-        selector: //div[contains(concat(' ',normalize-space(@class),' '),' mid-content-pr-past-date ')]
+        selector: //div[contains(@class,"mid-content-pr-past-date")]
         postProcess:
           - replace:
             - regex: .+?(\w+\s\d{1,2},\s\d{4}).+

--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -133,7 +133,7 @@ xPathScrapers:
       URL: //link[@rel="canonical"]/@href
   performerSearch:
     common:
-      $result: //div/a[contains(@href, "/model") and contains(concat(" ", normalize-space(@class), " "), " model-link ")]
+      $result: //div/a[contains(@href, "/model") and contains(@class,"model-link")]
     performer:
       Name: $result/img/@alt
       URL:
@@ -155,7 +155,7 @@ xPathScrapers:
               - regex: \s+$
                 with:
       Twitter:
-        selector: '//div/a[contains(concat(" ", normalize-space(@class), " "), " social-link ") and contains(@href, "twitter.com")]/@href'
+        selector: '//div/a[contains(@class,"social-link") and contains(@href, "twitter.com")]/@href'
       Image:
         selector: //img[contains(@class,'kink-slider-img') and contains(@class,'active')]/@data-src
       Tattoos:

--- a/scrapers/KinkMen.yml
+++ b/scrapers/KinkMen.yml
@@ -85,7 +85,7 @@ xPathScrapers:
               - regex: \s+$
                 with:
       Twitter:
-        selector: '//div/a[contains(concat(" ", normalize-space(@class), " "), " social-link ") and contains(@href, "twitter.com")]/@href'
+        selector: '//div/a[contains(@class,"social-link") and contains(@href, "twitter.com")]/@href'
       Image:
         selector: //img[contains(@class,'kink-slider-img') and contains(@class,'active')]/@data-src
       Tattoos:

--- a/scrapers/Mandyflores.yml
+++ b/scrapers/Mandyflores.yml
@@ -12,7 +12,7 @@ xPathScrapers:
     scene:
       Title: //span[@class="title_bar_hilite"]
       Details:
-        selector: $updateDesc$divCenter/span/span[@style]/text()[normalize-space(.)]|($updateDesc | $updateDesc/p)/text()[normalize-space(.)]|($updateDesc$divCenter/text())[1]|($updateDesc/text())[1]
+        selector: $updateDesc$divCenter/span/span[@style]/text()|($updateDesc | $updateDesc/p)/text()|($updateDesc$divCenter/text())[1]|($updateDesc/text())[1]
         concat: "\n\n"
       Date:
         selector: //div[@class="cell update_date"][not(ancestor::span[@class="update_description"])]/text()[1]

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -117,6 +117,7 @@ xPathScrapers:
     common:
       $datablob: //script[contains(., 'VideoObject')]/text()
       $videowrap: //div[@class="video-wrapper"]
+      $videoActions: //div[contains(@class,"video-actions-tabs")]
     scene:
       Title:
         selector: //meta[@property="og:title"]/@content
@@ -146,7 +147,12 @@ xPathScrapers:
                 with:
       Tags:
         Name:
-          selector: //div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," categoriesWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," tagsWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," productionWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," langSpokenWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," relatedSearchTermsContainer ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," userInfo ")]//div[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//i/text()
+          selector: $videoActions//div[contains(@class,"categoriesWrapper")]//a/text()
+            |$videoActions//div[contains(@class,"tagsWrapper")]//a/text()
+            |$videoActions//div[contains(@class,"productionWrapper")]//a/text()
+            |$videoActions//div[contains(@class,"langSpokenWrapper")]//a/text()
+            |$videoActions//div[contains(@class,"relatedSearchTermsContainer")]//a/text()
+            |//div[contains(@class,"userInfo")]//div[contains(@class,"usernameBadgesWrapper")]//i/text()
           postProcess:
             - replace:
                 - regex: "onlyfans"
@@ -155,7 +161,8 @@ xPathScrapers:
                   with: "Fansly"
       Performers:
         Name:
-          selector: //div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//span[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//span[contains(concat(" ",normalize-space(@class)," ")," pornstarsWrapper ")]//a/text()
+          selector: $videoActions//span[contains(@class,"usernameBadgesWrapper")]//a/text()
+            |$videoActions//span[contains(@class,"pornstarsWrapper")]//a/text()
           postProcess:
             - replace:
                 - regex: '\.'
@@ -164,7 +171,7 @@ xPathScrapers:
                   with: " "
       Image: //meta[@property="og:image"]/@content
       Studio:
-        Name: $videowrap//div[contains(concat(" ",normalize-space(@class)," ")," usernameWrap ")]//a/text()
+        Name: $videowrap//div[contains(@class,"usernameWrap")]//a/text()
 
 driver:
   cookies:

--- a/scrapers/Private.yml
+++ b/scrapers/Private.yml
@@ -107,7 +107,7 @@ xPathScrapers:
       Image: //meta[@property="og:image"]/@content
   performerScraper:
     common:
-      $performerData: //div[contains(concat(' ',normalize-space(@class),' '),' pornstar-wrapper ')]
+      $performerData: //div[contains(@class,"pornstar-wrapper")]
     performer:
       Name: $performerData//h1
       URL: //meta[@property="og:url"]/@content

--- a/scrapers/RachelSteele.yml
+++ b/scrapers/RachelSteele.yml
@@ -18,7 +18,7 @@ sceneByQueryFragment:
 xPathScrapers:
   sceneSearch:
     common:
-      $root: //li[contains(concat(' ',normalize-space(@class),' '),' first ')]
+      $root: //li[contains(@class,"first")]
     scene:
       Title: $root//h3
       Image:
@@ -36,9 +36,9 @@ xPathScrapers:
 
   sceneScraper:
     scene:
-      Title: //div[contains(concat(' ',normalize-space(@class),' '),' span12 ')]/h3/text()
+      Title: //div[contains(@class,"span12")]/h3/text()
       Image:
-        selector: //div[contains(concat(' ',normalize-space(@class),' '),' album-details ')]/div/div/img/@src
+        selector: //div[contains(@class,"album-details")]/div/div/img/@src
         postProcess:
           - replace:
               - regex: ^

--- a/scrapers/SlaveMouth.yml
+++ b/scrapers/SlaveMouth.yml
@@ -9,17 +9,17 @@ sceneByURL:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: //h3[contains(concat(" ", normalize-space(@class), " "), " mas_title ")]/text()
-      Details: //div[contains(concat(" ", normalize-space(@class), " "), " description ")]/p[contains(concat(" ", normalize-space(@class), " "), " mas_longdescription ")]/text()
+      Title: //h3[contains(@class,"mas_title")]/text()
+      Details: //div[contains(@class,"description")]/p[contains(@class,"mas_longdescription")]/text()
       Date: 
-        selector: //div[contains(concat(" ", normalize-space(@class), " "), " lch ")]/span[contains(concat(" ", normalize-space(@class), " "), " lc_info ")]
+        selector: //div[contains(@class,"lch")]/span[contains(@class,"lc_info")]
         postProcess:
           - replace:
             - regex: (.*?), (.+)
               with: $2
           - parseDate: January 2, 2006
       Image: 
-        selector: //div[contains(concat(" ", normalize-space(@class), " "), " jwpContainer ")]/script/text()
+        selector: //div[contains(@class,"jwpContainer")]/script/text()
         postProcess:
           - replace:
             - regex: .+splash:\ \'(.+\.jpg).+
@@ -29,7 +29,7 @@ xPathScrapers:
           fixed: SlaveMouth
       Tags:
         Name:
-          selector: //div[@id="caseContainer"]/div/p[contains(concat(" ", normalize-space(@class), " "), " tags ")]
+          selector: //div[@id="caseContainer"]/div/p[contains(@class,"tags")]
           split: ", "
           postProcess:
             - replace:
@@ -38,7 +38,7 @@ xPathScrapers:
                 with: $1
       Performers:
         Name:
-          selector: //div[contains(concat(" ", normalize-space(@class), " "), " lch ")]/span[contains(concat(" ", normalize-space(@class), " "), " lc_info ")]/text()
+          selector: //div[contains(@class,"lch")]/span[contains((@class,"lc_info")]/text()
           split: ","
       Code: //div[@id="caseContainer"]/@data-lid
 

--- a/scrapers/TheScoreGroup/TheScoreGroup.yml
+++ b/scrapers/TheScoreGroup/TheScoreGroup.yml
@@ -78,7 +78,7 @@ xPathScrapers:
     common:
       $url: //link[@rel="canonical"]/@href
       $videopage: //section[@id="videos_page-page" or @id="mixed_page-page"]
-      $stat: //div[contains(concat(' ',normalize-space(@class),' '),' mb-3 ')]
+      $stat: //div[contains(@class,"mb-3")]
     scene:
       # Original studio is determinable by looking at the CDN links (<source src="//cdn77.scoreuniverse.com/naughtymag/scenes...)
       # this helps set studio for PornMegaLoad URLs as nothing is released directly by the network

--- a/scrapers/TwistedFactory.yml
+++ b/scrapers/TwistedFactory.yml
@@ -84,7 +84,7 @@ xPathScrapers:
 
   performerSearch:
     common:
-      $result: //div/a[contains(@href, "/model") and contains(concat(" ", normalize-space(@class), " "), " model-link ")]
+      $result: //div/a[contains(@href, "/model") and contains(@class,"model-link")]
     performer:
       Name: $result/img/@alt
       URL:
@@ -106,7 +106,7 @@ xPathScrapers:
               - regex: \s+$
                 with:
       Twitter:
-        selector: '//div/a[contains(concat(" ", normalize-space(@class), " "), " social-link ") and contains(@href, "twitter.com")]/@href'
+        selector: '//div/a[contains(@class,"social-link") and contains(@href, "twitter.com")]/@href'
       Image:
         selector: //img[contains(@class,'kink-slider-img') and contains(@class,'active')]/@data-src
       Tattoos:

--- a/scrapers/XVirtual.yml
+++ b/scrapers/XVirtual.yml
@@ -20,7 +20,7 @@ sceneByQueryFragment:
 xPathScrapers:
   sceneSearch:
     common:
-      $ep: //div[contains(concat(' ', normalize-space(@class), ' '), ' episode ')]
+      $ep: //div[contains(@class,"episode")]
     scene:
       Title:
         selector: $ep//a[@class="title"]/h2[@class="nice-title"]/text()
@@ -29,7 +29,7 @@ xPathScrapers:
               - regex: \s*in\s+180°$
                 with:
       Image:
-        selector: $ep//img[contains(concat(' ', normalize-space(@class), ' '), ' poster ')]/@src
+        selector: $ep//img[contains(@class,"poster")]/@src
       URL:
         selector: $ep//a[@class="title"]/@href
         postProcess:

--- a/scrapers/pornworld.yml
+++ b/scrapers/pornworld.yml
@@ -30,7 +30,7 @@ jsonScrapers:
 xPathScrapers:
   sceneScraper:
     common:
-      $details: //div[contains(concat(' ',normalize-space(@class),' '),' scene-details ')]
+      $details: //div[contains(@class,"scene-details")]
     scene:
       Title: &title
         selector: //h1
@@ -44,7 +44,7 @@ xPathScrapers:
           - parseDate: 2006, January 2
       Details: $details//span[text() = 'Description:']/../text()[2]
       Tags:
-        Name: $details//span[text() = 'Tags:']/following-sibling::a[contains(concat(' ',normalize-space(@class),' '),' link-secondary ')]
+        Name: $details//span[text() = 'Tags:']/following-sibling::a[contains(@class,"link-secondary")]
       Performers:
         Name: $details//h1/following-sibling::p[1]/a
         URL:


### PR DESCRIPTION
the `contains(concat(' ', normalize-space(@class),' ')` chain would ensure that the classname had successive spaces collapsed, which only guaranteed that it was part of a multi-class selector. Since only a single class is being selected, this is completely redundant since consecutive spaces don't impact anything.

The trailing normalize-space(.) would make sure anything ending with `...` would be collapsed to `.` but this was not observed on any of the pages, and when it was observed, it was intentional styling.

The PornHub scraper was unraveled and and a common fragment added for $videoActions