### PR TITLE
Add tgirlx.com to Grooby scraper

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -30,6 +30,7 @@ performerByURL:
       - tgirls.xxx/tour/models
       - tgirlsfuck.com/tour/models
       - tgirltops.com/tour/models
+      - tgirlx.com/tour/models
       - transgasm.com/tour/models
     scraper: performerScraper3
   - action: scrapeXPath
@@ -75,6 +76,7 @@ sceneByURL:
       - tgirlsfuck.com
       - tgirlshookup.com
       - tgirltops.com
+      - tgirlx.com
       - transexpov.com
       - transgasm.com
       - transnificent.com
@@ -297,4 +299,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.transvr.com/
       Tags: *tagsVR
-# Last Updated August 01, 2024
+# Last Updated November 22, 2024


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

### performerByURL

- https://www.tgirlx.com/tour/models/Eva-Maxim.html

### sceneByURL

- https://www.tgirlx.com/tour/trailers/The-Muse.html

## Short description

Adds scene and performer URL scraping for tgirlx.com to the existing Grooby scraper
