### PR TITLE
Update Movie and Studio Image Selectors for J&M Elite

### DIFF
--- a/scrapers/JacquieEtMichelElite.yml
+++ b/scrapers/JacquieEtMichelElite.yml
@@ -53,7 +53,7 @@ xPathScrapers:
             - regex: ^.+datePublished":\s*"(\d\d\d\d-\d\d-\d\d).+$
               with: $1
       Image: 
-        selector: //div[contains(@class,"video-detail__handler")]/@style | //img[contains(@class,"video-detail__poster__img")]/@src | //img[contains(@class,"video-player__poster__img")]/@data-src
+        selector: //div[contains(@class,"video-detail__handler")]/@style | //img[@id="video-player-poster"]/@src
         postProcess:
           - replace:
             - regex: ^[^']*'([^']*).*

--- a/scrapers/JacquieEtMichelElite.yml
+++ b/scrapers/JacquieEtMichelElite.yml
@@ -39,7 +39,7 @@ xPathScrapers:
         selector: //div[contains(@class,"video-detail__description")]//text()
       Studio:
         Name: //li[contains(@class,"video-detail__info")]/strong[contains(.,'Studio:')]/following-sibling::a
-      FrontImage: //img[contains(@class,"video-detail__poster__img")]/@src
+      FrontImage: //img[contains(@class,"video-detail__poster__img")]/@src | //img[contains(@class,"video-player__poster__img")]/@data-src
   sceneScraper:
     scene:
       Title: 
@@ -53,7 +53,7 @@ xPathScrapers:
             - regex: ^.+datePublished":\s*"(\d\d\d\d-\d\d-\d\d).+$
               with: $1
       Image: 
-        selector: //div[contains(@class,"video-detail__handler")]/@style
+        selector: //div[contains(@class,"video-detail__handler")]/@style | //img[contains(@class,"video-detail__poster__img")]/@src | //img[contains(@class,"video-player__poster__img")]/@data-src
         postProcess:
           - replace:
             - regex: ^[^']*'([^']*).*
@@ -84,4 +84,4 @@ xPathScrapers:
               - regex: ^
                 with: https://www.jacquieetmichelelite.com 
 
-# Last Updated April 15, 2023
+# Last Updated May 5, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] groupByURL

## Examples to test

Scene: https://www.jacquieetmichelelite.com/en/porn-scene-elite/show/8066/an-orgy-to-honor-the-guests.html
Movie: https://www.jacquieetmichelelite.com/en/porn-movie/elite/8058/sweet-cousins.html
Movie: https://www.jacquieetmichelelite.com/en/porn-movie/elite/14976/paparazza.html


## Short description

Added new path to Movie FrontImage selector to match the poster image used in at least some of their releases.

Added new path to Scene Image selector to match the poster image used in at least some of their releases.

Old paths remain in the FrontImage and Image selectors as a defensive measure.  I've not seen those paths in my testing, but my search is far from exhaustive.