### PR TITLE
fix: Coomer.su sceneByFragment failing if file path contains any non english characters

### DIFF
--- a/scrapers/Coomer/Coomer.py
+++ b/scrapers/Coomer/Coomer.py
@@ -5,6 +5,7 @@ import stashapi.log as log
 import requests
 import re
 from bs4 import BeautifulSoup as bs
+import io
 
 # TODO: Enable searching from other fields?
 
@@ -18,6 +19,7 @@ def debugPrint(t):
 
 # Get JSON from Stash
 def readJSONInput():
+    sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     input = sys.stdin.read()
     return json.loads(input)
 


### PR DESCRIPTION
Coomer scrapper fails to scan by fragment, if video/image file path contains any non english characters due to encoding issues. 

For example:
[Scrape / Coomer] FileNotFoundError: [Errno 2] No such file or directory: 'G:\\Coomer\\yuzukitty\\gallery-dl\\coomerparty\\onlyfans\\[2021-03-23T13_17_34]126225299 - P站付费的旗�\udc8d黑�\udc9d完整版�\udc9d�到Onlyfans啦�\udc81�\xa0喜欢撕�\xa0��\udc9d袜嘛~柚�\xad\udc90猫觉得那是最刺激的啦~This is the p\\Videos\\126225299_P站付费的旗�\udc8d黑�\udc9d完整版�\udc9d�到Onlyfans啦�\udc81�\xa0喜欢撕�\xa0��\udc9d袜嘛~柚�\xad\udc90猫觉得那是最刺激的啦~This is the p.._01_8e881dc6-9574-4212-8028-eefbf75f98f5.mp4'

This change wraps sys.stdin in a utf-8 buffer so it can successfully read any non english utf-8 characters. This helps to resolve scanning issues if file path contains non english character.
