### PR TITLE
improve IAFD - add new gender parsing: tf, tm

### DIFF
--- a/scrapers/IAFD/IAFD.py
+++ b/scrapers/IAFD/IAFD.py
@@ -75,6 +75,8 @@ def map_gender(gender: str):
     genders = {
         "f": "Female",
         "m": "Male",
+        "tf": "Transgender Female",
+        "tm": "Transgender Male",
     }
     return genders.get(gender, gender)
 
@@ -195,21 +197,26 @@ def performer_url(tree):
 
 
 def performer_gender(tree):
-    def prepend_transgender(gender: str):
+    def parse_transgender(gender: str):
+        # get trans genders from the short code supplied
+        if gender in ['tf', 'tm']:
+            return map_gender(gender)
+
+        # next, attempt to get the trans gender from the performer id suffix
         perf_id = next(
             iter(tree.xpath('//form[@id="correct"]/input[@name="PerfID"]/@value')), ""
         )
         trans = (
             "Transgender "
             # IAFD are not consistent with their URLs
-            if any(mark in perf_id for mark in ("_ts", "_ftm", "_mtf"))
+            if any(mark in perf_id.lower() for mark in ("_ts", "_ftm", "_mtf"))
             else ""
         )
         return trans + map_gender(gender)
 
     return maybe(
         tree.xpath('//form[@id="correct"]/input[@name="Gender"]/@value'),
-        prepend_transgender,
+        parse_transgender,
     )
 
 

--- a/scrapers/IAFD/IAFD.yml
+++ b/scrapers/IAFD/IAFD.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../validator/scraper.schema.json
 name: IAFD
 # requires: py_common
 
@@ -34,4 +35,4 @@ movieByURL:
       - python
       - IAFD.py
       - movie
-# Last Updated December 03, 2024
+# Last Updated January 20, 2025


### PR DESCRIPTION
- [x] performerByURL

## Examples to test

male: https://www.iafd.com/person.rme/id=8cd72e74-8e0e-4fa5-9910-43661c44a6b5
female: https://www.iafd.com/person.rme/id=052624ea-39b7-4488-b42f-cb8259e468b8
trans-male: https://www.iafd.com/person.rme/id=9fc31d4a-7e77-4dc0-b9da-62c74ad356f1
trans-female: https://www.iafd.com/person.rme/id=26556fdd-0946-42e2-b1b4-65f168817c38

## Short description

IAFD has now added gender short "codes" `tf` and `tm` for Trans-female and Trans-male. The python script is updated to handle these while still keeping the old behaviour in case any transgender performers in IAFD still have the old/limited info (where the performer ID is used to determine a transgender variant of the gender).

For some performers, the `perf_id` string ends with "_TS" (i.e. uppercase) and the `any` function was not matching, so a `.lower()` has been added to fix that.
