### PR TITLE
Fix for Kink scraping details

### DIFF
--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -142,9 +142,9 @@ xPathScrapers:
         selector: //head/script[@type='application/ld+json' and contains(text(), '"@type":"VideoObject"')]
         postProcess:
           - replace:
-            - regex: '.+"description":"(.+?)",.+'
+            - regex: '.+"description":"(.+?)","duration".+'
               with: "$1"
-            - regex: '\\n'
+            - regex: '( ?)\\n'
               with: "\n"
             - regex: \\"
               with: '"'
@@ -269,4 +269,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated March 7, 2025
+# Last Updated March 9, 2025

--- a/scrapers/KinkMen.yml
+++ b/scrapers/KinkMen.yml
@@ -132,9 +132,9 @@ xPathScrapers:
         selector: //head/script[@type='application/ld+json' and contains(text(), '"@type":"VideoObject"')]
         postProcess:
           - replace:
-            - regex: '.+"description":"(.+?)",.+'
+            - regex: '.+"description":"(.+?)","duration".+'
               with: "$1"
-            - regex: '\\n'
+            - regex: '( ?)\\n'
               with: "\n"
             - regex: \\"
               with: '"'
@@ -163,4 +163,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated March 7, 2025
+# Last Updated March 9, 2025

--- a/scrapers/KinkTrans.yml
+++ b/scrapers/KinkTrans.yml
@@ -132,9 +132,9 @@ xPathScrapers:
         selector: //head/script[@type='application/ld+json' and contains(text(), '"@type":"VideoObject"')]
         postProcess:
           - replace:
-            - regex: '.+"description":"(.+?)",.+'
+            - regex: '.+"description":"(.+?)","duration".+'
               with: "$1"
-            - regex: '\\n'
+            - regex: '( ?)\\n'
               with: "\n"
             - regex: \\"
               with: '"'
@@ -163,4 +163,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated March 7, 2025
+# Last Updated March 9, 2025


### PR DESCRIPTION
Narrowed the regex for scraping details
For some scenes the details were incomplete, regex stopped after ``\",`` while the details continued
Scrape the url below to see this behaviour

Updated the regex for details, to remove any left-over whitespaces before a newline character

## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://www.kink.com/shoot/36182