### PR TITLE
handle relative hours/days at motherless

### DIFF
--- a/scrapers/Motherless.yml
+++ b/scrapers/Motherless.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: Motherless
 sceneByURL:
   - action: scrapeXPath
@@ -40,6 +41,19 @@ xPathScrapers:
       Date:
         selector: $meta//div[@class='media-meta-stats']/span[not(contains(.,'Views')) and not(contains(.,'Favorites'))]/text()
         postProcess:
+          # handle relative hours
+          - javascript: |
+              if (value && value.includes("h ago")) {
+                  const hours = parseInt(value.replace(/(\d+).*/, "$1"))
+                  return new Date(Date.now() - hours * 3600000).toISOString().substring(0, 10)
+              }
+              return value
+          # handle relative days
+          - replace:
+            - regex: (\d+)\s*d(ays)?\sago.*
+              with: $1
+          - subtractDays: true
+          # handle actual date
           - parseDate: 02 Jan 2006
       Image: //video/@data-poster
       Tags:
@@ -49,4 +63,4 @@ xPathScrapers:
             - replace:
                 - regex: \#
                   with:
-# Last Updated October 06, 2020
+# Last Updated April 01, 2025

--- a/scrapers/Motherless.yml
+++ b/scrapers/Motherless.yml
@@ -41,19 +41,22 @@ xPathScrapers:
       Date:
         selector: $meta//div[@class='media-meta-stats']/span[not(contains(.,'Views')) and not(contains(.,'Favorites'))]/text()
         postProcess:
-          # handle relative hours
+          # parse all in JS
           - javascript: |
-              if (value && value.includes("h ago")) {
-                  const hours = parseInt(value.replace(/(\d+).*/, "$1"))
-                  return new Date(Date.now() - hours * 3600000).toISOString().substring(0, 10)
+              let date
+              if (value.includes("m ago")) {
+                date = new Date()
+              } else if (value.includes("h ago")) {
+                const hours = parseInt(value.replace(/(\d+).*/, "$1"))
+                date = new Date(Date.now() - hours * 3600 * 1000)
+              } else if (value.includes ("d ago")) {
+                const days = parseInt(value.replace(/(\d+).*/, "$1"))
+                date = new Date(Date.now() - days * 24 * 3600 * 1000)
+              } else {
+                return value
               }
-              return value
-          # handle relative days
-          - replace:
-            - regex: (\d+)\s*d(ays)?\sago.*
-              with: $1
-          - subtractDays: true
-          # handle actual date
+              return date.toISOString().split("T")[0]
+          - parseDate: 2006-01-02
           - parseDate: 02 Jan 2006
       Image: //video/@data-poster
       Tags:


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

The following example URLs are valid as of right now, if they (at a later date) just show a regular date, go look on https://motherless.com/videos/recent for videos with hours/days offset

### relative hours

This scene _currently_ shows "23h ago"

- https://motherless.com/F70400A

and correctly scrapers to 2025-03-31 (compared to right now, today on 2025-04-01 18:33)

### relative days

scene _currently_ shows "1d ago"

- https://motherless.com/8193902

### regular date

- https://motherless.com/7E70E2D

## Short description

This uses inline JS to parse relative hours, and the native subtractDays feature (as suggested in https://github.com/stashapp/CommunityScrapers/issues/2201#issuecomment-2686796935)

Fixes #2201 
