### PR TITLE
add tgirl-network.com (network) and ts-baileyjay.com (sub-studio)

### DIFF
--- a/scrapers/TGirlNetwork.yml
+++ b/scrapers/TGirlNetwork.yml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+name: TGirl-Network
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - tgirl-network.com/tour/show_gal.php
+    scraper: tgirlNetworkScraper
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - tgirl-network.com/tour/show_video.php
+    scraper: tgirlNetworkScraper
+xPathScrapers:
+  tgirlNetworkScraper:
+    common:
+      $title: //h1[contains(@class, "galtitle")]
+    scene:
+      Title: &title
+        selector: $title
+      Performers: &performers
+        Name: &performersName
+          selector: //div[contains(@class, "galheader")]
+          postProcess:
+            - replace:
+                - regex: .*The TGirl Network Presents (.*) In.*
+                  with: "$1"
+      Details: &details
+        selector: $title/following-sibling::p
+      Image: &image
+        selector: &imageSel //div[@class="galbox"]/@style
+        postProcess:
+          - replace:
+              - regex: "background-image:\\ ?url\\((.*)\\);"
+                with: "$1"
+              - regex: width=\d+
+                with: width=1920
+              - regex: height=\d+
+                with: height=1080
+              - regex: "&crop=1"
+                with: ""
+              - regex: ^
+                with: https://www.tgirl-network.com/tour/
+      Code: &code
+        selector: *imageSel
+        postProcess:
+          - replace:
+              - regex: "background-image:\\ ?url\\((.*)\\);"
+                with: "$1"
+              - regex: .*gal=(\d+).*
+                with: "$1"
+      Studio: &studio
+        Name: *performersName
+    gallery:
+      Title: *title
+      Performers: *performers
+      Details: *details
+      Code: *code
+      Studio: *studio
+# Last Updated April 22, 2025

--- a/scrapers/TGirlNetwork.yml
+++ b/scrapers/TGirlNetwork.yml
@@ -10,6 +10,10 @@ sceneByURL:
     url:
       - tgirl-network.com/tour/show_video.php
     scraper: tgirlNetworkScraper
+  - action: scrapeXPath
+    url:
+      - ts-baileyjay.com/show_video.php
+    scraper: tsBaileyJayScraper
 xPathScrapers:
   tgirlNetworkScraper:
     common:
@@ -26,9 +30,9 @@ xPathScrapers:
                   with: "$1"
       Details: &details
         selector: $title/following-sibling::p
-      Image: &image
+      Image:
         selector: &imageSel //div[@class="galbox"]/@style
-        postProcess:
+        postProcess: &imagePostProcess
           - replace:
               - regex: "background-image:\\ ?url\\((.*)\\);"
                 with: "$1"
@@ -42,7 +46,7 @@ xPathScrapers:
                 with: https://www.tgirl-network.com/tour/
       Code: &code
         selector: *imageSel
-        postProcess:
+        postProcess: &codePostProcess
           - replace:
               - regex: "background-image:\\ ?url\\((.*)\\);"
                 with: "$1"
@@ -56,4 +60,19 @@ xPathScrapers:
       Details: *details
       Code: *code
       Studio: *studio
+  tsBaileyJayScraper:
+    scene:
+      Title: //tr[1]/td[2]
+      Performers:
+        Name:
+          fixed: Bailey Jay
+      Studio:
+        Name:
+          fixed: Bailey Jay
+      Image:
+        selector: &imageSelTsBaileyJay //tr[1]/td[1]/img/@src
+        postProcess: *imagePostProcess
+      Code:
+        selector: *imageSelTsBaileyJay
+        postProcess: *codePostProcess
 # Last Updated April 22, 2025

--- a/scrapers/TGirlNetwork.yml
+++ b/scrapers/TGirlNetwork.yml
@@ -1,4 +1,11 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
+# You will probably need to add the following environment variable to your stash config:
+#
+# GODEBUG=tlsrsakex=1
+#
+# This is a workaround for the Go TLS library not supporting RSA key exchange.
+# The sites below are currently using RSA key exchange, which is not supported by the Go TLS library.
+# source: https://github.com/stashapp/CommunityScrapers/issues/2064
 name: TGirl-Network
 galleryByURL:
   - action: scrapeXPath


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

### sceneByURL

- https://www.tgirl-network.com/tour/show_video.php?galid=8000&section=255&tview=new
- https://www.tgirl-network.com/tour/show_video.php?galid=13683&section=484&tview=new
- https://www.tgirl-network.com/tour/show_video.php?galid=13399&section=1284&tview=new

### galleryByURL

- https://www.tgirl-network.com/tour/show_gal.php?galid=13396&section=1283&tview=new
- https://www.tgirl-network.com/tour/show_gal.php?galid=13671&section=485&tview=new

## Short description

This adds tgirl-network.com. The studio for each scene or gallery tends to be the same as the performer name, as the sub-studios of TGirl Network generally are.

There doesn't seem to be a way to get the date from the TGirl Network pages, but some studios have tour pages with the most recent scenes with dates, e.g. https://www.ts-baileyjay.com/nwtour2, so those studios can have scene/gallery dates found manually and added to the scraped info.
