### PR TITLE
IAFD Fix Group Date Fallback

### DIFF
--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -303,7 +303,7 @@ def movie_date(tree):
         lambda d: clean_date(d.strip()),
     ) or maybe(
         tree.xpath("//h1/text()"),
-        lambda t: (re.sub(title_pattern, r"\1-01-01", t).strip() if re.match(title_pattern, t) else None),
+        lambda t: re.sub(title_pattern, r"\1-01-01", t).strip() if re.match(title_pattern, t) else None,
     )
 
 

--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -295,6 +295,7 @@ def movie_studio(tree):
 
 def movie_date(tree):
     # If there's no release date we will use the year from the title for an approximate date
+    title_pattern = re.compile(r".*\(([0-9]{4})\).*")
     return maybe(
         tree.xpath(
             '//p[@class="bioheading"][contains(text(), "Release Date")]/following-sibling::p[@class="biodata"][1]/text()'
@@ -302,7 +303,7 @@ def movie_date(tree):
         lambda d: clean_date(d.strip()),
     ) or maybe(
         tree.xpath("//h1/text()"),
-        lambda t: re.sub(r".*\(([0-9]+)\).*$", r"\1-01-01", t),
+        lambda t: (re.sub(title_pattern, r"\1-01-01", t).strip() if re.match(title_pattern, t) else None),
     )
 
 


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [X] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

[Movie](https://www.iafd.com/title.rme/id=b83c0afb-b45e-40e0-aac2-78cf51e28563)
[Movie](https://www.iafd.com/title.rme/id=c763342b-1b1e-445e-975c-079236171577)

## Short description

Newline and whitespace characters in IAFD title element (date fallback) are not matched by existing scraper.

- Fix matching extra whitespace in element text
- Don't return title if date not found
