### PR TITLE
AniDB scraper pulls scene tags from complete tag box

### DIFF
--- a/scrapers/AniDB.yml
+++ b/scrapers/AniDB.yml
@@ -185,7 +185,9 @@ xPathScrapers:
         selector: //div[@itemprop="description"]//text()
         concat: " "
       Tags:
-        Name: $info//div[@id="tab_1_pane"]//span[@class="tagname"]
+        #Name: $info//div[@id="tab_1_pane"]//span[@class="tagname"]
+        # limit to type content indicators, elements, fetishes, level at least 1 star (increase min star level by adjusting in weight, 600 = 3 stars)
+        Name: //div[@class="pane anime_tags"]//div[@class="tag" and (@data-anidb-weight="0" or @data-anidb-weight>="200") and (@data-anidb-groupid="animetb_2604" or @data-anidb-groupid="animetb_2611" or @data-anidb-groupid="animetb_2608")]//span[@class="tagname"]
       Performers:
         Name: $character/a/span
         URL: 


### PR DESCRIPTION
## Scraper type(s)
- [X] sceneByURL

## Examples to test
(examples are intentionally SFW, as NSFW requires account, but tags work the same)

* https://anidb.net/anime/17617
* https://anidb.net/anime/17870

## Short description

The AniDB scraper was pulling the scene tags from a small box on the left, which only had a few preselected tags. This pulls tags from the big tag box towards that bottom, which is much more detailed.

the scene tags returned must fulfill some conditions:
* either no level (grey star), or at least 1 star (is just a XPath filter on the weight attribute)
* is from group indicators, elements, fetishes (ignoring stuff like technical aspects, origins, setting, themes)