### PR TITLE
fix: migrate sceneByURL for TheScoreGroup to Python

### DIFF
--- a/scrapers/TheScoreGroup/TheScoreGroup.py
+++ b/scrapers/TheScoreGroup/TheScoreGroup.py
@@ -166,7 +166,6 @@ def scene_from_url(url: str) -> ScrapedScene:
     result = client.get(url)
     tree = html.fromstring(result.content)
 
-    stat = '//div[contains(concat(" ",normalize-space(@class)," ")," mb-3 ")]'
     video_page = '//section[@id="videos_page-page" or @id="mixed_page-page"]'
 
     # title
@@ -186,9 +185,11 @@ def scene_from_url(url: str) -> ScrapedScene:
         scene["studio"] = { "name": STUDIO_MAP.get(studio_ref, studio_ref) }
 
     # date
-    if raw_date := tree.xpath(f'{video_page}{stat}//span[contains(.,"Date:")]/following-sibling::span'):
-        clean_date = re.sub(r"(\d+)[a-z]{2}", r"\1", next(iter(raw_date)).text).replace("..,", "")
-        scene["date"] = datetime.strptime(clean_date, "%B %d, %Y").strftime("%Y-%m-%d")
+    if raw_date := tree.xpath(f'{video_page}//div[contains(concat(" ",normalize-space(@class)," ")," mb-3 ")]//span[contains(.,"Date:")]/following-sibling::span'):
+        scene["date"] = datetime.strptime(
+            re.sub(r"(\d+)[a-z]{2}", r"\1", next(iter(raw_date)).text).replace("..,", ""),
+            "%B %d, %Y"
+        ).strftime("%Y-%m-%d")
 
     # details
     if description := tree.xpath(f'{video_page}//div[@class="p-desc p-3" or contains(@class, "desc")]/text()'):

--- a/scrapers/TheScoreGroup/TheScoreGroup.py
+++ b/scrapers/TheScoreGroup/TheScoreGroup.py
@@ -191,7 +191,7 @@ def scene_from_url(url: str) -> ScrapedScene:
         scene["date"] = datetime.strptime(clean_date, "%B %d, %Y").strftime("%Y-%m-%d")
 
     # details
-    if description := tree.xpath(f'{video_page}//div[@class="p-desc p-3"]/text()'):
+    if description := tree.xpath(f'{video_page}//div[@class="p-desc p-3" or contains(@class, "desc")]/text()'):
         scene["details"] = "\n\n".join([p.strip() for p in description if len(p.strip())])
 
     # tags

--- a/scrapers/TheScoreGroup/TheScoreGroup.py
+++ b/scrapers/TheScoreGroup/TheScoreGroup.py
@@ -1,38 +1,78 @@
-import sys
-import argparse
+from datetime import datetime
 import json
-import os
-import requests
 import re
+import sys
+from urllib.parse import urlparse, urlunparse
 
-# to import from a parent directory we need to add that directory to the system path
-csd = os.path.dirname(os.path.realpath(__file__))  # get current script directory
-parent = os.path.dirname(csd)  #  parent directory (should be the scrapers one)
-sys.path.append(
-    parent
-)  # add parent dir to sys path so that we can import py_common from ther
+from lxml import html
+import requests
 
-try:
-    from lxml import html
-except ModuleNotFoundError:
-    print(
-        "You need to install the lxml module. (https://lxml.de/installation.html#installation)",
-        file=sys.stderr,
-    )
-    print(
-        "If you have pip (normally installed with python), run this command in a terminal (cmd): pip install lxml",
-        file=sys.stderr,
-    )
-    sys.exit()
+from py_common.deps import ensure_requirements
+import py_common.log as log
+from py_common.types import ScrapedPerformer, ScrapedScene
+from py_common.util import is_valid_url, scraper_args
 
