### PR TITLE
Update HelixStudios.yml

### DIFF
--- a/scrapers/HelixStudios.yml
+++ b/scrapers/HelixStudios.yml
@@ -113,16 +113,19 @@ xPathScrapers:
         selector: //span[text()="Height"]/following-sibling::text()
         postProcess:
           - feetToCm: true
-        PenisLength:
+      PenisLength:
         selector: //span[text()="Cock"]/following-sibling::text()
         postProcess:
           - replace:
-              - regex: ^
-                with: "0."
-          - replace:
-              - regex: \d\d [a-zA-Z]+ [a-zA-Z]+
-                with: "$&"
+              - regex: (\d+) inches (Cut|Uncut)
+                with: "0.$1"
           - feetToCm: true
+      Circumcised:
+        selector: //span[text()="Cock"]/following-sibling::text()
+        postProcess:
+          - replace:
+              - regex: (\d+) inches (Cut|Uncut)
+                with: "$2"
       Tags:
         Name: //span[text()="Position"]/following-sibling::text()
       Weight:

--- a/scrapers/HelixStudios.yml
+++ b/scrapers/HelixStudios.yml
@@ -106,23 +106,25 @@ xPathScrapers:
 
   performerScraper:
     performer:
-      Name: //div[contains(@class, "top")]/h1/text()
+      Name: //div[contains(@class, "section-box model-bio")]/h1/text()
       Gender:
         fixed: Male
       Height:
         selector: //span[text()="Height"]/following-sibling::text()
         postProcess:
           - feetToCm: true
-      Measurements:
+        PenisLength:
         selector: //span[text()="Cock"]/following-sibling::text()
         postProcess:
           - replace:
               - regex: ^
-                with: "0'"
+                with: "0."
           - replace:
-              - regex: inch*
-                with: "''"
+              - regex: \d\d [a-zA-Z]+ [a-zA-Z]+
+                with: "$&"
           - feetToCm: true
+      Tags:
+        Name: //span[text()="Position"]/following-sibling::text()
       Weight:
         selector: //span[text()="Weight"]/following-sibling::text()
         postProcess:
@@ -143,4 +145,4 @@ xPathScrapers:
           - replace:
               - regex: $
                 with: " "
-# Last Updated May 19, 2024
+# Last Updated Sep 28, 2024


### PR DESCRIPTION
Replacing Measurements with PenisLength. Position will also now pull in as a tag.

## Examples to test

https://www.helixstudios.com/model/1006/hayden-clark
https://www.helixstudios.com/model/2545/adam-reid

## Short description

I was able to fix the PenisLength, but couldn't figure out if it was possible to also scraper whether they were cut or uncut. On the studio's website it's listed as 8 inches uncut and they don't have uncut or cut as it's own separate item.
