### PR TITLE
Parse different datetime formats

### DIFF
--- a/scrapers/FileMetadata/FileMetadata.py
+++ b/scrapers/FileMetadata/FileMetadata.py
@@ -60,7 +60,7 @@ def scrape_file(path):
         scene["details"] = description
 
     if date := metadata_insensitive.get("date"):
-        scene["date"] = datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
+        scene["date"] = datetime.fromisoformat(date).strftime("%Y-%m-%d")
 
     if date := metadata_insensitive.get("creation_time"):
         scene["date"] = date[:10]

--- a/scrapers/FileMetadata/FileMetadata.yml
+++ b/scrapers/FileMetadata/FileMetadata.yml
@@ -6,4 +6,4 @@ sceneByFragment:
   script:
     - python
     - FileMetadata.py
-# Last Updated April 07, 2024
+# Last Updated Dec 03, 2024


### PR DESCRIPTION

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [X] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

## Short description
ffmpeg and ffprobe use [this](https://ffmpeg.org/ffmpeg-utils.html#Date) syntax for dates and times. [fromisoformat](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) should be able to parse any form that ffprobe can produce. 
