### PR TITLE
Update LucasEntertainment.yml

### DIFF
--- a/scrapers/LucasEntertainment.yml
+++ b/scrapers/LucasEntertainment.yml
@@ -2,7 +2,9 @@ name: Lucas Entertainment
 sceneByURL:
   - action: scrapeXPath
     url:
+      - lucasentertainment.com/movies/
       - lucasentertainment.com/scenes/
+      - lucasentertainment.com/tour/movies/
       - lucasentertainment.com/tour/scenes/
     scraper: sceneScraper
 sceneByName:
@@ -59,6 +61,7 @@ xPathScrapers:
               - regex: (^[a-zA-Z]+\s[0-9]+)[a-z]+(\s[0-9]+$)
                 with: $1$2
           - parseDate: January 2 2006
+          - parseDate: Jan 2, 2006
       Performers:
         Name: $performer/text()
         URL: $performer/@href
@@ -69,7 +72,7 @@ xPathScrapers:
         selector: //script[contains(text(), "image:")]/text()
         postProcess:
           - replace:
-              - regex: "^.*image: '([^']+)'.*$"
+              - regex: "^.*image: ['\"]([^'\"]+)*?['\"].+"
                 with: $1
       Studio: &studioAttr
         Name:
@@ -113,4 +116,4 @@ xPathScrapers:
         postProcess:
           - feetToCm: true
       Image: //div[@class="col-sm-5 col-md-5 col-lg-4 model-main-photo"]/img/@data-original
-# Last Updated August 11, 2024
+# Last Updated April 18, 2025


### PR DESCRIPTION
For those who happen to have full movies instead of individual scenes, but want the performers and other info in the scenes view, it is handy to scrape the movies URLs.  The existing LucasEntertainment scraper is nearly 100% compatible when scraping the movies URLs as scenes.

This update adds the movie URLs to the Scene Scraper, along with a modified Scene by URL Image selector to account for double quotes in the "movies" versions of the script where the image URL is taken.  The movie URLs also show the dates with the Jan 2, 2006 format, so a new parseDate postProcess was added, alongside the existing one that handles the format from the "scene" URLs.

Existing Scene By URL scrapes should work for individual scenes without issue.

## Scraper type(s)
- [x] sceneByURL

## Examples to test

Movie URL to scrape as a scene:  https://www.lucasentertainment.com/movies/view/flexed-and-worshipped
Scene URL to scrape, to ensure the changes did not introduce new problems:  https://www.lucasentertainment.com/scenes/play/michael-lucas-bottoms-for-louis-ricaute