### PR TITLE
get highest resolution cover image

### DIFF
--- a/scrapers/VRPorn.yml
+++ b/scrapers/VRPorn.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: "VRPorn"
 
 sceneByURL:
@@ -38,7 +39,12 @@ xPathScrapers:
         Name: $header//div[@class="name_pornstar"]/text()
       Studio:
         Name: $header//a[@id="studio-logo"]//span[@class="footer-titles"]/text()
-      Image: //main/article/header//dl8-video/@poster
+      Image:
+        selector: //main/article/header//dl8-video/@poster
+        postProcess:
+          - replace:
+              - regex: -\d+x\d+
+                with: ""
       URL: &sceneUrl //link[@rel="canonical"]/@href
   sceneSearch:
     common:
@@ -49,4 +55,4 @@ xPathScrapers:
       Image: $videos//div[@class="tube-thumbnail-wrapper"]/img/@src
       Studio:
         Name: $videos//div[@class="post_links"]/span[@class="left_links"]/text()
-# Last Updated April 26, 2024
+# Last Updated January 10, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://vrporn.com/trans-the-personal-touch/
- https://vrporn.com/hot-blonde-teen-dylan-is-multi-orgasmic/

## Short description

This removes the size variant from the filename, e.g.

https://mcdn.vrporn.com/files/20241122080315/Trans-The-Personal-Touch-VRBTrans-vr-porn-video-1000x562.jpg
becomes
https://mcdn.vrporn.com/files/20241122080315/Trans-The-Personal-Touch-VRBTrans-vr-porn-video.jpg

with the latter being 1300x731. This size varies with studio and scene, but appears to be consistently higher than the one presented as the video cover image on the scene page, e.g.

https://mcdn.vrporn.com/files/20250106180526/Hot-blonde-teen-Dylan-is-multi-orgasmic-Dylan-Moore-LethalHardcoreVR-vr-porn-video-1000x667.jpg
becomes
https://mcdn.vrporn.com/files/20250106180526/Hot-blonde-teen-Dylan-is-multi-orgasmic-Dylan-Moore-LethalHardcoreVR-vr-porn-video.jpg
which is 1920x1280
