### PR TITLE
Sheer: Doing the 2025 annual update required for date scraping

### DIFF
--- a/scrapers/Sheer.yml
+++ b/scrapers/Sheer.yml
@@ -16,7 +16,7 @@ xPathScrapers:
           - replace:
               # Append the current year for partial dates: this will need to be updated every year
               - regex: ^(\w{3}\s*\d{2})$
-                with: $1, 2024
+                with: $1, 2025
           - parseDate: Jan 02, 2006
       Image: //div[@class="post__sfw-preview"]/img/@src
       Performers:
@@ -26,4 +26,4 @@ xPathScrapers:
       Studio:
         Name: //div[contains(@class, "post__profile-name")]/a/span
         URL: //div[contains(@class, "post__profile-name")]/a/@href
-# Last Updated August 08, 2024
+# Last Updated April 18, 2025


### PR DESCRIPTION
The comment prior to the updated code is pretty self-explanatory for why this commit is required.
