### PR TITLE
Fix Nubiles image not scraping issue

### DIFF
--- a/scrapers/Nubiles.yml
+++ b/scrapers/Nubiles.yml
@@ -164,11 +164,7 @@ xPathScrapers:
       Tags: &tagsAttr
         Name: //div[@class="categories"]/a/text()
       Image: &imageAttr
-        selector: //img[@class="fake-video-player-cover"]/@src
-        postProcess:
-          - replace:
-              - regex: ^
-                with: "https:"
+        selector: //video/@poster
 
     gallery:
       Title: &galleryTitleAttr


### PR DESCRIPTION
Simplified Image selector to use the "poster" attribute from the "video" tag.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] sceneByURL

## Examples to test

https://youngermommy.com/video/watch/182474/stepmom-and-i-go-shopping-s3e7
https://nubilefilms.com/video/watch/217292/april-2025-fantasy-of-the-month

## Short description

Studio changed their layout so that the previous Image selector no longer worked (it was adding an additional "https" protocol to the URL.  Looking at some sample pages it appears that a simpler image value can be used.
