### PR TITLE
Add wifey to vixen network

### DIFF
--- a/scrapers/vixenNetwork/vixenNetwork.py
+++ b/scrapers/vixenNetwork/vixenNetwork.py
@@ -272,7 +272,7 @@ class Site:
         up = urlparse(u)
         if up.hostname is None:
             return False
-        if up.hostname.lstrip("www.").rstrip(".com") == self.id.lower():
+        if up.hostname.split('.')[1] == self.id.lower():
             splits = u.split("/")
             if len(splits) < 4:
                 return False
@@ -502,6 +502,7 @@ studios = {
     Site("Tushy Raw", ["Anal Sex"]),
     Site("Slayed", ["Lesbian Sex"]),
     Site("Vixen", []),
+    Site("Wifey", []),
 }
 
 frag = json.loads(sys.stdin.read())

--- a/scrapers/vixenNetwork/vixenNetwork.py
+++ b/scrapers/vixenNetwork/vixenNetwork.py
@@ -273,11 +273,10 @@ class Site:
         if up.hostname is None:
             return False
         if up.hostname.split('.')[1] == self.id.lower():
-            splits = u.split("/")
-            if len(splits) < 4:
+            splits = up.path.split("/")
+            if len(splits) < 3:
                 return False
-            if splits[-2] == "videos":
-                return True
+            return splits[-2] == "videos"
         return False
 
     def getSlug(self, url: str):

--- a/scrapers/vixenNetwork/vixenNetwork.yml
+++ b/scrapers/vixenNetwork/vixenNetwork.yml
@@ -11,6 +11,7 @@ sceneByURL:
       - tushy.com/videos
       - tushyraw.com/videos
       - vixen.com/videos
+      - wifey.com/videos
     action: script
     script:
       - python
@@ -38,4 +39,4 @@ sceneByFragment:
     script:
       - python
       - vixenNetwork.py
-# Last Updated December 30, 2023
+# Last Updated April 21, 2025


### PR DESCRIPTION
Add Wifey (wifey.com) to Vixen Newtork scraper.

## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://www.wifey.com/videos/victoria-and-leo-cute-blonde-hotwife-gets-fucked-doggystyle

## Short description
vixenNetwork.yml:  

Added wifey.com to sceneByURL scraper.

vixenNetwork.py:
Added Wifey to the studios dictionary.

Changed "isValidURL" processing to use split instead of lstrip and rstrip, as the previous implementation was coded under a wrong assumption on how the strip functions work, which resulted in the 'w' from wifey from being stripped.  The new implementation splits on '.' and takes the second element, so www dot wifey dot com becomes "wifey" instead of "ifey".

I've only tested scrape by URL.  Someone more comfortable with the other methods that this scarper supports should test those out (sceneByName, sceneByQueryFragment and sceneByFragment).