### PR TITLE
fix date scraping in virtualrealporn scraper

### DIFF
--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -55,7 +55,8 @@ xPathScrapers:
               - regex: VR [\s\w]+? video$
                 with: ""
       Date: &dateAttr
-        selector: //div[@class="featured_data"]/text()[2]
+        selector: //div[@class="featured_data"]/text()
+        concat: " "
         postProcess:
           - replace:
               - regex: '.* (\w+ \d+, \d{4}).*'
@@ -157,4 +158,4 @@ xPathScrapers:
               }
               return value
       Image: //div[@class="feature_img_model"]/img/@src
-# Last Updated August 21, 2024
+# Last Updated April 29, 2025


### PR DESCRIPTION
- [x] sceneByURL

## Examples to test

- https://virtualrealporn.com/vr-porn-video/anime-girl/
- https://virtualrealporn.com/vr-porn-video/dress-code/

## Short description

Currently the wrong element on the page is selected for scraping, e.g. "VR180 3D" as it is a fixed index of an array. As the regex pattern is reasonably robust to work for the whole div text, this change just concats the whole div to let the regex pick out the date string to parse.
