### PR TITLE
Update JavDatabase.yml

### DIFF
--- a/scrapers/JavDatabase.yml
+++ b/scrapers/JavDatabase.yml
@@ -1,4 +1,5 @@
 name: JAVDatabase
+
 sceneByURL:
   - action: scrapeXPath
     url:
@@ -45,22 +46,83 @@ xPathScrapers:
         FrontImage: *image
         Studio: *studio
         Duration: &duration
-          selector: &duration //td[contains(.,'Runtime:')]/following-sibling::td
+          selector: //td[contains(.,'Runtime:')]/following-sibling::td
           postProcess:
+            # 1) strip out any parenthetical content, e.g. (HD: 128)
             - replace:
-                - regex: min
-                  with: ":00"
+                - regex: '\s*\(.*?\)'
+                  with: ''
+            # 2) collapse multiple whitespace
+            - replace:
+                - regex: '\s+'
+                  with: ' '
+            # 3) convert “min” or “min.” to “:00”
+            - replace:
+                - regex: 'min\.?'
+                  with: ':00'
+            # 4) remove stray “HD” markers
+            - replace:
+                - regex: 'HD:?'
+                  with: ''
+            # 5) remove space before colon
+            - replace:
+                - regex: '\s+:'
+                  with: ':'
+            # 6) trim leading/trailing whitespace
+            - replace:
+                - regex: '^\s+|\s+$'
+                  with: ''
         URL: &url //link[@rel='canonical']/@href
 
   movieScraper:
     movie:
       Name: *title
-      Synopsis: *details
-      Date: *date
-      Duration: *duration
+      Synopsis:
+        selector: //h4[@class='subhead' and starts-with(normalize-space(.), 'About')]/following-sibling::text()
+        postProcess:
+          - replace:
+              - regex: '\s+'
+                with: ' '
+          - replace:
+              - regex: '^\s+|\s+$'
+                with: ''
+      Date:
+        selector: //p[b[contains(.,'Release Date:')]]/text()
+        postProcess:
+          - replace:
+              - regex: '\s+'
+                with: ' '
+          - replace:
+              - regex: '^\s+|\s+$'
+                with: ''
+      Duration:
+        selector: //p[b[contains(.,'Runtime:')]]/text()
+        postProcess:
+          - replace:
+              - regex: '\s*\(.*?\)'
+                with: ''
+          - replace:
+              - regex: '\s+'
+                with: ' '
+          - replace:
+              - regex: 'min\.?'
+                with: ':00'
+          - replace:
+              - regex: 'HD:?'
+                with: ''
+          - replace:
+              - regex: '\s+:'
+                with: ':'
+          - replace:
+              - regex: '^\s+|\s+$'
+                with: ''
       Director: *director
       FrontImage: *image
-      Studio: *studio
+      Studio:
+        Name:
+          selector: //p[b[contains(.,'Studio:')]]//a/text()
+        URL:
+          selector: //p[b[contains(.,'Studio:')]]//a/@href
       URL: *url
 
   performerScraper:
@@ -71,14 +133,14 @@ xPathScrapers:
         selector: //h1[@class='idol-name']
         postProcess:
           - replace:
-              - regex: (.+)\s*-\s*JAV\sProfile$
-                with: $1
+              - regex: '(.+)\s*-\s*JAV\sProfile$'
+                with: '$1'
       Gender:
         fixed: Female
       Image: //div[@class='idol-portrait']//img/@data-src
       Birthdate: //b[contains(.,'DOB:')]/following-sibling::a
       HairColor: //b[contains(.,'Hair Color(s):')]/following-sibling::a
-      Tags: 
+      Tags:
         Name: //b[contains(.,'Tags:')]/following-sibling::a/text()
       Height:
         selector: //b[contains(.,'Height:')]/following-sibling::a
@@ -90,10 +152,11 @@ xPathScrapers:
         selector: //b[contains(.,'Measurements:')]/following-sibling::text()
         postProcess:
           - replace:
