### PR TITLE
Make the Redgifs API lookup case-insensitive

### DIFF
--- a/scrapers/Redgifs/Redgifs.py
+++ b/scrapers/Redgifs/Redgifs.py
@@ -29,7 +29,8 @@ session.headers.update({"Authorization": "Bearer " + get_token()})
 
 
 def scene_by_id(gif_id: str) -> ScrapedScene | None:
-    api_url = f"https://api.redgifs.com/v2/gifs/{gif_id}?users=yes"
+    # The RedGIFs API only works with lowercased IDs, though other IDs are case-insensitive
+    api_url = f"https://api.redgifs.com/v2/gifs/{lower(gif_id)}?users=yes"
 
     req = session.get(api_url)
     if req.status_code != 200:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test
```
majesticnormalrodent
https://www.redgifs.com/watch/majesticnormalrodent
Redhead [majesticnormalrodent]
MajesticNormalRodent
https://www.redgifs.com/watch/MajesticNormalRodent
Redhead [MajesticNormalRodent]
```

## Short description

Updates the redgifs scraper to always use the lowercase form of the ID when hitting the API (even if a gif is named `MysteriousFancyPants`, the API will return the metadata at (only) the lowercase form `mysteriousfancypants`).
