### PR TITLE
Fix cover image xpath in badoink scaper

### DIFF
--- a/scrapers/BaDoink.yml
+++ b/scrapers/BaDoink.yml
@@ -71,11 +71,7 @@ xPathScrapers:
       Studio:
         Name: &studioName //meta[@name="dl8-customization-brand-name"]/@content
       Image: &imageSel
-        selector: //img[@class="video-image"]/@src
-        postProcess:
-          - replace:
-              - regex: \?.+
-                with: ""
+        selector: //div[@id="videoPreviewContainer"]//video[@id="video-preview-hover"]/@poster
       URL: &sceneUrl //link[@rel="canonical"]/@href
       Code:
         selector: *sceneUrl


### PR DESCRIPTION

## Examples to test
NSFW
https://18vr.com/vrpornvideo/feed_the_need-325692/
https://babevr.com/vrpornvideo/sybil_101-325713/
https://badoinkvr.com/vrpornvideo/a_little_miss_conduct-326572/
https://vrcosplayx.com/cosplaypornvideo/euphoria_maddy_a_xxx_parody-326303/

## Short description
Fixed the image xpath for the badoink scraper