### PR TITLE
Update PervCity scraper

### DIFF
--- a/scrapers/PervCity.yml
+++ b/scrapers/PervCity.yml
@@ -1,4 +1,4 @@
-name: "PervCity"
+name: PervCity
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -8,52 +8,102 @@ sceneByURL:
       - oraloverdose.com/trailers/
       - pervcity.com/trailers/
       - upherasshole.com/trailers/
-      - dpdiva.com/trailers/
     scraper: sceneScraper
+    queryURL: '{url}'
+    queryURLReplace:
+      url:
+        - regex: (?:^.+\.com)(/.+)
+          with: https://pervcity.com$1
+  - action: scrapeXPath
+    url:
+      - dpdiva.com/trailers/
+    scraper: dpdivaScraper
+
 xPathScrapers:
   sceneScraper:
     common:
       $sceneinfo: //div[@class="videoInfo"]
       $base: //head/base/@href
+      $image: //img[contains(@class,'posterimg')]
     scene:
-      Title: $sceneinfo/div[@class="infoHeader"]
-      Studio:
-        Name:
-          selector: //head/base/@href
-          postProcess:
-            - replace:
-                - regex: .+/(?:www\.)?([^\.]+)\.com/.*
-                  with: $1
-            - map:
-                analoverdose: Anal Overdose
-                bangingbeauties: Banging Beauties
-                chocolatebjs: Chocolate BJs
-                dpdiva: DP Diva
-                oraloverdose: Oral Overdose
-                pervcity: PervCity
-                upherasshole: Up Her Asshole
-      Performers:
-        Name: $sceneinfo//span[@class="tour_update_models"]/a
-      Tags:
-        Name: $sceneinfo//div[@class="tagcats"]/a/text()
-      Details: $sceneinfo//p/text()|$sceneinfo//h3[@class="description"]
-      Image:
-        selector: //head/base/@href|//img[@class="posterimg stdimage thumbs"]/@src
-        concat: "|"
+      Title: &title $sceneinfo/div[@class="infoHeader"]
+      Code: &code
+        selector: //meta[@property="og:image"]/@content
         postProcess:
           - replace:
-              - regex: ([^|]+)\|(.*)/(content/.+)
-                with: $1$3
+              - regex: https.+/content/(\w+\-\d{4})\-.*/\d.+?$
+                with: $1
+      Studio: &studio
+        Name:
+          selector: //meta[@property="og:image"]/@content
+          postProcess:
+            - replace:
+                - regex: https.+/content/(\w+\-\d{4})\-.*/\d.+?$
+                  with: $1
+                - regex: (?:-.+)
+                  with:
+            # Convert studiocode uppercase to be able to map to studio
+            - javascript: |
+                if (value && value.length) {
+                  return value.toUpperCase()
+                }
+            - map:
+                AO: Anal Overdose
+                BAM: PervCity
+                BB: Banging Beauties
+                BTS: PervCity
+                CBJ: Chocolate BJs
+                DPD: DP Diva
+                LISC: PervCity
+                OO: Oral Overdose
+                SOLO: PervCity
+                UHA: Up Her Asshole
+      Performers: &performers
+        Name: $sceneinfo//span[@class="tour_update_models"]/a
+      Tags: &tags
+        Name: $sceneinfo//div[@class="tagcats"]/a/text()
+      Details: &details $sceneinfo//h3[@class="description"]/text()|$sceneinfo//p/text()
+      Image: &sceneimage $image/@src0_3x|$image/@src0_2x|$image/@src0_1x
       Date:
         selector: $sceneinfo/div[@class="infoHeader"]
         postProcess:
           - replace:
-              - regex: \s
+              - regex: \s|-|\'|’|,
                 with: "_"
+              - regex: "&"
+                with: "%26"
               - regex: ^
                 with: "https://pervcity.com/search.php?query="
           - subScraper:
-              selector: //div[@class="category_listing_block"]//div[@class="date"]/text()
+              selector: &scenedate //div[@class="category_listing_block"]//div[@class="date"]/text()
               postProcess:
                 - parseDate: 01-02-2006
-# Last Updated February 13, 2022
+
+  dpdivaScraper:
+    common:
+      $sceneinfo: //div[@class="videoInfo"]
+      $base: //head/base/@href
+      $image: //img[contains(@class,'posterimg')]
+    scene:
+      Title: *title
+      Image: *sceneimage
+      Tags: *tags
+      Studio: *studio
+      Details: *details
+      Performers: *performers
+      Code: *code
+      Date:
+        selector: $sceneinfo/div[@class="infoHeader"]
+        postProcess:
+          - replace:
+              - regex: \s|-|\'|’|,
+                with: "_"
+              - regex: "&"
+                with: "%26"
+              - regex: ^
+                with: "https://dpdiva.com/search.php?query="
+          - subScraper:
+              selector: *scenedate
+              postProcess:
+                - parseDate: 01-02-2006
+# Last Updated September 12, 2024


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

[Scene url](https://upherasshole.com/trailers/alt-babes-bonnie-rotten-juelz-ventura-get-nasty.html) (Up Her Asshole)
[Scene url](https://analoverdose.com/trailers/taboo-anal-sex-three-way-part-2.html) (Anal Overdose)
[Scene url](https://www.dpdiva.com/trailers/Stunning-Latina-Vanessa-Sky-Intense-DP.html) (DP Diva)

## Short description
- Tags for scenes
Tags can only be grabbed on the pervcity.com website, not on the individual subsites.
The slug is the same for a scene, so I used queryURLReplace to replace domain to pervcity.com to grab the tags.

- Updated regex for dates 
Dates for scenes are only displayed on the pervcity.com website, when searching for a scene.
So searching for exact title that has a ``’`` or ``,`` would return more than 1 scene, and most of the time the wrong one.

- Map the studio to their corresponding studiocode
So for example, studiocode ``ao-0328`` maps to studio ``Anal Overdose``
In some cases, it's hard to tell which studio that scene belongs to. For example when the studiocode is ``BTS`` or ``SOLO``, it could be any studio, so I've mapped those to the main PervCity studio. We could always move it to the correct studio later on.

    Out of the 1050 scenes I used this scraper on, I've found only 5 or so scenes which had the anal overdose studiocode, but only could be found on upherasshole.com.

- Higher quality image
Grabs higher quality image. I've noticed they started higher quality scene images around 2021-01, so anything before that will give you low-quality.

- Moved dpdiva.com to own scraper
Because I used queryURLReplace to map urls to pervcity.com and DP Diva scenes can **only** be found on dpdiva.com, I moved DP Diva to it's own subscraper