### PR TITLE
AniDB scraper tag pull fix of previous PR #2247

### DIFF
--- a/scrapers/AniDB.yml
+++ b/scrapers/AniDB.yml
@@ -187,7 +187,7 @@ xPathScrapers:
       Tags:
         #Name: $info//div[@id="tab_1_pane"]//span[@class="tagname"]
         # limit to type content indicators, elements, fetishes, level at least 1 star (increase min star level by adjusting in weight, 600 = 3 stars)
-        Name: //div[@class="pane anime_tags"]//div[@class="tag" and (@data-anidb-weight="0" or @data-anidb-weight>="200") and (@data-anidb-groupid="animetb_2604" or @data-anidb-groupid="animetb_2611" or @data-anidb-groupid="animetb_2608")]//span[@class="tagname"]
+        Name: //div[@class="pane anime_tags"]//div[@class="tag" and (@data-anidb-weight="0" or number(@data-anidb-weight)>=200) and (@data-anidb-groupid="animetb_2604" or @data-anidb-groupid="animetb_2611" or @data-anidb-groupid="animetb_2608")]//span[@class="tagname"]
       Performers:
         Name: $character/a/span
         URL: 


### PR DESCRIPTION
## Scraper type(s)
- [X] sceneByURL

## Examples to test
(examples are intentionally SFW, as NSFW requires account, but tags work the same)

* https://anidb.net/anime/17617
* https://anidb.net/anime/17870

## Short description

The previous version submitted in #2247 worked fine in XPath extensions in browser, but did not match all tags it should in stashapp itself, most likely due to difference in XPath engine behavior when in comes to attribute number string comparisons like `@data-anidb-weight>="200"`. Actually doing a numeric comparison `number(@data-anidb-weight)>=200` seems to work in both.

My apologies for not testing enough in the actual application, I got mislead by the Browser extension matching everything as expected.