### PR TITLE
Handle new TeamSkeet image paths

### DIFF
--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -20,20 +20,24 @@ except ModuleNotFoundError:
     print("If you have pip (normally installed with python), run this command in a terminal (cmd): pip install requests", file=sys.stderr)
     sys.exit()
 
-def try_img(imgurl):
+def try_url(url):
+    return requests.head(url).status_code == 200
+
+def try_img_replacement(imgurl):
     # members/full - 1600x900
     # bio_big - 1500x844
     # shared/hi - 1280x720
     # shared/med - 765x430
-    for replacement in ['members/full', 'bio_big']:
+    for replacement in ['members/full', 'bio_big', 'shared/hi']:
         newurl = imgurl.replace('shared/med', replacement)
-        if requests.head(newurl).status_code == 200:
+        if (try_url(newurl)):
             return newurl
-    # try shared/hi on /tour url for MYLF
-    if 'mylf' in imgurl:
-        newurl = imgurl.replace('mylf/alm', 'mylf/alm/tour/pics').replace('shared/med', 'shared/hi')
-        if requests.head(newurl).status_code == 200:
-            return newurl
+    # try shared/hi on /tour url
+    tourHi = imgurl.replace('/alm', '/alm/tour/pics').replace('shared/med', 'shared/hi')
+    if (try_url(tourHi)):
+        return tourHi
+    # fallback to original image
+    return imgurl
 
 def save_json(api_json, url):
     try:
@@ -231,7 +235,7 @@ else:
 # the scraped value and the higher resolution version.
 
 # try to (and check) higher res images if possible
-high_res = try_img(scene_api_json.get('img'))
+high_res = try_img_replacement(scene_api_json.get('img'))
 
 log.debug(f"Image before: {scrape['image']}")
 log.debug(f"Image after: {high_res}")

--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -33,7 +33,10 @@ def try_img_replacement(imgurl):
         if (try_url(newurl)):
             return newurl
     # try shared/hi on /tour url
-    tourHi = imgurl.replace('/alm', '/alm/tour/pics').replace('shared/med', 'shared/hi')
+    # get the subsite name
+    subsite = imgurl.split("/")[4]
+    # replace with /tour/pics
+    tourHi = imgurl.replace(f"/{subsite}", f"/{subsite}/tour/pics").replace('shared/med', 'shared/hi')
     if (try_url(tourHi)):
         return tourHi
     # fallback to original image


### PR DESCRIPTION
| path | note | resolution | test URLs |
|---|---|---|---|
| members/full | TeamSkeet | 1600x900 | [1](https://www.teamskeet.com/movies/breed-me-daddy) |
| bio_big | MYLF | 1500x844 | [2](https://www.mylf.com/movies/i-cant-resist-my-stepmom-needs-a-young-mans-seed) [7](https://www.mylf.com/movies/dirty-principal-lets-me-free-use-her-to-avoid-suspension) |
| shared/hi |  | 1280x720 | [4](https://www.mylf.com/movies/my-anal-lover) [6](https://www.teamskeet.com/movies/for-the-good-of-the-team) |
| tour/pics/shared/hi | MYLF | 1280x720 | [3](https://www.mylf.com/movies/the-mature-anal-queen-next-door) |
| shared/med | SayUncle | 1600x900 | [5](https://www.sayuncle.com/movies/threesome-for-breakfast) |
| shared/med | default | 765x430 |  |