### PR TITLE
Update GroobyNetwork-Partial.yml to handle performer names in titles

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -213,7 +213,7 @@ xPathScrapers:
       Measurements: //li/b[text()="Breast Size:"]/following-sibling::text()
   sceneScraper:
     scene:
-      Title: &title //p[@class="trailertitle"]/text()|//div[@class="trailer_toptitle_left"]/text()
+      Title: &title //p[@class="trailertitle"]/text()|//div[@class="trailer_toptitle_left"]/text()[last()]
       Date: &date
         selector: //div[@class="setdesc"]//b[contains(.,"Added")]/following-sibling::text()[1]
         postProcess:
@@ -299,4 +299,4 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.transvr.com/
       Tags: *tagsVR
-# Last Updated November 22, 2024
+# Last Updated May 16, 2025


### PR DESCRIPTION


## Examples to test
* https://www.transnificent.com/tour/trailers/Felix-Raunchy-Job-Interview.html
* https://www.realtgirls.com/tour/trailers/Probation-Officer-Jenna-Jaden-Gets-Attitude-Adjustment-From-Smash-Thompson.html


## Short description

For several sites covered by this scraper, when there are multiple performers, the scene title will include the performer names (linked to the performer page) and then the title. This causes the xpath to just result in a title of `&`. I think what's happening here is when there are 2 or more performers, the `&` between the performer names is getting captured as a `text()` value and being picked up as the scene title.

To fix this, I've adjusted the xpath query to only take the *last* text element when matching the `trailer_toptitle_left` element. I manually tested these changes against all the other sites for this scraper to confirm that this change doesn't break their ability to scrape the scene title.

I didn't make this change for the other `trailertitle` selector, because for the sites that have that element, it seems to always be the original scene title without any extra text.