### PR TITLE
fix: adjust regex replace to match WxH only at end of filename (vrporn.com)

### DIFF
--- a/scrapers/VRPorn.yml
+++ b/scrapers/VRPorn.yml
@@ -43,7 +43,7 @@ xPathScrapers:
         selector: //main/article/header//dl8-video/@poster
         postProcess:
           - replace:
-              - regex: (.*)(-\d+x\d+)(.jpg)
+              - regex: (.*)(-\d+x\d+)(\.\w+$)
                 with: $1$3
       URL: &sceneUrl //link[@rel="canonical"]/@href
   sceneSearch:

--- a/scrapers/VRPorn.yml
+++ b/scrapers/VRPorn.yml
@@ -43,8 +43,8 @@ xPathScrapers:
         selector: //main/article/header//dl8-video/@poster
         postProcess:
           - replace:
-              - regex: -\d+x\d+
-                with: ""
+              - regex: (.*)(-\d+x\d+)(.jpg)
+                with: $1$3
       URL: &sceneUrl //link[@rel="canonical"]/@href
   sceneSearch:
     common:


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://vrporn.com/trans-the-best-teen-compilation/

## Short description

Though #2159 was an improvement to get higher resolution images, there is an edge case where the filename includes more than one WxH occurrence, e.g.

https://vrporn.com/trans-the-best-teen-compilation/
has
https://mcdn.vrporn.com/files/20240925170921/The-Best-Teen-Compilation_Hard_slider-2000x1000-1-1000x562.jpg
which needs to only remove the -WxH at the end to become
https://mcdn.vrporn.com/files/20240925170921/The-Best-Teen-Compilation_Hard_slider-2000x1000-1.jpg
which exists

This regex replace adjustment achieves this.
