### PR TITLE
Update NewSensationsNetworkSites.yml

### DIFF
--- a/scrapers/NewSensationsNetworkSites.yml
+++ b/scrapers/NewSensationsNetworkSites.yml
@@ -7,6 +7,7 @@ sceneByURL:
       - freshoutofhighschool.com/tour_fohs/
       - familyxxx.com/tour_famxxx/
       - girlgirlxxx.com/tour_girlgirlxxx/
+      - heavyhandfuls.com/tour_hh/
       - hotwifexxx.com/tour_hwxxx/
       - jizzbomb.com/tour_jb/
       - newsensations.com/tour_rs/
@@ -47,6 +48,7 @@ xPathScrapers:
                 https://jizzbomb.com/tour_jb/: Jizz Bomb
                 https://familyxxx.com/tour_famxxx/: FamilyXXX
                 https://girlgirlxxx.com/tour_girlgirlxxx/: Girl Girl XXX
+                https://heavyhandfuls.com/tour_hh/: Heavy Handfuls
                 https://hotwifexxx.com/tour_hwxxx/: Hot Wife XXX
                 https://newsensations.com/tour_rs/: New Sensations
                 https://parodypass.com/tour_pp/: Parody Pass
@@ -55,4 +57,4 @@ xPathScrapers:
                 https://thelesbianexperience.com/tour_tle/: The Lesbian Experience
                 https://thetabutales.com/tour_tt/: The Tabu Tales
                 https://unlimitedmilfs.com/tour_um/: Unlimited Milfs
-# Last Updated January 21, 2024
+# Last Updated May 2, 2025


### PR DESCRIPTION
Added heavhandfuls.com to scene URL scraper and studio map.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] sceneByURL

## Examples to test

https://heavyhandfuls.com/tour_hh/scenes/New-Sensations-Elizabeth-Skylar-Wife-Cheating-Milf-Big-Tits-Watching_vids.html
https://heavyhandfuls.com/tour_hh/scenes/New-Sensations-Alex-Harper-Milf-Wife-Redhead-Big-Tits_vids.html
https://heavyhandfuls.com/tour_hh/scenes/New-Sensations-Lexi-Stone-Wife-Big-Tits-Interracial-Creampie_vids.html

## Short description

Added heavyhandfuls.com as an additional site to the NewSensations Network scraper.

The site's a bit of a mess, with some scenes not scraping the poster image properly.  Those scenes have a value for the poster attribute, but it does not resolve to an image.