### PR TITLE
Update WeAreHairy.yml

### DIFF
--- a/scrapers/WeAreHairy.yml
+++ b/scrapers/WeAreHairy.yml
@@ -24,7 +24,7 @@ xPathScrapers:
               - regex: \s-\sWeAreHairy\.com$
                 with:
       Date: &date
-        selector: //h6//span
+        selector: //h6/span[last()]
         postProcess:
           - parseDate: Jan 2, 2006
       Details: &details //meta[@name="description"]/@content


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

Single performer:
https://www.wearehairy.com/models/polly-white/polly-white-masturbates-with-her-dildo [Imageset]
https://www.wearehairy.com/models/polly-white/polly-white-masturbates-on-her-armchair [Video]

Multiple performers:
https://www.wearehairy.com/models/polly-white/polly-white-and-kira-light-have-fun-in-bed [Imageset]
https://www.wearehairy.com/models/polly-white/polly-white-has-sex-with-her-girlfriend [Video]


## Short description

Fix date parsing if the content features multiple models.
If multiple models are included in the content update, the current date XPATH `//h6/span` returns multiple results: `[",", "Nov 6, 2024"]`.
The new date XPATH `//h6/span[last()]` selects only the last element.
