### PR TITLE
Fix JacquieEtMichelTV details

### DIFF
--- a/scrapers/JacquieEtMichelTV/JacquieEtMichelTV.py
+++ b/scrapers/JacquieEtMichelTV/JacquieEtMichelTV.py
@@ -1,5 +1,7 @@
 import base64
 from datetime import datetime as dt
+from html import unescape
+
 import json
 import sys
 from py_common import log
@@ -36,7 +38,7 @@ def scene_from_url(url: str) -> ScrapedScene | None:
     log.debug(f"Video data: {json.dumps(video_data)}")
     scene: ScrapedScene = {
         "title": video_data["name"],
-        "details": video_data["description"],
+        "details": unescape(video_data["description"]).strip(),
         "date": dt.fromisoformat(video_data["datePublished"]).date().isoformat(),
         "tags": [{"name": t} for t in video_data["keywords"].split(",")],
     }

--- a/scrapers/JacquieEtMichelTV/JacquieEtMichelTV.yml
+++ b/scrapers/JacquieEtMichelTV/JacquieEtMichelTV.yml
@@ -10,4 +10,4 @@ sceneByURL:
       - JacquieEtMichelTV.py
       - scene-by-url
 
-# Last Updated November 19, 2024
+# Last Updated March 9, 2025


### PR DESCRIPTION
Added python's unescape() to convert html character references to their unicode characters, for example ``&amp;`` to ``&``

Strip trailing newline character in details

## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://www.jacquieetmicheltv.net/en/content/6352b7338b4552ba57ee3947/mary-jane-is-enjoying-herself-again