-try:
-    import py_common.log as log
-except ModuleNotFoundError:
-    print(
-        "You need to download the folder 'py_common' from the community repo! (CommunityScrapers/tree/master/scrapers/py_common)",
-        file=sys.stderr,
-    )
-    sys.exit()
+ensure_requirements("lxml", "requests")
+
+
+STUDIO_MAP = {
+    "18eighteen": "18 Eighteen",
+    "40somethingmag": "40 Something Mag",
+    "50plusmilfs": "50 Plus MILFs",
+    "60plusmilfs": "60 Plus MILFs",
+    "autumn-jade": "Autumn Jade",
+    "bigboobspov": "Big Boobs POV",
+    "bigtitangelawhite": "Big Tit Angela White",
+    "bigtithitomi": "Big Tit Hitomi",
+    "bigtithooker": "Big Tit Hooker",
+    "bigtitterrynova": "Big Tit Terry Nova",
+    "bigtitvenera": "Big Tit Venera",
+    "bonedathome": "Boned At Home",
+    "bootyliciousmag": "Bootylicious Mag",
+    "bustyangelique": "Busty Angelique",
+    "bustyarianna": "Busty Arianna",
+    "bustydanniashe": "Busty Danni Ashe",
+    "bustydustystash": "Busty Dusty Stash",
+    "bustyinescudna": "Busty Ines Cudna",
+    "bustykellykay": "Busty Kelly Kay",
+    "bustykerrymarie": "Busty Kerry Marie",
+    "bustylornamorga": "Busty Lorna Morga",
+    "bustymerilyn": "Busty Merilyn",
+    "bustyoldsluts": "Busty Old Sluts",
+    "chicksonblackdicks": "Chicks on Black Dicks",
+    "chloesworld": "Chloe's World",
+    "christymarks": "Christy Marks",
+    "cock4stepmom": "Cock 4 Stepmom",
+    "creampieforgranny": "Creampie for Granny",
+    "crystalgunnsworld": "Crystal Gunns World",
+    "daylenerio": "Daylene Rio",
+    "desiraesworld": "Desiraes World",
+    "evanottyvideos": "Eva Notty Videos",
+    "feedherfuckher": "Feed Her Fuck Her",
+    "flatandfuckedmilfs": "Flat and Fucked MILFs",
+    "homealonemilfs": "Home Alone MILFs",
+    "karinahart": "Karina Hart",
+    "legsex": "Leg Sex",
+    "mickybells": "Micky Bells",
+    "milftugs": "MILF Tugs",
+    "mommystoytime": "Mommy's Toy Time",
+    "naughtymag": "Naughty Mag",
+    "pickinguppussy": "Picking Up Pussy",
+    "pornmegaload": "Porn Mega Load",
+    "reneerossvideos": "Renee Ross Video",
+    "scoreclassics": "Score Classics",
+    "scoreland2": "Scoreland2",
+    "scoreland": "Scoreland",
+    "scorevideos": "Score Videos",
+    "sharizelvideos": "Sha Rizel Videos",
+    "stacyvandenbergboobs": "Stacy Vandenberg Boobs",
+    "tawny-peaks": "Tawny Peaks",
+    "titsandtugs": "Tits And Tugs",
+    "valoryirene": "Valory Irene",
+    "xlgirls": "XL Girls",
+    "yourwifemymeat": "Your Wife My Meat",
+}
+
 
 # Shared client because we're making multiple requests
 client = requests.Session()
@@ -59,15 +99,18 @@ client = requests.Session()
 #     </div>
 #   </div>
 # </div>
-def map_performer(el):
+def map_performer(el) -> ScrapedPerformer:
+    "Converts performer search result into scraped performer"
     url = el.xpath(".//a/@href")[0]
     if "no-model" in url:
         return None
     name = el.xpath(".//a/@title")[1]
     image = el.xpath(".//img/@src")[0]
     fixed_url = re.sub(r".*?([^/]*(?=/2/0))/2/0/([^?]*)", r"https://www.\1.com/\2", url)
+    log.debug(f"url: {url}")
+    log.debug(f"fixed_url: {fixed_url}")
 
