### PR TITLE
New PetersKingdom Network Scene URL Scraper

### DIFF
--- a/scrapers/PetersKingdom.yml
+++ b/scrapers/PetersKingdom.yml
@@ -1,0 +1,27 @@
+name: PetersKingdom
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - dirtycinema.com
+      - milfuckd.com
+      - mypovfam.com
+      - passionsonly.com
+      - pervertedpov.com    
+      - peterskingdom.com
+      - rawwhitemeat.com
+      - slutsaroundtown.com
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //h1
+      Details: //div[contains(@class,'info__content')]/p | //div[@class='e-con-inner']//div[not(h2) and @class='elementor-widget-container']/text()
+      Image: //video/@poster
+      Studio:
+        Name: //a[contains(@class,'header__logo')]/img/@alt
+      Performers:
+        Name: //span[contains(.,'Starring')]/a | //a[contains(@href,'performers') and @class='jet-listing-dynamic-terms__link']
+
+# Last Updated May 16, 2025


### PR DESCRIPTION

## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://dirtycinema.com/videos/forever-episode-2/
https://milfuckd.com/videos/hotwife-seduces-gym-hookup/
https://www.mypovfam.com/videos/stepsister-found-my-dick-pics/
https://www.passionsonly.com/videos/exes-reconnect-with-breakup-fuck/
https://pervertedpov.com/videos/date-night-ends-with-kinky-hookup/
https://peterskingdom.com/videos/red-headed-girl-next-door-gets-nasty/
https://rawwhitemeat.com/videos/athletic-babe-begs-for-deep-anal-pounding/
https://slutsaroundtown.com/videos/slutty-fairy-gets-magical-anal-orgasm/

## Short description
New scraper for sites under PetersKingdom network.  No date or tag information in the HTML, unfortunately.
