### PR TITLE
Allow PremiumBukkake to scrape all scenes types 

### DIFF
--- a/scrapers/PremiumBukkake/PremiumBukkake.py
+++ b/scrapers/PremiumBukkake/PremiumBukkake.py
@@ -235,6 +235,11 @@ def scrape_scene(given_url):
 
     ret['studio'] = {}
     ret['studio']['name'] = 'Premium Bukkake'
+    ret['urls'] = []
+    ret['performers'] = []
+    ret['tags'] = []
+    ret['image'] = ''
+    ret['date'] = ''
 
     # Get info from the paywalled site first as the most accurate source
     # for most details and only source for some scenes

--- a/scrapers/PremiumBukkake/PremiumBukkake.py
+++ b/scrapers/PremiumBukkake/PremiumBukkake.py
@@ -2,6 +2,7 @@ import json
 import re
 import sys
 import py_common.log as log
+import datetime
 
 try:
     from requests import Session
@@ -18,11 +19,13 @@ except ModuleNotFoundError:
     sys.exit()
 
 
+free_url = ""
+paywall_url = ""
+members_url = ""
 ret = {}
 s = Session()
 s.headers['User-Agent'] = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
                            " (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36")
-
 
 def get_request(url):
     try:
@@ -30,54 +33,7 @@ def get_request(url):
         return page
     except Exception as e:
         log.error(f'Scrape error {e} for {url}')
-        return
-
-
-def scrape_scene_tags_and_performers(url):
-
-    # Note this information is behind the paywall
-
-    # Redirect to https://premiumbukkake.com/
-    url = url.replace("free.", "")
-    url = url.replace(".com/", ".com/tour2/")
-
-    r = get_request(url)
-    # Check if being redirected
-    if not r.url == url:
-        log.warning('Unable to scrape tags/performer from https://premiumbukkake.com')
-        return
-
-    soup = BeautifulSoup(r.text, 'html.parser')
-    html_text = soup.find('div', attrs={'class': 'section tour'})
-    html_info = html_text.find_all('div', attrs={'class': 'slide_info_row'})
-
-    # Add paywalled url
-    ret['urls'] += [url]
-
-    # Find the tag and performer rows by their title
-    tags_row = performer_row = None
-    for info_row in html_info:
-        if "Pornstars:" in info_row.get_text():
-            performer_row = info_row
-        elif "Categories:" in info_row.get_text():
-            tags_row = info_row
-
-    # Get Tags
-    if tags_row:
-        ret['tags'] = [{'name': tag.text.strip()} for tag in tags_row.find_all('a')]
-
-    # Get Performers
-    if performer_row:
-        performers = [performer.text.strip() for performer in performer_row.find_all('a')]
-        perf = []
-        for perf_name in performers:
-            try:
-                perf.append(scrape_performer(perf_name))
-            except Exception:
-                log.warning(f"[DEBUG] UNABLE TO SCRAPE PERFROMER {perf_name} ")
-                pass
-        ret['performers'] = perf
-
+        return    
 
 def scrape_performer(name):
     modified_name = name.replace(' ', '-')
@@ -100,12 +56,128 @@ def scrape_performer(name):
 
     return perfomer_details
 
+def generate_free_url(pagename):
+    pagename = re.sub(r'-first-camera', '', pagename, flags=re.IGNORECASE)
+    pagename = re.sub(r'-second-camera', '', pagename, flags=re.IGNORECASE)
+    return f"https://free.premiumbukkake.com/updates/{pagename}.html"
 
