### PR TITLE
Fix ashemaletube performerByURL

### DIFF
--- a/scrapers/AShemaleTube/AShemaleTube.py
+++ b/scrapers/AShemaleTube/AShemaleTube.py
@@ -1,0 +1,79 @@
+import json
+from lxml import html
+import sys
+
+from py_common import log
+from py_common.deps import ensure_requirements
+from py_common.types import (
+    ScrapedPerformer,
+)
+from py_common.util import scraper_args
+
+ensure_requirements("cloudscraper")
+import cloudscraper  # noqa: E402
+
+scraper = cloudscraper.create_scraper(
+    # browser={
+    #     'browser': 'firefox',
+    #     'platform': 'windows',
+    #     'mobile': False
+    # }
+    debug = True,
+)
+
+def scrapeUrl(url):
+    page_content = scrapeUrlToString(url)
+    log.debug(f"page_content: {page_content}")
+    try:
+        tree = html.document_fromstring(page_content)
+        return tree
+    except Exception as e:
+        log.error(f"html parsing failed: {e}")
+        sys.exit(1)
+
+
+def scrapeUrlToString(url):
+    scraper = cloudscraper.create_scraper()
+    try:
+        scraped = scraper.get(url)
+        log.debug(f"scraped.status_code: {scraped.status_code}")
+    except:
+        log.error("scrape error")
+        sys.exit(1)
+
+    if scraped.status_code >= 400:
+        log.error('HTTP Error: %s' % scraped.status_code)
+        sys.exit(1)
+
+    return scraped.content
+
+
+def performer_from_url(url) -> ScrapedPerformer | None:
+    performer: ScrapedPerformer = {}
+    try:
+        tree = scrapeUrl(url)
+        log.debug(f"tree: {tree}")
+        name_h1 = next(iter(tree.xpath('//h1[contains(@class, "content-name")]')), None)
+        if name_h1 is not None:
+            performer["name"] = name_h1.text
+    except Exception as e:
+        log.error(f'error happened: {e}')
+    performer["url"] = url
+    log.debug(f"performer: {performer}")
+    return performer
+
+
+if __name__ == "__main__":
+    op, args = scraper_args()
+
+    result = None
+    match op, args:
+        case "performer-by-url", {"url": url}:
+            result = performer_from_url(url)
+        case _:
+            log.error(
+                f"Not implemented: Operation: {op}, arguments: {json.dumps(args)}"
+            )
+            sys.exit(1)
+
+    print(json.dumps(result))

--- a/scrapers/AShemaleTube/AShemaleTube.py
+++ b/scrapers/AShemaleTube/AShemaleTube.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 import json
 from lxml import html
+import re
 import sys
+from urllib.parse import urlparse, urlunparse
 
 from py_common import log
 from py_common.deps import ensure_requirements
@@ -11,55 +14,131 @@ from py_common.util import scraper_args
 
 ensure_requirements("cloudscraper")
 import cloudscraper  # noqa: E402
+ensure_requirements("fp:free-proxy")
+from fp.fp import FreeProxy
 
-scraper = cloudscraper.create_scraper(
-    # browser={
-    #     'browser': 'firefox',
-    #     'platform': 'windows',
-    #     'mobile': False
-    # }
-    debug = True,
-)
+
+scraper = cloudscraper.create_scraper()
+
+free_proxies = None
+
+
+def get_proxies() -> dict:
+    proxy = FreeProxy(rand=True).get()
+    log.debug("proxy: %s" % proxy)
+    return { 'http': proxy } if proxy.startswith('http:') else { 'https': proxy }
+
+def li_value(key: str) -> str:
+    return f'//div[@class="info-box info"]/ul/li/span[text()="{key}:"]/../text()[2]'
+
+
+def parse_date(date_string: str) -> str:
+    try:
+        return datetime.strftime(datetime.strptime(date_string, "%d %B %Y"), "%Y-%m-%d")
+    except:
+        return date_string
+
 
 def scrapeUrl(url):
