### PR TITLE
Update Algolia.py - MAIN_CHANNELS_AS_STUDIO_FOR_SCENE logic

### DIFF
--- a/scrapers/Algolia/Algolia.py
+++ b/scrapers/Algolia/Algolia.py
@@ -35,6 +35,7 @@ NON_FEMALE = True
 # a list of main channels (`mainChannelName` from the API) to use as the studio
 # name for a scene
 MAIN_CHANNELS_AS_STUDIO_FOR_SCENE = [
+    "BiPhoria",
     "Buttman",
     "Cock Choking Sluts",
     "Devil's Film Parodies",
@@ -118,6 +119,7 @@ SITES_USING_OVERRIDE_AS_STUDIO_FOR_SCENE = {
 # this is because the `serie_name` is the Movie (series) title on these sites,
 # not the studio
 SITES_USING_SITENAME_AS_STUDIO_FOR_SCENE = [
+    "Biphoria",
     "ChaosMen",
     "Devil's Film",
     "Evil Angel",
@@ -611,6 +613,7 @@ def determine_studio_name_from_json(some_json):
     - movie
     '''
     studio_name = None
+    log.debug(f"Main Channel Name - [{some_json.get('mainChannel',{}).get('name','')}]")
     if some_json.get('segment') in SITES_SEGMENT_USING_MAIN_CHANNEL_AS_SCENE_STUDIO:
         studio_name = some_json.get('mainChannel', {}).get('name', '')
         return studio_name
@@ -618,20 +621,25 @@ def determine_studio_name_from_json(some_json):
         if some_json.get('sitename_pretty') in SITES_USING_OVERRIDE_AS_STUDIO_FOR_SCENE:
             studio_name = \
                     SITES_USING_OVERRIDE_AS_STUDIO_FOR_SCENE.get(some_json.get('sitename_pretty'))
+            log.debug(f"Studio Using override as studio")
         elif some_json.get('sitename_pretty') in SITES_USING_SITENAME_AS_STUDIO_FOR_SCENE \
                 or some_json.get('serie_name') in SERIE_USING_SITENAME_AS_STUDIO_FOR_SCENE \
                 or some_json.get('network_name') \
                 and some_json.get('network_name') in NETWORKS_USING_SITENAME_AS_STUDIO_FOR_SCENE:
+            log.debug(f"Studio Using sitename_pretty")
             studio_name = some_json.get('sitename_pretty')
         elif some_json.get('sitename_pretty') in SITES_USING_NETWORK_AS_STUDIO_FOR_SCENE \
                 and some_json.get('network_name'):
+            log.debug(f"Studio Using network name")
             studio_name = some_json.get('network_name')
     if not studio_name and some_json.get('network_name') and \
             some_json.get('network_name') in NETWORKS_USING_SITENAME_AS_STUDIO_FOR_SCENE:
+        log.debug(f"Studio Using network using site name")
         studio_name = some_json.get('sitename_pretty')
-    if not studio_name and some_json.get('mainChannelName') and \
-            some_json.get('mainChannelName') in MAIN_CHANNELS_AS_STUDIO_FOR_SCENE:
-        studio_name = some_json.get('mainChannelName')
+    if not studio_name and some_json.get('mainChannel', {}).get('name', '') and \
+            some_json.get('mainChannel', {}).get('name', '') in MAIN_CHANNELS_AS_STUDIO_FOR_SCENE:
+        log.debug(f"Studi Using Main Channel Name")
+        studio_name = some_json.get('mainChannel', {}).get('name', '')
     if studio_name and some_json.get('directors'):
         for director in [ d.get('name').strip() for d in some_json.get('directors') ]:
             if DIRECTOR_AS_STUDIO_OVERRIDE_FOR_SCENE.get(director):
@@ -641,6 +649,7 @@ def determine_studio_name_from_json(some_json):
         studio_name = \
                 SERIE_USING_OVERRIDE_AS_STUDIO_FOR_SCENE.get(some_json.get('serie_name'))
     if not studio_name and some_json.get('serie_name'):
+        log.debug(f"Default Series Name")
         studio_name = some_json.get('serie_name')
     return studio_name
 


### PR DESCRIPTION
Changed logic for MAIN_CHANNELS_AS_STUDIO_FOR_SCENE processing in the determine_studio_name_from_json subroutine, as the check if a site is in the dictionary for studio name processing was not using the proper key.  The value returned in the JSON for this key is a dictionary itself.  Changed the check to match the SITES_SEGMENT_USING_MAIN_CHANNEL_AS_SCENE_STUDIO check in the same block.

Added some debugging lines so it's more obvious which IF block is being triggered to assist in future efforts to hunt down studio name processing issues.

Added BiPhoria to MAIN_CHANNELS_AS_STUDIO_FOR_SCENE  dictionary to allow the scraper to return BiPhoria as the studio instead of  the scene name.

## Scraper type(s)
- [x] sceneByURL

## Examples to test
The following should return "BiPhoria" instead of the scene names:
https://www.biphoria.com/en/video/biphoria/Saying-GoodBi---Scene-3/232742
https://www.biphoria.com/en/video/biphoria/Saying-GoodBi---Scene-1/232740
https://www.biphoria.com/en/video/biphoria/Saying-GoodBi---Scene-2/232741

Another random URL from a studio in the dictionary. Should return "Devil's Film Parodies" as the studio name
https://www.devilsfilm.com/en/video/This-Isnt-UFC---Ultimate-Fucking-Championship-02/29464