### PR TITLE
Extend HobbyPorn with multiple URLs

### DIFF
--- a/scrapers/HobbyPorn.yml
+++ b/scrapers/HobbyPorn.yml
@@ -26,9 +26,12 @@ xPathScrapers:
           - parseDate: 01/02/2006
       Tags:
         Name: //a[@itemprop="genre"]/text()
-      URL: //link[@itemprop="url"]/@href # gets the hobby.porn url
-      # Possible update once XPath scraper handles multiple urls
-      # //div[@class="player"]//a/@href gets the pornhub url
+      URLs:
+        selector: //link[@itemprop="url"]/@href | //iframe[contains(@src, 'pornhub.com')]/@src
+        postProcess:
+          - replace:
+              - regex: https:\/\/www\.pornhub\.com\/embed\/
+                with: "https://www.pornhub.org/view_video.php?viewkey="
       Image: //span[@itemprop="thumbnail"]/link/@href
   sceneSearch:
     common:
@@ -37,4 +40,4 @@ xPathScrapers:
       Title: $scenecard//div[@class="item-title"]
       URL: $scenecard//a/@href
       Image: $scenecard//img/@src
-# Last Updated January 05, 2024
+# Last Updated March 24, 2025

--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -42,9 +42,9 @@ xPathScrapers:
       $searchThumb: //ul[contains(@class, "search-video-thumbs") and not(@id="bottomVideos")]//div[contains(@class, "thumbnail-info-wrapper")]
 
     scene:
-      Title: $searchThumb/span[@class="title"]/a/text()
+      Title: $searchThumb//span[@class="title"]/a/text()
       URL:
-        selector: $searchThumb/span[@class="title"]/a/@href
+        selector: $searchThumb//span[@class="title"]/a/@href
         postProcess:
           - replace:
               - regex: ^
@@ -152,4 +152,4 @@ driver:
           Domain: ".pornhub.com"
           Value: "1"
           Path: "/"
-# Last Updated August 19, 2024
+# Last Updated March 24, 2025


### PR DESCRIPTION
`https://hobby.porn/` contains also the original Pornhub URL in the embedded video player.
Due to stashapp/stash#5677 it's possible to receive the HobbyPorn and Pornhub URL now.