-    page_content = scrapeUrlToString(url)
-    log.debug(f"page_content: {page_content}")
-    try:
-        tree = html.document_fromstring(page_content)
-        return tree
-    except Exception as e:
-        log.error(f"html parsing failed: {e}")
-        sys.exit(1)
+    return html.document_fromstring(scrapeUrlToString(url))
 
 
-def scrapeUrlToString(url):
-    scraper = cloudscraper.create_scraper()
-    try:
-        scraped = scraper.get(url)
-        log.debug(f"scraped.status_code: {scraped.status_code}")
-    except:
-        log.error("scrape error")
-        sys.exit(1)
+def scrapeUrlToString(url, max_retries=5):
+    retries = 0
+    while retries < max_retries:
+        try:
+            log.debug('about to execute scraper.get, attempt %d' % (retries + 1))
+            global free_proxies
+            free_proxies = get_proxies()
+            scraped = scraper.get(url, proxies=free_proxies)
+            if scraped.status_code == 200:
+                log.debug('HTTP Status: 200')
+                return scraped.text
+            else:
+                log.error('HTTP Error: %s' % scraped.status_code)
+        except Exception as e:
+            log.error("scraper.get error: %s" % e)
+        
+        retries += 1
+        log.debug('Retrying (%d/%d)...' % (retries, max_retries))
+    
+    raise Exception('Failed to scrape the URL after %d retries' % max_retries)
 
-    if scraped.status_code >= 400:
-        log.error('HTTP Error: %s' % scraped.status_code)
-        sys.exit(1)
 
-    return scraped.content
+def remove_query(url: str) -> str:
+    return urlunparse(urlparse(url)._replace(query=""))
 
 
 def performer_from_url(url) -> ScrapedPerformer | None:
     performer: ScrapedPerformer = {}
     try:
         tree = scrapeUrl(url)
-        log.debug(f"tree: {tree}")
-        name_h1 = next(iter(tree.xpath('//h1[contains(@class, "content-name")]')), None)
-        if name_h1 is not None:
-            performer["name"] = name_h1.text
+        if (name := next(iter(tree.xpath('//h1[contains(@class, "content-name") or contains(@class, "username")]/text()')), None)) is not None:
+            performer["name"] = name.strip()
+        else:
+            log.warning("could not scrape name")
+        if (aliases := next(iter(tree.xpath(li_value('AKA'))), None)) is not None:
+            performer["aliases"] = aliases.strip()
+        else:
+            log.warning("could not scrape aliases")
+        if (birthdate := next(iter(tree.xpath(li_value('Date of Birth'))), None)) is not None:
+            performer["birthdate"] = parse_date(birthdate.strip())
+        else:
+            log.warning("could not scrape birthdate")
+        if (status := next(iter(tree.xpath(li_value('Status'))), None)) is not None:
+            if (match := re.search(r"\d{1,2} \w+ \d{4}", status.strip())):
+                performer["death_date"] = parse_date(match.group())
+            else:
+                log.warning('could not parse death_date from status: %s' % status)
+        else:
+            log.debug("could not scrape death_date")
+        if (country := next(iter(tree.xpath(li_value('Country'))), None)) is not None:
+            performer["country"] = country.strip()
+        else:
+            log.warning("could not scrape country")
+        if (eye_color := next(iter(tree.xpath(li_value('Eye Color'))), None)) is not None:
+            performer["eye_color"] = eye_color.strip()
+        else:
+            log.warning("could not scrape eye_color")
+        if (hair_color := next(iter(tree.xpath(li_value('Hair Color'))), None)) is not None:
+            performer["hair_color"] = hair_color.strip()
+        else:
+            log.warning("could not scrape hair_color")
+        if (ethnicity := next(iter(tree.xpath(li_value('Ethnicity'))), None)) is not None:
+            performer["ethnicity"] = ethnicity.strip()
+        else:
+            log.warning("could not scrape ethnicity")
+        if (height := next(iter(tree.xpath(li_value('Height'))), None)) is not None:
+            performer["height"] = re.sub(r"(\d+) cm.*", r"\1", height.strip())
+        else:
+            log.warning("could not scrape height")
+        if (tags := iter(tree.xpath('//a[@class="tag-item"]/text()')), None) is not None:
+            performer["tags"] = [ { 'name': tag } for tag in tags ]
+        else:
+            log.warning("could not scrape tags")
+        if (image := next(iter(tree.xpath('//div[@class="user-photo"]/img/@src')), None)) is not None:
+            performer["images"] = [image]
+        else:
+            log.warning("could not scrape image")
+        performer["urls"] = [url] 
+        if (social_media_links_out := iter(tree.xpath('//a[starts-with(@class, " social-")]/@href')), None) is not None:
+            social_media_urls = [
+                remove_query(scraper.get(f"https://www.ashemaletube.com{link_out}", proxies=free_proxies).url)
+                for link_out in social_media_links_out
+            ]
+            log.debug("social media urls: %s" % social_media_urls)
+            performer["urls"].extend(social_media_urls)
+        else:
+            log.warning("could not scrape twitter")
+        if (website_links := iter(tree.xpath('//div[@class="info-box info"]/ul/li/span[text()="Website:"]/following-sibling::a/@href')), None) is not None:
+            website_urls = [ remove_query(url) for url in website_links ]
+            log.debug("website_urls: %s" % website_urls)
+            performer["urls"].extend(website_urls)
+        else:
+            log.warning("could not scrape website links")
     except Exception as e:
