### PR TITLE
Add scene and performer scrapers for ModelMediaAsia

### DIFF
--- a/scrapers/ModelMediaAsia.yml
+++ b/scrapers/ModelMediaAsia.yml
@@ -1,0 +1,85 @@
+name: "ModelMediaAsia"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - modelmediaasia.com
+    scraper: sceneScraper
+
+sceneByFragment:
+  action: scrapeXPath
+  queryURL: https://modelmediaasia.com/zh-CN/videos/{filename}
+  queryURLReplace:
+    # Assume beginning part contains the code
+    filename:
+      # Get the beginning part before the space
+      - regex: '(.*)\s.*'
+        with: $1
+  scraper: sceneScraper
+
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - modelmediaasia.com
+    scraper: performerScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[1]/h2/text()
+      Date:
+        # Some text may be in front of the date
+        selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[3]/span/text()
+        postProcess:
+          - replace:
+            - regex: '.*(\d{4}/\d{1,2}/\d{1,2})'
+              with: $1
+          - parseDate: 2006/01/02
+      Details:
+        selector: //*[@id="description-01"]/div/p/text()
+      Performers:
+        Name: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[3]/div/ul/li/a/div[2]/h6]/text()
+        # Directly set URL doesn't work?
+        Details:
+          selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[3]/div/ul/li/a/@href
+          postProcess:
+            - replace:
+              - regex: ^
+                with: https://modelmediaasia.com
+      Studio:
+        Name:
+          fixed: "Model Media"
+      Tags:
+        Name: //li[@class="p-1 px-3"]/a[@class="title"]/text()
+      Image: //*[@id="__nuxt"]/main/div/div[1]/div/div/div/div/div[2]/img/@src
+      URL: //link[@rel="canonical"]/@href
+      Code: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[2]/a/text()
+  performerScraper:
+    performer:
+      Name: //*[@id="__nuxt"]/main/div/div/div/div[2]/div[1]/h4/text()
+      Gender:
+        fixed: Female
+      Ethnicity:
+        fixed: Asian
+      Country:
+        fixed: Taiwan
+      Height:
+        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[1]/text()
+        postProcess:
+          - replace:
+            - regex: '(\d+)\D+cm'
+              with: $1
+      Weight:
+        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[2]/text()
+        postProcess:
+          - replace:
+            - regex: '(\d+)\D+kg'
+              with: $1
+      Measurements:
+        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[3]/text()
+        postProcess:
+          - replace:
+            - regex: '\s+(\d\d\w*)\D+(\d+)\D+(\d+)'
+              with: $1-$2-$3
+      Image: //*[@id="__nuxt"]/main/div/div/div/div[1]/img/@src
+      URL: //link[@rel='canonical']/@href
+# Last Updated October 17, 2024

--- a/scrapers/ModelMediaAsia.yml
+++ b/scrapers/ModelMediaAsia.yml
@@ -2,89 +2,89 @@ name: "ModelMediaAsia"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - modelmediaasia.com
+      - modelmediaasia.com/en-US/videos/
+      - modelmediaasia.com/zh-CN/videos/
     scraper: sceneScraper
 
 sceneByFragment:
   action: scrapeXPath
-  queryURL: https://modelmediaasia.com/zh-CN/videos/{filename}
+  queryURL: https://modelmediaasia.com/videos/{filename}
   queryURLReplace:
     # Assume beginning part contains the code
     filename:
-      # Get the beginning part before the space
-      - regex: ^(\S+).*
+      # Get file that matches code
+      - regex: ^([\w\d-]+)
         with: $1
+      - regex: .*\.[^\.]+$ # if no id is found in the filename
+        with: # clear the filename so that it doesn't leak
   scraper: sceneScraper
 
 performerByURL:
   - action: scrapeXPath
     url:
-      - modelmediaasia.com
+      - modelmediaasia.com/en-US/models/
+      - modelmediaasia.com/zh-CN/models/
     scraper: performerScraper
 
 xPathScrapers:
   sceneScraper:
+    common:
+      $detailspart: //div[@class="details-part"]
     scene:
-      Title: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[1]/h2/text()
+      Title: $detailspart//h2
       Date:
         # Some text may be in front of the date
-        selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[3]/span/text()
+        selector: $detailspart//span[contains(@class, "trending-year")]
         postProcess:
           - replace:
             - regex: '.*(\d{4}/\d{1,2}/\d{1,2})'
               with: $1
           - parseDate: 2006/01/02
       Details:
-        selector: //*[@id="description-01"]/div/p/text()
+        selector: //div[@id="description-01"]/div/p/text()
       Performers:
-        Name: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[3]/div/ul/li/a/div[2]/h6]/text()
-        # Directly set URL doesn't work?
-        Details:
-          selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[3]/div/ul/li/a/@href
-          postProcess:
-            - replace:
-              - regex: ^
-                with: https://modelmediaasia.com
+        Name: $detailspart//div[@class="content-details trending-info"][2]//h6/text()
+        # workaround for including URL
+        # URL arrays don't work https://github.com/stashapp/stash/issues/5294
+        # Details:
+        #   selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[3]/div/ul/li/a/@href
+        #   postProcess:
+        #     - replace:
+        #       - regex: ^
+        #         with: https://modelmediaasia.com
       Studio:
         Name:
           fixed: "Model Media"
       Tags:
-        Name: //li[@class="p-1 px-3"]/a[@class="title"]/text()
-      Image: //*[@id="__nuxt"]/main/div/div[1]/div/div/div/div/div[2]/img/@src
-      URL:
-        selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[2]/a/text()
-        postProcess:
-          - replace:
-            - regex: ^
-              with: https://modelmediaasia.com/zh-CN/videos/
-      Code: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[2]/a/text()
+        Name: //ul[contains(@class, "iq-blogtag")]/li/a/text()
+      Image: //div[@class="iq-main-slider site-video"]//div[contains(@class,"object-cover")]/img/@src
+      Code: //div[@class="details-part"]//a[contains(@class,"text-capitalize")]/text()
   performerScraper:
+    common:
+      $infobox: //div[@id="__nuxt"]/main//div[@class="flex flex-col gap-3 my-5"]
     performer:
-      Name: //*[@id="__nuxt"]/main/div/div/div/div[2]/div[1]/h4/text()
+      Name: //div[@id="__nuxt"]/main//div[contains(@class,"text-white")]/div/h4[1]/text()
       Gender:
         fixed: Female
       Ethnicity:
         fixed: Asian
-      Country:
-        fixed: Taiwan
       Height:
-        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[1]/text()
+        selector: $infobox/p[1]/text()
         postProcess:
           - replace:
             - regex: '(\d+)\D+cm'
               with: $1
       Weight:
-        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[2]/text()
+        selector: $infobox/p[2]/text()
         postProcess:
           - replace:
             - regex: '(\d+)\D+kg'
               with: $1
       Measurements:
-        selector: //*[@id="__nuxt"]/main/div/div/div/div[1]/div[2]/p[3]/text()
+        selector: $infobox/p[3]/text()
         postProcess:
           - replace:
-            - regex: '\s+(\d\d\w*)\D+(\d+)\D+(\d+)'
+            - regex: '\s*(\d+\w*)\D+(\d+)\D+(\d+)'
               with: $1-$2-$3
-      Image: //*[@id="__nuxt"]/main/div/div/div/div[1]/img/@src
-      URL: //link[@rel='canonical']/@href
-# Last Updated October 17, 2024
+      Image: //img[@class="w-full aspect-[3/4]"]/@src
+# Last Updated October 26, 2024

--- a/scrapers/ModelMediaAsia.yml
+++ b/scrapers/ModelMediaAsia.yml
@@ -12,7 +12,7 @@ sceneByFragment:
     # Assume beginning part contains the code
     filename:
       # Get the beginning part before the space
-      - regex: '(.*)\s.*'
+      - regex: ^(\S+).*
         with: $1
   scraper: sceneScraper
 

--- a/scrapers/ModelMediaAsia.yml
+++ b/scrapers/ModelMediaAsia.yml
@@ -51,7 +51,12 @@ xPathScrapers:
       Tags:
         Name: //li[@class="p-1 px-3"]/a[@class="title"]/text()
       Image: //*[@id="__nuxt"]/main/div/div[1]/div/div/div/div/div[2]/img/@src
-      URL: //link[@rel="canonical"]/@href
+      URL:
+        selector: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[2]/a/text()
+        postProcess:
+          - replace:
+            - regex: ^
+              with: https://modelmediaasia.com/zh-CN/videos/
       Code: //*[@id="__nuxt"]/main/div/div[2]/div/div/div/div[1]/div/div[1]/div[2]/a/text()
   performerScraper:
     performer:


### PR DESCRIPTION
Scrapers for a new site.

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [X] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [X] sceneByFragment
- [X] sceneByURL
- [ ] movieByURL
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

Scene example: https://modelmediaasia.com/zh-CN/videos/MD-0182
Performer example: https://modelmediaasia.com/zh-CN/models/11

## Short description

I have used it for several scenes and things seem to work as expected so far.

The only thing I couldn't figure out is the way how performer URL should be added when a new performer is scraped with the scene scraper. See what I do with "Details" under "Performer" for the scene scraper. I am putting the URL there for the ease of use. For some unknown reason, if I directly set URL for performer, nothing will be set in the URL field for a newly created performer. I hope someone can take a look at that and see if it's a bug or something.

This should close #2068