### PR TITLE
fix lewood.com URL scraping via evilangel

### DIFF
--- a/scrapers/EvilAngel/EvilAngel.py
+++ b/scrapers/EvilAngel/EvilAngel.py
@@ -148,6 +148,7 @@ def fix_url(_url: str) -> str:
         site = site_from_url(_url)
         # if the site does not have a real/working domain
         if site in [
+            "lewood",   # real site, but uses AdultEmpireCash system rather than Algolia
             "lexingtonsteele",
         ]:
             return urlparse(_url)._replace(netloc="www.evilangel.com").geturl()


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.evilangel.com/en/video/evilangel/Cream-Of-Cleavage-Sofis-Natural-Jugs/126145

## Short description

The lewood.com uses AdultEmpireCash so the scene IDs and URLs are completely different

e.g. corresponding scene URL: https://www.lewood.com/508940/lewood-black-haired-babe-uses-a-vibrating-wand-and-enjoys-a-big-dick-streaming-scene-video.html
