### PR TITLE
fix for getting the video release date TMDB.yml

### DIFF
--- a/scrapers/TMDB.yml
+++ b/scrapers/TMDB.yml
@@ -34,7 +34,7 @@ xPathScrapers:
           - replace:
               - regex: \(.*$
                 with:
-          - parseDate: 02/01/2006
+          - parseDate: 01/02/2006
       Synopsis: &details //div[@class='header_info']/div[@class='overview']/p
       URL: //meta[@name='og:url']/@content
       FrontImage: &image
@@ -86,4 +86,4 @@ driver:
           # {"adult":true,"i18n_fallback_language":"en-US","locale":"en-US","country_code":"US","timezone":"America/Pacific"}
           Value: "%7B%22adult%22%3Atrue%2C%22i18n_fallback_language%22%3A%22en-US%22%2C%22locale%22%3A%22en-US%22%2C%22country_code%22%3A%22US%22%2C%22timezone%22%3A%22America%2FPacific%22%7D"
           Path: "/"
-# Last Updated April 14, 2024
+# Last Updated May 12, 2025


### PR DESCRIPTION
according to some links, the scraper received a date format that stash did not perceive as correct

## Examples to test

https://www.themoviedb.org/movie/574475-final-destination-bloodlines
https://www.themoviedb.org/movie/1233069-exterritorial
https://www.themoviedb.org/movie/1197306-a-working-man

## Short description

Describe the general changes
Now the scraper always gets the date in the same stash-compatible format.

before
![1](https://github.com/user-attachments/assets/46449a49-c92a-4954-ada3-14d9f7583402)

after
![2](https://github.com/user-attachments/assets/f9bf5550-ecc9-4baf-adf9-94eb19c3be90)
