### PR TITLE
Add SNT to KB Productions configurations

### DIFF
--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -64,6 +64,7 @@ studio_map = {
     "sexymodernbull.com": "Sexy Modern Bull",
     "shesbrandnew.com": "She's Brand New",
     "sidechick.com": "SIDECHICK",
+    "straightnakedthugs.com": "Straight Naked Thugs",
     "suckthisdick.com": "Suck This Dick",
     "swallowed.com": "Swallowed",
     "thaigirlswild.com": "Thai Girls Wild",

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -54,6 +54,7 @@ sceneByURL:
       - s3xus.com/scenes
       - sexymodernbull.com/videos
       - sidechick.com/videos
+      - straightnakedthugs.com/straight-naked-thugs-watch
       - thaigirlswild.com/videos
       - tour.allanal.com/scenes
       - tour.nympho.com/scenes
@@ -118,6 +119,7 @@ performerByURL:
       - tour.shesbrandnew.com/models
       - sidechick.com/models
       - sexymodernbull.com/models
+      - straightnakedthugs.com/straight-naked-thugs-model
       - tour.swallowed.com/models
       - tour.topwebmodels.com/models
       - trueanal.com/models


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

Scenes:

* https://www.straightnakedthugs.com/straight-naked-thugs-watch/snt0639_compilation0043/11+Straight+Guys+Beat+Their+Meat%21 (compilation)
* https://www.straightnakedthugs.com/straight-naked-thugs-watch/sntint0001_wiley/Getting+Personal+With+Naked+Young+Skinny+White+Thug (interview)
* https://www.straightnakedthugs.com/straight-naked-thugs-watch/snt0264_welsykincaid_boomerjacoby/Dick+Swapping+Straight+Guy (regular)

Performers:

* https://www.straightnakedthugs.com/straight-naked-thugs-model/Potter/Potter/7058
* https://www.straightnakedthugs.com/straight-naked-thugs-model/Wiley/Wiley/7102

## Short description

This just adds the SNT URLs to the scraper configuration so they can be scraped. I have not yet had the chance to test this locally but it looks like it should just work.
