### PR TITLE
[Coomer] Avoid filling RAM for sha256, speedup by matching hash in filename

### DIFF
--- a/scrapers/Coomer/Coomer.py
+++ b/scrapers/Coomer/Coomer.py
@@ -2,6 +2,7 @@ import sys
 import json
 import hashlib
 import stashapi.log as log
+import pathlib
 import requests
 import re
 from bs4 import BeautifulSoup as bs
@@ -104,11 +105,15 @@ def get_scene(inputurl):
     return post_query(service, user, id)
 
 def sceneByFragment(fragment):
-    file = fragment[0]
-    with open(file["path"], "rb") as f:
-        bytes = f.read()
-        readable_hash = hashlib.sha256(bytes).hexdigest()
-        log.debug(f"sha256 hash: {readable_hash}")
+    file = pathlib.Path(fragment[0]["path"])
+    matched_hash = re.search(r"([0-9a-f]{64})", file.name)
+    if matched_hash:
+        readable_hash = matched_hash.group(1)
+        log.debug(f"sha256 hash in file name: {readable_hash}")
+    else:
+        with file.open("rb") as f:
+            readable_hash = hashlib.file_digest(f, "sha256").hexdigest()
+            log.debug(f"calculated sha256 hash: {readable_hash}")
 
     coomer_searchhash_url = "https://coomer.su/api/v1/search_hash/"
 


### PR DESCRIPTION
## Short description

Improves scraping Coomer sceneByFragment by:
- when calculating sha256, using `hashlib.file_digest()` which will hash 256kb at a time, thus not wasting RAM by reading the entire file at once
- if present, uses sha256 hash from filename, since many download tools include it, thus skipping the sha256 calculation and giving immediate results


I realized after making this work that `hashlib.file_digest()` was added in Python 3.11, is support for Python 3.10 (or earlier) required?