### PR TITLE
Update app.teamskeet.com API_BASE

### DIFF
--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -130,7 +130,7 @@ IS_MEMBER = False
 if 'app.teamskeet.com' in scene_url:
     ORIGIN = "https://app.teamskeet.com"
     REFERER = "https://app.teamskeet.com"
-    API_BASE = "https://ma-store.teamskeet.com/ts_movies/_doc/"
+    API_BASE = "https://ma-store.teamskeet.com/ts_index/_doc/movie-"
     MEMBER_ACCESS_TOKEN = TEAMSKEET_ACCESS_TOKEN
     IS_MEMBER = True
 elif 'app.mylf.com' in scene_url:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL (formerly movieByURL)
- [ ] galleryByFragment
- [ ] galleryByURL

## Examples to test

- https://app.teamskeet.com/movies/27092
- https://app.teamskeet.com/movies/27078
- https://app.teamskeet.com/movies/23868

## Short description

Discovered that TeamSkeet recently changed their API path, breaking the app.teamskeet.com scraper. 

Checked the corresponding fetch GET call made in the live site and found this new format works as a drop-in replacement to the previous behavior.

Before, the called API would be `https://ma-store.teamskeet.com/ts_movies/_doc/27092`. This now 404s. The new format is now `https://ma-store.teamskeet.com/ts_index/_doc/movie-27092`, where `27092` is the scene ID