### PR TITLE
removed text normalize-space, add PornHub videoActions common

### DIFF
--- a/scrapers/Boundhoneys.yml
+++ b/scrapers/Boundhoneys.yml
@@ -9,7 +9,7 @@ xPathScrapers:
     scene:
       Title: //div[@class="updateVideoTitle"]
       Details:
-        selector: //div[@class="updateDescription"]/b/text()[normalize-space(.)]
+        selector: //div[@class="updateDescription"]/b/text()
         concat: "\n\n"
       Image: //meta[@name="twitter:image"]/@content
       Studio:

--- a/scrapers/Dickdrainers.yml
+++ b/scrapers/Dickdrainers.yml
@@ -9,7 +9,7 @@ xPathScrapers:
     scene:
       Title: //div[@class="videoDetails clear"]//h3
       Details:
-        selector: //div[@class="videoDetails clear"]/p//text()[normalize-space(.)]
+        selector: //div[@class="videoDetails clear"]/p//text()
         concat: "\n\n"
       Date:
         selector: //span[contains(text(), "Date Added")]/following-sibling::text()
@@ -29,6 +29,6 @@ xPathScrapers:
       Tags:
         Name: //li[@class="label"][contains(text(),"Tags:")]/following-sibling::li/a/text()
       Performers:
-        Name: //li[@class="update_models"]//a/text()[normalize-space(.)]
+        Name: //li[@class="update_models"]//a/text()
 
 # Last Updated January 08, 2021

--- a/scrapers/FreeonesCommunity.yml
+++ b/scrapers/FreeonesCommunity.yml
@@ -71,7 +71,7 @@ xPathScrapers:
         Name: $commonRoot//span[@data-test="link_span_Studio"]
       Director: $commonRoot//span[@data-test="link_span_Director"]
       Date:
-        selector: //div[contains(concat(' ',normalize-space(@class),' '),' mid-content-pr-past-date ')]
+        selector: //div[contains(concat(' ',normalize-space(@class),' '),' uploaded-date ')]/text()
         postProcess:
           - replace:
             - regex: .+?(\w+\s\d{1,2},\s\d{4}).+

--- a/scrapers/Mandyflores.yml
+++ b/scrapers/Mandyflores.yml
@@ -12,7 +12,7 @@ xPathScrapers:
     scene:
       Title: //span[@class="title_bar_hilite"]
       Details:
-        selector: $updateDesc$divCenter/span/span[@style]/text()[normalize-space(.)]|($updateDesc | $updateDesc/p)/text()[normalize-space(.)]|($updateDesc$divCenter/text())[1]|($updateDesc/text())[1]
+        selector: $updateDesc$divCenter/span/span[@style]/text()|($updateDesc | $updateDesc/p)/text()|($updateDesc$divCenter/text())[1]|($updateDesc/text())[1]
         concat: "\n\n"
       Date:
         selector: //div[@class="cell update_date"][not(ancestor::span[@class="update_description"])]/text()[1]

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -117,6 +117,7 @@ xPathScrapers:
     common:
       $datablob: //script[contains(., 'VideoObject')]/text()
       $videowrap: //div[@class="video-wrapper"]
+      $videoActions: //div[contains(@class,"video-actions-tabs")]
     scene:
       Title:
         selector: //meta[@property="og:title"]/@content
@@ -146,7 +147,12 @@ xPathScrapers:
                 with:
       Tags:
         Name:
-          selector: //div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," categoriesWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," tagsWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," productionWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," langSpokenWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//div[contains(concat(" ",normalize-space(@class)," ")," relatedSearchTermsContainer ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," userInfo ")]//div[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//i/text()
+          selector: $videoActions//div[contains(concat(" ",normalize-space(@class)," ")," categoriesWrapper ")]//a/text()
+            |$videoActions//div[contains(concat(" ",normalize-space(@class)," ")," tagsWrapper ")]//a/text()
+            |$videoActions//div[contains(concat(" ",normalize-space(@class)," ")," productionWrapper ")]//a/text()
+            |$videoActions//div[contains(concat(" ",normalize-space(@class)," ")," langSpokenWrapper ")]//a/text()
+            |$videoActions//div[contains(concat(" ",normalize-space(@class)," ")," relatedSearchTermsContainer ")]//a/text()
+            |//div[contains(concat(" ",normalize-space(@class)," ")," userInfo ")]//div[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//i/text()
           postProcess:
             - replace:
                 - regex: "onlyfans"
@@ -155,7 +161,7 @@ xPathScrapers:
                   with: "Fansly"
       Performers:
         Name:
-          selector: //div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//span[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//a/text()|//div[contains(concat(" ",normalize-space(@class)," ")," video-actions-tabs ")]//span[contains(concat(" ",normalize-space(@class)," ")," pornstarsWrapper ")]//a/text()
+          selector: //$videoActions//span[contains(concat(" ",normalize-space(@class)," ")," usernameBadgesWrapper ")]//a/text()|$videoActions//span[contains(concat(" ",normalize-space(@class)," ")," pornstarsWrapper ")]//a/text()
           postProcess:
             - replace:
                 - regex: '\.'


### PR DESCRIPTION
changes from https://github.com/stashapp/CommunityScrapers/pull/2014

- `[normalize-space(.)]` transforms the text, in some cases transforming it from the studio name
- FreeOnesCommunity updated with new selector
- PornHub now with video-actions-tab common, split up for readability