### PR TITLE
IAFD fix careerlength performer

### DIFF
--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -234,9 +234,9 @@ def performer_aliases(tree):
 def performer_careerlength(tree):
     return maybe(
         tree.xpath(
-            '//div/p[@class="biodata"][contains(text(),"Started around")]/text()'
+            '//div/p[@class="bioheading"][contains(text(), "Active")][1]/following-sibling::p[1]/text()'
         ),
-        lambda c: re.sub(r"(\D+\d\d\D+)$", "", c),
+        lambda c: " - ".join(re.sub(r"(\D+\d\d\D+)$", "", c.strip()).split("-")),
     )
 
 


### PR DESCRIPTION
IAFD scraper wasn't correctly pulling in performers careerlength, when performers are new or when IAFD is missing the ``(Started around xx years old)`` code

Small fix so it correctly grabs the careerlength the same way it grabs it from StashDB. It now grabs the text after ``Years Active`` since that is always listed on IAFD

[IAFD url](https://www.iafd.com/person.rme/id=1ac7507f-a610-47fd-84ef-42a7d32e196f) new performer lacking the ``(Started around xx years old)``
[IAFD url](https://www.iafd.com/person.rme/id=3659f3a2-2fad-4880-b20a-517b94b8cfd6) performer with multiple ``Years Active`` (when they're also directing)