### PR TITLE
add working sceneByURL for transdaylight.com and transmidnight.com

### DIFF
--- a/scrapers/Arx/Arx.py
+++ b/scrapers/Arx/Arx.py
@@ -16,6 +16,7 @@ site_ids = {
     'cuckhunter.com': 10,
     'nudeyogaporn.com': 11,
     'transroommates.com': 12,
+    'transmidnight.com': 14,
     'transdaylight.com': 15
 }
 

--- a/scrapers/Arx/Arx.py
+++ b/scrapers/Arx/Arx.py
@@ -15,7 +15,8 @@ site_ids = {
     'povmasters.com': 8,
     'cuckhunter.com': 10,
     'nudeyogaporn.com': 11,
-    'transroommates.com': 12
+    'transroommates.com': 12,
+    'transdaylight.com': 15
 }
 
 # Timeout (seconds) to prevent indefinite hanging

--- a/scrapers/Arx/Arx.yml
+++ b/scrapers/Arx/Arx.yml
@@ -9,10 +9,11 @@ sceneByURL:
       - povmasters.com/scenes/
       - cuckhunter.com/scenes/
       - nudeyogaporn.com/scenes/
+      - transdaylight.com/scenes/
       - transroommates.com/scenes/
     script:
       - python
       - Arx.py
       - scrapeByURL
 
-# Last Updated February 27, 2024
+# Last Updated September 9, 2024

--- a/scrapers/Arx/Arx.yml
+++ b/scrapers/Arx/Arx.yml
@@ -10,6 +10,7 @@ sceneByURL:
       - cuckhunter.com/scenes/
       - nudeyogaporn.com/scenes/
       - transdaylight.com/scenes/
+      - transmidnight.com/scenes/
       - transroommates.com/scenes/
     script:
       - python


### PR DESCRIPTION
## Scraper type(s)
- sceneByURL

## Examples to test

- https://transmidnight.com/scenes/3313/skinny-trans-dolly-rotten-enjoys-deep-raw-anal-and-big-facial
- https://transdaylight.com/scenes/3316/blonde-trans-olivia-would-fucks-thicc-rubie-hellia

## Short description

Adds `sceneByURL` scraping for the following sites:

- transmidnight.com
- transdaylight.com
