### PR TITLE
Add sensuallove.xxx scraper

### DIFF
--- a/scrapers/sensuallovexxx.yml
+++ b/scrapers/sensuallovexxx.yml
@@ -1,0 +1,34 @@
+name: "sensuallove.xxx"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - sensuallove.xxx/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //h1[@class='entry-title']/text()
+      Date:
+        selector: //script[@type="application/ld+json"]/text()
+        postProcess:
+          - replace:
+              - regex: '.*(datePublished":")(\d{4}-\d{2}-\d{2}).*'
+                with: $2
+          - parseDate: 2006-01-02
+      Performers:
+        Name:
+          selector: //div[@id="video-actors"]/a/@title
+      Tags:
+        Name:
+          selector: //div[@class="tags-list"]/a/@title
+          postProcess:
+            - replace:
+                - regex: Movies
+                  with: ""
+      Image:
+        selector: //meta[@property="og:image"]/@content
+      Studio:
+        Name:
+          fixed: "sensual.love"
+# Last Updated October 25, 2024


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] movieByURL
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

https://www.sensuallove.xxx/exploring-depth-2/
https://www.sensuallove.xxx/girls-with-a-lust-for-lovemaking-2/
https://www.sensuallove.xxx/girlfriend-intimacy-2/

## Short description

Adds a new scene scraper for sensuallove.xxx
This is a 'tour' site, which is separate from the members site which is https://sensual.love/members