-def scrape_scene_url(url):
-    # Check if scene is removed
-    if not (r := get_request(url)):
-        log.warning('Unable to retrieve scene details. Wrong URL or scene is removed?')
+def generate_members_url(pagename):
+    return f"https://members.premiumbukkake.com/scenes/{pagename}_vids.html"
+
+def generate_paywall_url(pagename):
+    return f"https://premiumbukkake.com/tour2/updates/{pagename}.html"
+
+def generate_site_urls(given_url):
+    global paywall_url, free_url, members_url
+    if "free.premiumbukkake.com" in given_url:
+            # Extract page name from something like "mypage.html"
+            match = re.search(r'/([^/]+)\.html$', given_url)
+            if match:
+                pagename = match.group(1)
+            else:
+                raise ValueError("Could not extract page name from free URL.")
+            paywall_url = generate_paywall_url(pagename)
+            members_url = generate_members_url(pagename)
+            free_url = given_url
+        
+    # Check for members domain
+    elif "members.premiumbukkake.com" in given_url:
+        # Extract base page name from something like "mypage_test.html"
+        match = re.search(r'/([^/]+)_vids\.html$', given_url)
+        if match:
+            pagename = match.group(1)
+        else:
+            raise ValueError("Could not extract page name from members URL.")
+        paywall_url = generate_paywall_url(pagename)
+        free_url = generate_free_url(pagename)
+        members_url = given_url
+
+    # Check for main domain (note: exclude other subdomains)
+    elif "premiumbukkake.com/tour2" in given_url:
+        # For main domain, expect a URL like .../mypage.html (note: might have extra path parts before 'updates')
+        match = re.search(r'/([^/]+)\.html$', given_url)
+        if match:
+            pagename = match.group(1)
+        else:
+            raise ValueError("Could not extract page name from main URL.")
+        free_url = generate_free_url(pagename)
+        members_url = generate_members_url(pagename)
+        paywall_url = given_url
+
+def get_request(url):
+    try:
+        page = s.get(url, timeout=10)
+        return page
+    except Exception as e:
+        log.error(f'Scrape error {e} for {url}')
         return
+
+def scrape_info_from_paywalled():
+    r = get_request(paywall_url)
+    # Check if being redirected
+    if not r.url == paywall_url:
+        log.warning(f"Unable to scrape tags/performer from {paywall_url}")
+        return False
+
+    soup = BeautifulSoup(r.text, 'html.parser')
+    html_text = soup.find('div', attrs={'class': 'section tour'})
+   
+    # Get studio code - contained within the image URLS in the format PB_nnn
+    image_url = html_text.find('div', class_='slide_avatar').find('img')['data-src']    
+    if image_url:    
+        base_url = image_url.rsplit('/', 1)[0]
+        image_url = f"https://premiumbukkake.com{base_url}/0.jpg"
+        ret['image'] = image_url
+        ret['code'] = re.search(r'PB_\d+', image_url).group(0)
+    
+    ret['title'] = html_text.find('h2', class_='slide_title').text
+
+    # Details are not always full on this site, so overwritten by free site if exists
+    ret['details'] = html_text.find('p', class_='slide_text').text
+
+    # Get row information
+    html_info = html_text.find_all('div', attrs={'class': 'slide_info_row'})
+
+    # Find the tag and performer rows by their title
+    tags_row = performer_row = None
+    for info_row in html_info:
+        if "Pornstars:" in info_row.get_text():
+            performer_row = info_row
+        elif "Categories:" in info_row.get_text():
+            tags_row = info_row
+        elif "Posted" in info_row.get_text():
+            date_line = info_row.find('span').text
+            date_str = date_line.replace('Posted ', '')
+            date_obj = datetime.datetime.strptime(date_str, '%B %d, %Y')
+            formatted_date = date_obj.strftime('%Y-%m-%d')
+            ret['date'] = formatted_date
+
+    # Get Tags
+    if tags_row:
+        ret['tags'] = [{'name': tag.text.strip()} for tag in tags_row.find_all('a')]
+
+    # Get Performers
+    if performer_row:
+        performers = [performer.text.strip() for performer in performer_row.find_all('a')]
+        perf = []
+        for perf_name in performers:
+            try:
+                perf.append(scrape_performer(perf_name))
+            except Exception:
+                log.warning(f"[DEBUG] UNABLE TO SCRAPE PERFROMER {perf_name} ")
+                pass
+        ret['performers'] = perf
+    
+    # Add paywalled url
+    ret['urls'] = [paywall_url, members_url]
+    return True
+
+
+def scrape_info_from_free():
+    # Check if scene is removed
+    if not (r := get_request(free_url)):
+        log.warning('Unable to retrieve scene details from free site, may not exist')
+        return False
 
     soup = BeautifulSoup(r.text, 'html.parser')
     script_text = soup.find('script', attrs={'type': 'application/ld+json'})
@@ -113,7 +185,7 @@ def scrape_scene_url(url):
     # Grab scene description first, grab rest later
     details = re.search(r".+?(?:\"description\":\s\")([^\"]+)", str(script_text)).group(1)
 
