### PR TITLE
Teamskeet remove trailing newline scene details

### DIFF
--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -206,7 +206,7 @@ if dt:
 #fix for TeamKseet including HTML tags in Description
 CLEANR = re.compile('<.*?>') 
 cleandescription = re.sub(CLEANR,'',scene_api_json.get('description'))
-scrape['details'] = cleandescription
+scrape['details'] = cleandescription.strip()
 scrape['studio'] = {}
 studioApiName = scene_api_json['site'].get('name')
 log.debug("Studio API name is '" + studioApiName + "'")


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

[scene url](https://teamskeet.com/movies/my-trick-or-treat-fembot)
[scene url](https://teamskeet.com/movies/laundry-day-surprise)

## Short description
Small fix to remove ending newline, and since StashDB already removes leading/ending whitespaces, it's hard to notice the ending newline when rescraping from StashDB.