### PR TITLE
Iafd alias fix

### DIFF
--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -500,7 +500,7 @@ def main():
     result = {}
     if args.operation == "performer":
         result = performer_from_tree(scraped)
-        result["url"] = iafd_uuid_url
+        result["urls"] = [iafd_uuid_url]
     elif args.operation == "movie":
         result = movie_from_tree(scraped)
     elif args.operation == "scene":

--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -236,7 +236,9 @@ def performer_eyecolor(tree):
 
 def performer_aliases(tree):
     aliases = tree.xpath(
-        '//div[p[@class="bioheading" and contains(normalize-space(text()),"Performer AKA")]]//div[@class="biodata" and not(normalize-space(text())="No known aliases")]/text()'
+        '//div[p[@class="bioheading" and contains(normalize-space(text()),"Performer AKA")'
+        'or contains(normalize-space(text()),"AKA")]]'
+        '//div[@class="biodata" and not(normalize-space(text())="No known aliases")]/text()'
     )
     return ", ".join([clean_alias(alias.strip()) for alias in aliases if alias])
 

--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -240,7 +240,7 @@ def performer_aliases(tree):
         'or contains(normalize-space(text()),"AKA")]]'
         '//div[@class="biodata" and not(normalize-space(text())="No known aliases")]/text()'
     )
-    return ", ".join([clean_alias(alias.strip()) for alias in aliases if alias])
+    return ", ".join([y for x in aliases for y in [clean_alias(x.strip())] if y])
 
 
 def performer_careerlength(tree):


### PR DESCRIPTION
I noticed IAFD changed the layout when a performer is also active as director. As a result, the IAFD scraper didn't grab the alias

For example [Jules Jordan](https://www.iafd.com/person.rme/id=d5d8c2da-efe7-41ef-99a3-46a1aebccd07) or [Dana DeArmond](https://www.iafd.com/person.rme/id=3659f3a2-2fad-4880-b20a-517b94b8cfd6)
When also active as director, IAFD changed ``Performer AKA`` to ``AKA``

Plus a small fix for performer urls