### PR TITLE
replace bencoder.pyx with fastbencode

### DIFF
--- a/scrapers/torrent/torrent.py
+++ b/scrapers/torrent/torrent.py
@@ -9,10 +9,9 @@ from pathlib import Path
 from py_common.deps import ensure_requirements
 from py_common import graphql
 
-ensure_requirements("bencoder.pyx")
+ensure_requirements("fastbencode")
 
-from bencoder import bdecode  # noqa: E402
-
+from fastbencode import bdecode # noqa: E402
 
 TORRENTS_PATH = Path("torrents")
 


### PR DESCRIPTION
bencoder.pyx is troublesome since it needs to be built from scratch, fastbencode is a drop-in replacement and performs much better than bencoder.pyx

```benchmark.py
import timeit

file_handle = open("target.torrent", "rb")
file_data = file_handle.read()

# bencode.pyx
# https://github.com/whtsky/bencoder.pyx
# existing stash
from bencoder import bdecode as bdecode_pyx

# fastbencode
# https://github.com/breezy-team/fastbencode
# debian
from fastbencode import bdecode as bdecode_fastbencode

# bencode.py
# https://github.com/fuzeman/bencode.py
# alpine
from bencodepy import bdecode as bdecode_bencodepy

# fast-bencode
# 

def bencode_pyx():
    bdecode_pyx(file_data)

def bencode_fastbencode():
    bdecode_fastbencode(file_data)

def bencode_bencodepy():
    bdecode_bencodepy(file_data)

def check():
    print(bdecode_pyx(file_data)[b"metadata"][b"taglist"])
    print(bdecode_fastbencode(file_data)[b"metadata"][b"taglist"])
    print(bdecode_bencodepy(file_data)[b"metadata"][b"taglist"])
check()

def benchmark():
    print(timeit.timeit(bencode_pyx, number=1000))
    print(timeit.timeit(bencode_fastbencode, number=1000))
    print(timeit.timeit(bencode_bencodepy, number=1000))
benchmark()
```

They all return the same result, with the speeds being
```
0.03148120001424104
0.007315099996048957
0.06574869999894872
```
and being able to drop the build requirements is very nice