### PR TITLE
Update GayAdultEmpire.yml

### DIFF
--- a/scrapers/GayAdultEmpire.yml
+++ b/scrapers/GayAdultEmpire.yml
@@ -78,7 +78,13 @@ xPathScrapers:
       Director: //a[@label="Director"]/text()
       Image: //a[@id="front-cover"]/@data-href
       Studio:
-        Name: //a[@label="Studio"]/text()
+        Name: 
+          selector:  //a[@label="Studio"]/text()
+          concat: '__SEP__'
+          postProcess:
+            - replace:
+                - regex: '^.+__SEP__(.+)$'
+                  with:  $1
       Movies:
         Name: //h1/text()
         URL: //link[@rel="canonical"]/@href
@@ -107,4 +113,4 @@ driver:
           Domain: "www.gaydvdempire.com"
           Value: "true"
           Path: "/"
-# Last Updated October 21, 2024
+# Last Updated November 12, 2024


### PR DESCRIPTION
Changed sceneByUrl studio selector to account for scenes that have more than one studio label attribute.  Addressing #2099.

## Scraper type(s)
- [x] sceneByURL

## Examples to test
Example of a link having the issue before this change:
https://www.gaydvdempire.com/clip/836894/scene-1-streaming-scene.html

Example of a link that had only one studio label to verify these scenes are not affected by change:
https://www.gaydvdempire.com/clip/1698707/angel-elias-riding-marco-alessandro-streaming-scene.html

## Short description

Studio selector for sceneByURL was looking for a specific tag.  Most scenes would scrape file, while some would be in the format of "from MOVIE by STUDIO" where both "MOVIE" and "STUDIO" would have the tag used in the selector.  Before the change we were matching only on the first tag found.  The change will chain all values of the tag and select the last one in the list, on the assumption that the final tag will be the studio.