-    # Remove leading/trailing/double whitespaces
+    # Remove leading/trailing/double whitespaces, details longer on free site
     ret['details'] = '\n'.join(
         [
             ' '.join([s for s in x.strip(' ').split(' ') if s != ''])
@@ -124,21 +196,13 @@ def scrape_scene_url(url):
     # Now remove excessive linebreaks and parse it as json
     json_script = json.loads(script_text.string.replace('\n', ''))
 
-    # Add Studio Details
-    ret['studio'] = {}
-    ret['studio']['name'] = 'Premium Bukkake'
+    # Release Date on free site can be off by a few days so only use if paywalled site does not have it
+    if not ret['date']:
+        ret['date'] = json_script['uploadDate']
 
-    # Populate URLs
-    ret['urls'] = [url]
-
-    # Add Scene Details
-    ret['title'] = json_script['name']
-    ret['date'] = json_script['uploadDate']
-    ret['image'] = json_script['thumbnailUrl']
-
-    # Get tags and performer from the paywalled site
-    ret['performers'] = ret['tags'] = []
-    scrape_scene_tags_and_performers(url)
+    # Get image if paywalled site not found
+    if not ret['image']:
+        ret['image'] = json_script['thumbnailUrl']
 
     # Extract actor details in free site in case paywalled site does not have information
     # Actor field comma delimited and starts with actors names, ends with scene type tag.
@@ -156,16 +220,36 @@ def scrape_scene_url(url):
         # No tags in paywalled site, get classification tag from free site
         ret['tags'] = [ { 'name': tag.strip() } ]
 
-    return ret
+    ret['urls'] += [free_url]
+
+    return True
 
 
 FRAGMENT = json.loads(sys.stdin.read())
 SCENE_URL = FRAGMENT.get("url")
 
+def scrape_scene(given_url):
+
+    # Generate all of the 3 URL's from the given URL
+    generate_site_urls(given_url)
+
+    ret['studio'] = {}
+    ret['studio']['name'] = 'Premium Bukkake'
+
+    # Get info from the paywalled site first as the most accurate source
+    # for most details and only source for some scenes
+    scrape_info_from_paywalled()
+
+    # Get additional info from the free site if the page exists
+    scrape_info_from_free()
+
+    return ret
+
 
 if SCENE_URL:
     log.debug(f"[DEBUG] Url Scraping: {SCENE_URL}")
-    if (result := scrape_scene_url(SCENE_URL)):
+    
+    if (result := scrape_scene(SCENE_URL)):
         # log.debug(result)
         print(json.dumps(result))
     else:

--- a/scrapers/PremiumBukkake/PremiumBukkake.yml
+++ b/scrapers/PremiumBukkake/PremiumBukkake.yml
@@ -1,10 +1,12 @@
 name: "PremiumBukkake"
 sceneByURL:
   - url:
-      - free.premiumbukkake.com
+      - free.premiumbukkake.com/updates
+      - premiumbukkake.com/tour2
+      - members.premiumbukkake.com/scenes
     action: script
     script:
       - python
       - PremiumBukkake.py
       - query
-# Last Updated August 15, 2024
+# Last Updated February 21, 2025


### PR DESCRIPTION
## Scraper type(s)

- [x] sceneByURL


## Examples to test

A member site first camera angle - prevoiusly not scrapable as no entry on free site 
https://members.premiumbukkake.com/scenes/Daruma-Rai-2-Bukkake-First-Camera_vids.html

Free site link to scene but with incorrect title and cover, replaced with correct ones from main site.
https://free.premiumbukkake.com/updates/Athenea-Rose-3-Bukkake.html

Scene which is same on all sites
https://premiumbukkake.com/tour2/updates/Georgia-Koneva-1-Bukkake-Behind-The-Scenes.html

## Short description

There are 3 PremiumBukkake sites, a free site, a paywalled site(not protected)  and a members site(protected). The free site is published after the other sites and not all scenes have are published, the First & Second camera scenes and some of the BTS and Interviews never make it to this free site. The free site title is not always consistent with the main sites and the release date lags as it is delayed by a few days from the main sites. Prior to this if it wasn't on the free site it could not be scraped. This modification allows you to supply any of the 3 site scene URLs (calculating the other 2) and allows any missing scenes (on the free site) to be scraped, also correcting inconsistencies in the title ands the dates using the info from the main paywalled site.
