### PR TITLE
Add thePornDB.net performer scraper

### DIFF
--- a/scrapers/ThePornDBJAV.yml
+++ b/scrapers/ThePornDBJAV.yml
@@ -34,8 +34,55 @@ movieByURL:
     scraper: movieScraper
     queryURL: "{url}"
     queryURLReplace: *redirectToAPI
+performerByName:
+  action: scrapeJson
+  queryURL: https://api.theporndb.net/performers?q={}&page=1&per_page=10
+  scraper: performerSearch
+performerByURL:
+  - action: scrapeJson
+    url:
+      - https://api.theporndb.net/performers
+    scraper: performerScraper
 
 jsonScrapers:
+  performerScraper:
+    performer:
+      Name: data.name
+      Gender: data.extras.gender
+      URL:
+        selector: data.slug
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://theporndb.net/performers/
+      Twitter: data.extras.links.Twitter
+      Instagram: data.extras.links.Instagram
+      Birthdate: data.birthday
+      DeathDate: data.deathday
+      Ethnicity: data.extras.ethnicity
+      # Country:
+      HairColor: data.extras.hair_colour
+      EyeColor: data.extras.eye_colour
+      Height: data.extras.height
+      Weight: data.extras.weight
+      Measurements: data.extras.measurements
+      FakeTits: data.extras.fake_boobs
+      # CareerLength
+      Tattoos: data.extras.tattoos
+      Piercings: data.extras.piercings
+      # Aliases
+      # Tags (see Tag fields)
+      Image: data.image
+      Details: data.bio
+  performerSearch:
+    performer:
+      Name: data.#.name
+      URL:
+        selector: data.#.id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://api.theporndb.net/performers/
   sceneSearch:
     scene:
       Title:

--- a/scrapers/ThePornDBJAV.yml
+++ b/scrapers/ThePornDBJAV.yml
@@ -63,8 +63,18 @@ jsonScrapers:
       # Country:
       HairColor: data.extras.hair_colour
       EyeColor: data.extras.eye_colour
-      Height: data.extras.height
-      Weight: data.extras.weight
+      Height:
+        selector: data.extras.height
+        postProcess:
+          - replace:
+              - regex: \D
+                with:
+      Weight:
+        selector: data.extras.weight
+        postProcess:
+          - replace:
+              - regex: \D
+                with:
       Measurements: data.extras.measurements
       FakeTits: data.extras.fake_boobs
       # CareerLength

--- a/scrapers/ThePornDBJAV.yml
+++ b/scrapers/ThePornDBJAV.yml
@@ -60,7 +60,7 @@ jsonScrapers:
       Birthdate: data.birthday
       DeathDate: data.deathday
       Ethnicity: data.extras.ethnicity
-      # Country:
+      Country: data.extras.birthplace_code
       HairColor: data.extras.hair_colour
       EyeColor: data.extras.eye_colour
       Height:
@@ -80,7 +80,7 @@ jsonScrapers:
       # CareerLength
       Tattoos: data.extras.tattoos
       Piercings: data.extras.piercings
-      # Aliases
+      Aliases: data.aliases
       # Tags (see Tag fields)
       Image: data.image
       Details: data.bio

--- a/scrapers/ThePornDBMovies.yml
+++ b/scrapers/ThePornDBMovies.yml
@@ -34,8 +34,55 @@ movieByURL:
     scraper: movieScraper
     queryURL: "{url}"
     queryURLReplace: *redirectToAPI
+performerByName:
+  action: scrapeJson
+  queryURL: https://api.theporndb.net/performers?q={}&page=1&per_page=10
+  scraper: performerSearch
+performerByURL:
+  - action: scrapeJson
+    url:
+      - https://api.theporndb.net/performers
+    scraper: performerScraper
 
 jsonScrapers:
+  performerScraper:
+    performer:
+      Name: data.name
+      Gender: data.extras.gender
+      URL:
+        selector: data.slug
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://theporndb.net/performers/
+      Twitter: data.extras.links.Twitter
+      Instagram: data.extras.links.Instagram
+      Birthdate: data.birthday
+      DeathDate: data.deathday
+      Ethnicity: data.extras.ethnicity
+      # Country:
+      HairColor: data.extras.hair_colour
+      EyeColor: data.extras.eye_colour
+      Height: data.extras.height
+      Weight: data.extras.weight
+      Measurements: data.extras.measurements
+      FakeTits: data.extras.fake_boobs
+      # CareerLength
+      Tattoos: data.extras.tattoos
+      Piercings: data.extras.piercings
+      # Aliases
+      # Tags (see Tag fields)
+      Image: data.image
+      Details: data.bio
+  performerSearch:
+    performer:
+      Name: data.#.name
+      URL:
+        selector: data.#.id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://api.theporndb.net/performers/
   sceneSearch:
     scene:
       Title:

--- a/scrapers/ThePornDBMovies.yml
+++ b/scrapers/ThePornDBMovies.yml
@@ -63,8 +63,18 @@ jsonScrapers:
       # Country:
       HairColor: data.extras.hair_colour
       EyeColor: data.extras.eye_colour
-      Height: data.extras.height
-      Weight: data.extras.weight
+      Height:
+        selector: data.extras.height
+        postProcess:
+          - replace:
+              - regex: \D
+                with:
+      Weight:
+        selector: data.extras.weight
+        postProcess:
+          - replace:
+              - regex: \D
+                with:
       Measurements: data.extras.measurements
       FakeTits: data.extras.fake_boobs
       # CareerLength

--- a/scrapers/ThePornDBMovies.yml
+++ b/scrapers/ThePornDBMovies.yml
@@ -60,7 +60,7 @@ jsonScrapers:
       Birthdate: data.birthday
       DeathDate: data.deathday
       Ethnicity: data.extras.ethnicity
-      # Country:
+      Country: data.extras.birthplace_code
       HairColor: data.extras.hair_colour
       EyeColor: data.extras.eye_colour
       Height:
@@ -80,7 +80,7 @@ jsonScrapers:
       # CareerLength
       Tattoos: data.extras.tattoos
       Piercings: data.extras.piercings
-      # Aliases
+      Aliases: data.aliases
       # Tags (see Tag fields)
       Image: data.image
       Details: data.bio


### PR DESCRIPTION
## Scraper type(s)
- [X] performerByName
- [ ] performerByFragment
- [X] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

Yui Hatano:

![Screenshot 2024-11-30 193001](https://github.com/user-attachments/assets/a982608f-b0d1-4055-86a0-fb90a8b70753)

## Short description

Adds a performer scraper for the two metadata scrapers for "theporndb.net".
