### PR TITLE
Update AdultSiteRunner.yml

### DIFF
--- a/scrapers/AdultSiteRunner.yml
+++ b/scrapers/AdultSiteRunner.yml
@@ -2,24 +2,24 @@ name: Raunchy Bastards
 sceneByURL:
   - action: scrapeXPath
     url:
-      - boundjocks.com/scene/
-      - boyshalfwayhouse.com/scene/
-      - coltstudiogroup.com/scene/
       - daddycarl.com/scene/
-      - hotoldermale.com/scene/
-      - monstercub.com/scene/
       - naturalbornbreeders.com/scene/
-      - older4me.com/scene/
-      - raunchybastards.com/scene/
-      - stockydudes.com/scene/
-      - toplatindaddies.com/scene/
     scraper: oldStyleSite
   - action: scrapeXPath
     url:
       - blackboyaddictionz.com/scene/
       - blacksondaddies.com/scene/
+      - boundjocks.com/scene/
+      - boyshalfwayhouse.com/scene/
+      - coltstudiogroup.com/scene/
+      - hotoldermale.com/scene/
+      - monstercub.com/scene/
       - myfirstdaddy.com/scene/
+      - older4me.com/scene/
       - playdaddy.com/scene/
+      - raunchybastards.com/scene/
+      - stockydudes.com/scene/
+      - toplatindaddies.com/scene/
     scraper: newStyleSite
 xPathScrapers:
   oldStyleSite:
@@ -54,21 +54,8 @@ xPathScrapers:
                 - regex: ^(?:https:\/\/[\w\.]*?)([^.]+)\.com.*$
                   with: $1
             - map:
-                blackboyaddictionz: Black Boy Addictionz
-                blacksondaddies: Blacks on Daddies
-                boundjocks: Bound Jocks
-                boyshalfwayhouse: Boys Halfway House
-                coltstudiogroup: Colt Studio Group
                 daddycarl: Daddy Carl
-                hotoldermale: Hot Older Male
-                monstercub: Monster Cub
-                myfirstdaddy: My First Daddy
                 naturalbornbreeders: Natural Born Breeders
-                older4me: Older4Me
-                playdaddy: Play Daddy
-                raunchybastards: Raunchy Bastards
-                stockydudees: Stocky dudes
-                toplatindaddies: Top Latin Daddies
         URL:
           selector: *image
           postProcess:
@@ -131,4 +118,4 @@ xPathScrapers:
         selector: //meta[@property="og:image"]/@content
       Tags:
         Name: $details//h5[contains(., "Categories")]/a/text()
-# Last Updated September 22, 2023
+# Last Updated November 12, 2024


### PR DESCRIPTION
Moved sites from "OldStyle" to "NewStyle" sceneByURL scraper after update for several of the studio sites.  To address #2050. 

## Scraper type(s)
- [x] sceneByURL

## Examples to test
(using New Style)
https://www.stockydudes.com/scene/1135-eat-it-then-breed-it
https://www.monstercub.com/scene/258-hunter-and-colton-split-a-snack
https://www.raunchybastards.com/scene/271-goin-gay-ain-t-so-bad
https://www.toplatindaddies.com/scene/773-you-are-in-trouble
https://www.older4me.com/scene/10880-twitter-help
https://www.hotoldermale.com/scene/839-sexy-emil-jameson-needs-roman-mercury-s-emergency-dick
https://www.coltstudiogroup.com/scene/723-colt-man-sam-vass-photoshoothttps://www.boyshalfwayhouse.com/scene/376-not-totally-useless
https://www.boundjocks.com/scene/177-mr-kristofer-fists-dolan-wolf


(using Old Style)
https://www.daddycarl.com/scene/382-carls-best-blowjobs-29

## Short description

The scraper has two sceneByURL scrapers, one for "old style" and another for "new style".  Most of the sites have been updated to use the New Style.  These URLs have been moved to the URL list for "new style" and removed from the studio mapping in the "old style".  There is a studio listed (naturalbornbreeders.com) that is resolving but isn't rendering. I'm leaving that one in Old Style for the time being in case this is a temporary issue with the site.