-              - regex: .+?[^\d-]([\d-]+)[^\d-].+
-                with: $1
-            # This can pick up a trailing dash, so get rid of it.
-              - regex: -$
+              - regex: '.+?[^\d-]([\d-]+)[^\d-].+'
+                with: '$1'
+          # remove any trailing dash
+          - replace:
+              - regex: '-$'
                 with: ''
 
-# Last Updated April 16, 2024
+# Last Updated May 6, 2025

--- a/scrapers/JavDatabase.yml
+++ b/scrapers/JavDatabase.yml
@@ -84,19 +84,13 @@ xPathScrapers:
         URL: &url //link[@rel='canonical']/@href
 
   movieScraper:
+    common:
+      $infobox: //div[@class="movietable"]/div[@class="row"][1]
     movie:
       Name: *title
-      Synopsis:
-        selector: //h4[@class='subhead' and starts-with(normalize-space(.), 'About')]/following-sibling::text()
-        postProcess:
-          - replace:
-              - regex: '\s+'
-                with: ' '
-          - replace:
-              - regex: '^\s+|\s+$'
-                with: ''
+      Synopsis: $infobox/div[2]/p[1]/text()
       Date:
-        selector: //p[b[contains(.,'Release Date:')]]/text()
+        selector: $infobox//p[b[contains(.,'Release Date:')]]/text()
         postProcess:
           - replace:
               - regex: '\s+'
@@ -105,7 +99,7 @@ xPathScrapers:
               - regex: '^\s+|\s+$'
                 with: ''
       Duration:
-        selector: //p[b[contains(.,'Runtime:')]]/text()
+        selector: $infobox//p[b[contains(.,'Runtime:')]]/text()
         postProcess:
           - replace:
               - regex: '\s*\(.*?\)'
@@ -129,9 +123,9 @@ xPathScrapers:
       FrontImage: *image
       Studio:
         Name:
-          selector: //p[b[contains(.,'Studio:')]]//a/text()
+          selector: $infobox//p[b[contains(.,'Studio:')]]//a/text()
         URL:
-          selector: //p[b[contains(.,'Studio:')]]//a/@href
+          selector: $infobox//p[b[contains(.,'Studio:')]]//a/@href
       URL: *url
 
   performerScraper:
@@ -181,7 +175,7 @@ xPathScrapers:
       Studio:
         Name: $videoItem/p/span[../b[contains(.,'Studio:')]]/a[@rel='tag']/text()
       Performers:
-        Name: 
+        Name:
           selector: $videoItem/p/span[../b[contains(.,'Idol(s)/Actress(es):')]]/a/text()
         URL: $videoItem/p/span[../b[contains(.,'Idol(s)/Actress(es):')]]/a/@href
       Image: /html/head/meta[@property='og:image']/@content


### PR DESCRIPTION
Duration: Updated XPath selector and added multiple regex-based post-processing steps to improve formatting. This now strips out unwanted parenthetical content (e.g., “(HD: 128)”), replaces “min” or “min.” with “:00”, collapses multiple spaces, removes stray “HD” labels, and trims unnecessary whitespace. This prevents outputs like `"120 :00"` or `"120 (HD: 120)"` and ensures consistent formatting such as `"120:00"`.

Synopsis: Replaced the reused `*details` anchor with a dedicated XPath selector that explicitly targets the synopsis block following the “About” header. The previous approach missed many valid entries and often returned `Unknown`. The new logic ensures accurate scraping of descriptive text and includes whitespace normalization for clean output.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] performerByURL
- [x] sceneByURL
- [x] movieByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

https://www.javdatabase.com/movies/tek-102/  
https://www.javdatabase.com/movies/cosx-085/  
https://www.javdatabase.com/movies/hmdnv-815/  

## Short description

Improved accuracy and formatting of the `Duration` and `Synopsis` fields for scene and movie scrapers. Fixes missing or malformed data in those fields by using targeted XPath selectors and thorough post-processing cleanup.

--Generated by ChatGPT because I'm lazy...xD
