### PR TITLE
fix: VirtualRealTrans: maintain newlines in scene description

### DIFF
--- a/scrapers/VirtualRealTrans.yml
+++ b/scrapers/VirtualRealTrans.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: VirtualRealTrans
 
 sceneByURL:
@@ -60,6 +61,10 @@ xPathScrapers:
       Details: &detailsSel
         selector: //div[@class="description_container"]/p
         concat: "\n\n"
+        postProcess:
+          - replace:
+              - regex: ([A-Za-z])(\.)([A-Za-z])
+                with: "$1$2\n\n$3"
       Tags:
         Name:
           selector: //div[@class="metaHolder"]//a/span/text()|//script[@type="application/ld+json"][contains(text(),"genre")]/text()
@@ -153,4 +158,4 @@ xPathScrapers:
               }
               return value
       Image: //div[@class="feature_img_model"]/img/@src
-# Last Updated August 21, 2024
+# Last Updated December 16, 2024

--- a/scrapers/VirtualRealTrans.yml
+++ b/scrapers/VirtualRealTrans.yml
@@ -63,8 +63,8 @@ xPathScrapers:
         concat: "\n\n"
         postProcess:
           - replace:
-              - regex: ([A-Za-z])(\.)([A-Za-z])
-                with: "$1$2\n\n$3"
+              - regex: (?:[A-Za-z])(\.)(?:^com|^\s)
+                with: "$1\n\n"
       Tags:
         Name:
           selector: //div[@class="metaHolder"]//a/span/text()|//script[@type="application/ld+json"][contains(text(),"genre")]/text()


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://virtualrealtrans.com/vr-trans-porn-video/best-compilation/
- https://virtualrealtrans.com/vr-trans-porn-video/symptoms-of-attraction/
- https://virtualrealtrans.com/vr-trans-porn-video/valentines-surprise/ (this contains VirtualRealTrans.com. in the description, which shows the change adds a newline for the correct `.` scenario)

## Short description

Currently, the description is parsed in such a way that the source newlines from the `<br>` tags are being dropped entirely, resulting in the last word and `.` in a paragraph being followed immediately by the first character of the next paragraph.

This change uses this consistent parsing behaviour to add newlines at these points, to maintain the intended paragraph separation.

### Notes

Simple regex has been used instead of using non-capturing, look-behind, look-ahead, `\w` (word characters), as it appears stashdb regex implementation is limited/basic and does not properly support these features.