### PR TITLE
Fix RealJamVR

### DIFF
--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -9,6 +9,13 @@ sceneByURL: &byURL
 
 galleryByURL: *byURL
 
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - porncornvr.com/actor/
+      - realjamvr.com/actor/
+    scraper: performerScraper
+
 xPathScrapers:
   sceneScraper:
     scene:
@@ -59,5 +66,38 @@ xPathScrapers:
       Tags: *tags
       Details: *details
       Studio: *studio
-      
+  performerScraper:
+    performer:
+      Name: //h1
+      Gender: //div[span[text()="Gender:"]]/text()
+      Country:
+        selector: //div[span[text()="Birth Place:"]]/text()
+        postProcess:
+          - replace:
+              - regex: .*,
+                with: ""
+      Birthdate:
+        selector: //div[span[text()="Date of Birth:"]]/text()
+        postProcess:
+          - parseDate: Jan. 2, 2006
+          - parseDate: January 2, 2006
+      Height:
+        selector: //div[span[text()="Height:"]]/text()
+        postProcess:
+          - replace:
+              - regex: .*\ (\d+)\ cm.*
+                with: $1
+      Weight:
+        selector: //div[span[text()="Weight:"]]/text()
+        postProcess:
+          - replace:
+              - regex: .*\ (\d+)\ kg.*
+                with: $1
+      HairColor: //div[span[text()="Hair color:"]]/text()
+      EyeColor: //div[span[text()="Eyes color:"]]/text()
+      Tags:
+        Name: //div[span[text()="Tags:"]]/a/text()
+      Image: //div[contains(@class, "actor-view")]//img/@src
+      Piercings: //div[span[text()="Piercing:"]]/text()
+      Tattoos: //div[span[text()="Tattoo:"]]/text()
 # Last Updated January 8, 2025

--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: RealJamVR
 sceneByURL: &byURL
   - action: scrapeXPath
@@ -27,9 +28,15 @@ xPathScrapers:
       Performers: &performers
         Name: //div[contains(@class,"scene-view")]/a[contains(@href,"/actor/")]
       Tags: &tags
-        Name: //a[starts-with(@href, "/scenes") and @class="tag"]/text() | //div[not(@class)]/div[@class="specs-icon" and not(i)]
+        Name:
+          selector: //a[starts-with(@href, "/scenes") and @class="tag"]/text() | //div[not(@class)]/div[@class="specs-icon"]
+          postProcess:
+            - replace:
+                # use the duration "specs-icon" as a fixed value replacement "hack"
+                - regex: \d+:\d+:\d+
+                  with: Virtual Reality
       Details: &details
-        selector: //div[@class="opacity-75 my-2"]
+        selector: //div[contains(@class, "collapse-content-wrapper")]/div[contains(@class, "collapse-content")]
       Image:
         selector: //*[@id="video-player"]//@poster
       Studio: &studio
@@ -39,6 +46,12 @@ xPathScrapers:
           - replace:
               - regex: '(.*)\| ([^\|]+VR)$'
                 with: $2
+      Code:
+        selector: //dl8-video/source[1]/@src
+        postProcess:
+          - replace:
+              - regex: .*/scenes/(\d+)/.*
+                with: $1
     gallery:
       Title: *title
       Date: *date
@@ -47,4 +60,4 @@ xPathScrapers:
       Details: *details
       Studio: *studio
       
-# Last Updated October 22, 2023
+# Last Updated January 8, 2025

--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -28,10 +28,9 @@ xPathScrapers:
       Date: &date
         selector: //div[@class="specs-icon"]/following-sibling::strong
         postProcess:
-          - replace:
-            - regex: ^([a-zA-Z]{3})\D*(\d{1,2},\s*\d+)$
-              with: $1. $2
+          # both date formats are used interchangeably
           - parseDate: Jan. 2, 2006
+          - parseDate: January 2, 2006
       Performers: &performers
         Name: //div[contains(@class,"scene-view")]/a[contains(@href,"/actor/")]
       Tags: &tags
@@ -58,6 +57,8 @@ xPathScrapers:
         postProcess:
           - replace:
               - regex: .*/scenes/(\d+)/.*
+                with: $1
+              - regex: .*/videos_app/\w+/(\d+)_.*
                 with: $1
     gallery:
       Title: *title

--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -79,6 +79,7 @@ xPathScrapers:
       Birthdate:
         selector: //div[span[text()="Date of Birth:"]]/text()
         postProcess:
+          # both date formats are used interchangeably
           - parseDate: Jan. 2, 2006
           - parseDate: January 2, 2006
       Height:


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByURL
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

### performerByURL

- https://porncornvr.com/actor/lexi-lore/
- https://realjamvr.com/actor/valentina-nappi/
- https://porncornvr.com/actor/charlie-forde/

### sceneByURL

- https://porncornvr.com/scene/threesome-passion-compilation/
- https://realjamvr.com/scene/hot-orgies-compilation-3/
- https://realjamvr.com/scene/threesome-ex-knows-best/
- https://realjamvr.com/scene/anal-satisfaction/

### galleryByURL

The scene photo sets look like they are on the same page as the video content of the scene, so you should be able to use the example URLs above

## Short description

- sceneByURL
  - fix: details selector updated
  - improvement: studio code added
  - improvement: "Virtual Reality" fixed tag added to scraped tags
- galleryByURL 
  - (inherited) fix: details selector updated
  - (inherited) improvement: "Virtual Reality" fixed tag added to scraped tags
- performerByURL
  - added with all fields discovered via browsing