-    if client.head(fixed_url).status_code != 200:
+    if not is_valid_url(fixed_url):
         log.debug(f"Performer '{name}' has a broken profile link, skipping")
         return None
 
@@ -79,6 +122,7 @@ def map_performer(el):
 
 
 def performer_query(query: str):
+    "Search performer by name"
     # Form data to be sent as the POST request body
     payload = {
         "ci_csrf_token": "",
@@ -100,45 +144,89 @@ def performer_query(query: str):
     return performers
 
 
+def best_quality_scene_image(code: str) -> str | None:
+    "Finds the highest resolution scene image for a scene ID"
+    no_qual_path = (
+        "https://cdn77.scoreuniverse.com/modeldir/data/posting/"
+        f"{code[0:len(code)-3]}/{code[-3:]}/posting_{code}"
+    )
+    for quality in ["_1920", "_1600", "_1280", "_800", "_xl", "_lg", "_med", ""]:
+        image_url = f"{no_qual_path}{quality}.jpg"
+        if is_valid_url(image_url):
+            return image_url
+    return None
+
+
+def scene_from_url(url: str) -> ScrapedScene:
+    "Scrape scene URL from HTML"
+    # url
+    clean_url = urlunparse(urlparse(url)._replace(query=""))
+    scene: ScrapedScene = { "url": clean_url }
+
+    result = client.get(url)
+    tree = html.fromstring(result.content)
+
+    stat = '//div[contains(concat(" ",normalize-space(@class)," ")," mb-3 ")]'
+    video_page = '//section[@id="videos_page-page" or @id="mixed_page-page"]'
+
+    # title
+    if title := tree.xpath(
+        'normalize-space('  # trim leading/trailing whitespace
+        f'{video_page}//h1/span/following-sibling::text()[1] | '    # if h1 contains a span, ignore the span and take the remaining text
+        f'{video_page}//h1[not(span)]/text()'   # if h1 has no span, just take the text
+        ')'
+    ):
+        scene["title"] = title
+
+    # studio
+    # Original studio is determinable by looking at the CDN links (<source src="//cdn77.scoreuniverse.com/naughtymag/scenes...)
+    # this helps set studio for PornMegaLoad URLs as nothing is released directly by the network
+    if video_src := tree.xpath(f'{video_page}//video/source/@src'):
+        studio_ref = re.sub(r".*\.com/(.+?)\/(video|scene).*", r"\1", next(iter(video_src)))
+        scene["studio"] = { "name": STUDIO_MAP.get(studio_ref, studio_ref) }
+
+    # date
+    if raw_date := tree.xpath(f'{video_page}{stat}//span[contains(.,"Date:")]/following-sibling::span'):
+        clean_date = re.sub(r"(\d+)[a-z]{2}", r"\1", next(iter(raw_date)).text).replace("..,", "")
+        scene["date"] = datetime.strptime(clean_date, "%B %d, %Y").strftime("%Y-%m-%d")
+
+    # details
+    if description := tree.xpath(f'{video_page}//div[@class="p-desc p-3"]/text()'):
+        scene["details"] = "\n\n".join([p.strip() for p in description if len(p.strip())])
+
+    # tags
+    if tags := tree.xpath(f'{video_page}//a[contains(@href, "videos-tag") or contains(@href, "scenes-tag")]'):
+        scene["tags"] = [ { "name": tag.text } for tag in iter(tags) ]
+
+    # performers
+    if performers := tree.xpath(f'{video_page}//span[contains(.,"Featuring:")]/following-sibling::span/a'):
+        scene["performers"] = [ { "name": p.text } for p in iter(performers) ]
+
+    # code
+    scene_id = re.sub(r".*\/(\d+)\/?$", r"\1", clean_url)
+    scene["code"] = scene_id
+
+    # image
+    if image_url := best_quality_scene_image(scene_id):
+        scene["image"] = image_url
+
+    return scene
+
+
 def main():
-    parser = argparse.ArgumentParser("ScoreGroup Scraper", argument_default="")
-    subparsers = parser.add_subparsers(
-        dest="operation", help="Operation to perform", required=True
-    )
-    subparsers.add_parser("search", help="Search for performers").add_argument(
-        "name", nargs="?", help="Name to search for"
-    )
-
-    if len(sys.argv) == 1:
-        parser.print_help(sys.stderr)
-        sys.exit(1)
-
-    args = parser.parse_args()
-    log.debug(f"Arguments from commandline: {args}")
-    # Script is being piped into, probably by Stash
-    if not sys.stdin.isatty():
-        try:
-            frag = json.load(sys.stdin)
-            args.__dict__.update(frag)
-            log.debug(f"With arguments from stdin: {args}")
-        except json.decoder.JSONDecodeError:
-            log.error("Received invalid JSON from stdin")
+    op, args = scraper_args()
+    log.debug(f"Operation: {op}, arguments: {json.dumps(args)}")
+    result = None
+    match op, args:
+        case "scene-by-url", {"url": url} if url:
+            result = scene_from_url(url)
+        case "performer-by-name", {"name": name} if name:
+            result = performer_query(name)
+        case _:
+            log.error(f"Operation not implemented: {op}")
             sys.exit(1)
 
-    if args.operation == "search":
-        name: str = args.name
-        if not name:
-            log.error("No query provided")
-            sys.exit(1)
-        log.debug(f"Searching for '{name}'")
-        matches = performer_query(name)
-        print(json.dumps(matches))
-        sys.exit(0)
-
-    # Just in case the above if statement doesn't trigger somehow
-    # Something has gone quite wrong should this ever get hit
-    log.error("An error has occured")
-    sys.exit(2)
+    print(json.dumps(result))
 
 
 if __name__ == "__main__":

--- a/scrapers/TheScoreGroup/TheScoreGroup.yml
+++ b/scrapers/TheScoreGroup/TheScoreGroup.yml
@@ -1,6 +1,7 @@
+# yaml-language-server: $schema=../../validator/scraper.schema.json
 name: TheScoreGroup
 sceneByURL:
-  - action: scrapeXPath
+  - action: script
     url: &urls
       - 18eighteen.com
       - 40somethingmag.com
@@ -57,7 +58,10 @@ sceneByURL:
       - valoryirene.com
       - xlgirls.com
       - yourwifemymeat.com
-    scraper: sceneScraper
+    script:
+      - python
+      - TheScoreGroup.py
+      - scene-by-url
 galleryByURL:
   - action: scrapeXPath
     url: *urls
@@ -71,7 +75,7 @@ performerByName:
   script:
     - python
     - TheScoreGroup.py
-    - search
+    - performer-by-name
 
 xPathScrapers:
   sceneScraper:
@@ -79,18 +83,19 @@ xPathScrapers:
       $url: //link[@rel="canonical"]/@href
       $videopage: //section[@id="videos_page-page" or @id="mixed_page-page"]
       $stat: //div[contains(concat(' ',normalize-space(@class),' '),' mb-3 ')]
-    scene:
-      # Original studio is determinable by looking at the CDN links (<source src="//cdn77.scoreuniverse.com/naughtymag/scenes...)
-      # this helps set studio for PornMegaLoad URLs as nothing is released directly by the network
-      Title: $videopage//h1
+  galleryScraper:
+    common:
+      $photopage: //section[@id='photos_page-page']
+    gallery:
+      Title: //h1
       Studio:
         Name:
-          selector: ($videopage//video/source/@src)[1]
+          selector: //link[@rel="canonical"]/@href
           postProcess:
             - replace:
-                - regex: .*\.com/(.+?)\/(video|scene).*
-                  with: $1
-            - map: &studioMap
+                - regex: ^(https://)?.+?([^\.]+)\.com/.*
+                  with: $2
+            - map:
                 18eighteen: 18 Eighteen
                 40somethingmag: 40 Something Mag
                 50plusmilfs: 50 Plus MILFs
@@ -147,66 +152,6 @@ xPathScrapers:
                 valoryirene: Valory Irene
                 xlgirls: XL Girls
                 yourwifemymeat: Your Wife My Meat
-      Date: &dateAttr
-        selector: $videopage$stat//span[contains(.,"Date:")]/following-sibling::span
-        postProcess:
-          - replace:
-              - regex: ..,
-                with:
-          - parseDate: January 2 2006
-      Details: &details
-        selector: $videopage//div[@class="p-desc p-3"]/text()
-        postProcess:
-          - replace:
-              - regex: Read More »
-                with:
-              # Attempt to fix erroneous line breaks where HTML tags existed
-              - regex: \n\n([0-9a-zA-Z\.]+)\n\n
-                with: " $1 "
-        concat: "\n\n"
-      Tags:
-        Name: $videopage//a[contains(@href, "videos-tag") or contains(@href, "scenes-tag")]
-      Performers: &performersAttr
-        Name: $videopage//span[contains(.,"Featuring:")]/following-sibling::span/a
-      Image:
-        # This selector scrapes the canonical scene page cover image
-        selector: //script[contains(text(), "poster")]
-        postProcess:
-          - replace:
-              - regex: ^.+poster.+'(.+jpg)'.+$
-                with: $1
-              - regex: ^//
-                with: https://
-              - regex: _x_
-                with: _
-      # This Selector scrapes the image posted on social media sites
-      #        selector: //meta[@itemprop="image"]/@content
-      # Enable this post process if you want better image quality but sometimes it can fail
-      #          postProcess:
-      #            - replace:
-      #                - regex: _lg
-      #                  with: _x_800
-      URL: &urlAttr
-        selector: $url
-      Code: &codeAttr
-        selector: $url
-        postProcess:
-          - replace:
-              - regex: .*\/(\d+)\/?$
-                with: $1
-  galleryScraper:
-    common:
-      $photopage: //section[@id='photos_page-page']
-    gallery:
-      Title: //h1
-      Studio:
-        Name:
-          selector: //link[@rel="canonical"]/@href
-          postProcess:
-            - replace:
-                - regex: ^(https://)?.+?([^\.]+)\.com/.*
-                  with: $2
-            - map: *studioMap
       Date:
         selector: //div[span[@class="label" and contains(.,"Date")]]/span[@class="value"]/text()
         postProcess:
@@ -253,4 +198,4 @@ xPathScrapers:
               - regex: (\d+[a-zA-Z]{1,3})-\d+(-\d+-\d+)
                 with: $1$2
       Image: //section[@id="model-page"]//img[@class="lazyload"]/@src
-# Last Updated April 08, 2024
+# Last Updated April 01, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.scoreland.com/big-boob-videos/Danniella-Levy/50022/
- https://www.18eighteen.com/xxx-teen-videos/Alyssa-Star/12003/
- https://www.18eighteen.com/xxx-teen-videos/Olivia-Zlota/78187/?nats=MTAwNC45LjMuMy43MDMuMC4wLjAuMA
- https://www.18eighteen.com/xxx-teen-videos/Emma-Bugg/71841/
- https://www.18eighteen.com/xxx-teen-videos/Julissa-Delor/11628/
- https://www.xlgirls.com/bbw-videos/Ashlinx/78137/
- https://www.50plusmilfs.com/xxx-milf-videos/Jazmyn-James/78619
- https://www.40somethingmag.com/xxx-mature-videos/Harlow-Wilde/78282/
- https://www.naughtymag.com/amateur-videos/Vixi-Rafi/77273/

## Short description

The YAML xpaths for sceneByURL have been migrated to Python to make use of the highest resolution image available logic provided by @feederbox826 's in https://github.com/stashapp/CommunityScrapers/issues/1831#issuecomment-2311449810

Fixes #1831 