### PR TITLE
Add Latina Coochies to TheScoreGroup

### DIFF
--- a/scrapers/TheScoreGroup/TheScoreGroup.py
+++ b/scrapers/TheScoreGroup/TheScoreGroup.py
@@ -52,6 +52,7 @@ STUDIO_MAP = {
     "flatandfuckedmilfs": "Flat and Fucked MILFs",
     "homealonemilfs": "Home Alone MILFs",
     "karinahart": "Karina Hart",
+    "latinacoochies": "Latina Coochies",
     "legsex": "Leg Sex",
     "mickybells": "Micky Bells",
     "milftugs": "MILF Tugs",

--- a/scrapers/TheScoreGroup/TheScoreGroup.yml
+++ b/scrapers/TheScoreGroup/TheScoreGroup.yml
@@ -40,6 +40,7 @@ sceneByURL:
       - flatandfuckedmilfs.com
       - homealonemilfs.com
       - karinahart.com
+      - latinacoochies.com
       - legsex.com
       - mickybells.com
       - milftugs.com
@@ -133,6 +134,7 @@ xPathScrapers:
                 flatandfuckedmilfs: Flat and Fucked MILFs
                 homealonemilfs: Home Alone MILFs
                 karinahart: Karina Hart
+                latinacoochies: Latina Coochies
                 legsex: Leg Sex
                 mickybells: Micky Bells
                 milftugs: MILF Tugs
@@ -199,4 +201,4 @@ xPathScrapers:
               - regex: (\d+[a-zA-Z]{1,3})-\d+(-\d+-\d+)
                 with: $1$2
       Image: //section[@id="model-page"]//img[@class="lazyload"]/@src
-# Last Updated April 01, 2025
+# Last Updated April 22, 2025


### PR DESCRIPTION
Add latinacoochies.com to TheScoreGroup scraper.

## Scraper type(s)
- [x] performerByURL
- [x] sceneByURL

## Examples to test

Performer URL:
https://www.latinacoochies.com/latina-porn-stars/Gabriela-Lopez/9115/

Scene URLs:
https://www.latinacoochies.com/latina-porn-videos/Gabriela-Lopez/78263/
https://www.latinacoochies.com/latina-porn-videos/Charlotte-Queen/78264

## Short description

The Score Group has created Latina Coochies (latinacoochies.com), with URLs that scrape perfectly with the existing Score Group scraper.  This change adds the URL to the scrapers list, and adds the studio to the studios map in the YML and PY files.

It appears that the current Latina Coochies content is made up of scenes that already exist in other studios within The Score Group network, so using a latinacoochies.com URLs is likely to return the studio name for the scene's original studio.  This is pretty much par for the course for The Score Group, and is not necessarily an indication that the scraper is malfunctioning.