-        log.error(f'error happened: {e}')
-    performer["url"] = url
-    log.debug(f"performer: {performer}")
+        log.error('error happened: %s' % e)
+    log.debug("performer: %s" % performer)
     return performer
 
 
@@ -76,4 +155,5 @@ if __name__ == "__main__":
             )
             sys.exit(1)
 
+    log.debug("result: %s" % result)
     print(json.dumps(result))

--- a/scrapers/AShemaleTube/AShemaleTube.py
+++ b/scrapers/AShemaleTube/AShemaleTube.py
@@ -129,7 +129,7 @@ def performer_from_url(url) -> ScrapedPerformer | None:
             log.debug("social media urls: %s" % social_media_urls)
             performer["urls"].extend(social_media_urls)
         else:
-            log.warning("could not scrape twitter")
+            log.warning("could not scrape social media links")
         if (website_links := iter(tree.xpath('//div[@class="info-box info"]/ul/li/span[text()="Website:"]/following-sibling::a/@href')), None) is not None:
             website_urls = [ remove_query(url) for url in website_links ]
             log.debug("website_urls: %s" % website_urls)

--- a/scrapers/AShemaleTube/AShemaleTube.yml
+++ b/scrapers/AShemaleTube/AShemaleTube.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../validator/scraper.schema.json
 name: AShemaleTube
 
 performerByName:
@@ -5,10 +6,13 @@ performerByName:
   queryURL: "https://www.ashemaletube.com/models/?modelsearchSubmitCheck=FORM_SENDED&key=models&mode=model-search&searchName={}&submitModelSearch=Search&filterCountry=&filterHair=&filterEthnicity=&filterEyes=&filterPenis=&filterBreast=&mode=model-search"
   scraper: performerSearch
 performerByURL:
-  - action: scrapeXPath
+  - action: script
     url:
       - ashemaletube.com/model/
-    scraper: performerScraper
+    script:
+      - python
+      - AShemaleTube.py
+      - performer-by-url
 sceneByName:
   action: scrapeXPath
   queryURL: "https://www.ashemaletube.com/search/{}/?sort=re"
@@ -120,4 +124,4 @@ xPathScrapers:
                   with: https://www.ashemaletube.com/
       Image: //meta[@property="og:image"]/@content
       URL: //meta[@property="og:url"]/@content
-# Last Updated September 29, 2022
+# Last Updated January 20, 2025


### PR DESCRIPTION
- [x] performerByURL

## Examples to test

- https://www.ashemaletube.com/model/domino-presley-796-m9nr/
- https://www.ashemaletube.com/model/bailey-jay-308-m0xx/
- https://www.ashemaletube.com/model/daisy-taylor-5700-m1h4/

## Short description

The ashemaletube.com site now has cloudflare protection. This refactor to Python makes use of `cloudscraper` to bypass the protection, and `FreeProxy` to improve the success chance of fetching the page successfully.

Each time a request is made via cloudscraper with a proxy, if a non-200 http status code is retrieved (i.e. usually 403 due to blocking) then another random proxy is used and the request re-attempted, until the response is a 200, or the max retries is reached. When the page is fetched successfully, the proxy used is used again to resolve any outgoing social media links (which are ashemaletube.com links that forward to the respective external URLs)

Due to the cloudflare protection, the scraping is not always successful, but it can be tried again until it succeeds. I would say the success rate is >95% for me, which is much better than it succeeding a constant 0% of the time.
