### PR TITLE
fix date parsing to handle month strings between 3 characters and full

### DIFF
--- a/scrapers/RealJamVR.yml
+++ b/scrapers/RealJamVR.yml
@@ -29,8 +29,14 @@ xPathScrapers:
         selector: //div[@class="specs-icon"]/following-sibling::strong
         postProcess:
           # both date formats are used interchangeably
-          - parseDate: Jan. 2, 2006
-          - parseDate: January 2, 2006
+          # e.g.
+          # Jan. 2, 2006
+          # January 2, 2006
+          # Sept. 2, 2024
+          - replace:
+              - regex: ([\w]{3})([^\ ]+)?(.*)
+                with: $1$3
+          - parseDate: Jan 2, 2006
       Performers: &performers
         Name: //div[contains(@class,"scene-view")]/a[contains(@href,"/actor/")]
       Tags: &tags
@@ -102,4 +108,4 @@ xPathScrapers:
       Image: //div[contains(@class, "actor-view")]//img/@src
       Piercings: //div[span[text()="Piercing:"]]/text()
       Tattoos: //div[span[text()="Tattoo:"]]/text()
-# Last Updated January 8, 2025
+# Last Updated January 10, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://realjamvr.com/scene/matty-mila-perez-tries-anal/ (date is "Sept. 2, 2024")
- https://realjamvr.com/scene/threesome-ex-knows-best/ (date is "Jan. 7, 2025")
- https://realjamvr.com/scene/sweet-trio/ (date is "April 26, 2017")

## Short description

This lets the date parsing handle the date format variants used on the site as shown above
