### PR TITLE
Add a few more studio overrides to AdultTime

### DIFF
--- a/scrapers/AdultTime/AdultTime.py
+++ b/scrapers/AdultTime/AdultTime.py
@@ -188,6 +188,7 @@ site_map = {
     "bethecuck": "Be the Cuck",
     "devilstgirls": "Devil's Tgirls",
     "girlsunderarrest": "Girls Under Arrest",
+    "officemsconduct-channel": "Transfixed",
     "SuperHornyFunTime": "Super Horny Fun Time",
 }
 """
@@ -230,6 +231,7 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
         return site_map.get(site_match, site_match)
     if serie_name in [
         *serie_name_map,
+        "Accidental Gangbang",
         "Casey: A True Story",
         "Feed Me",
         "Future Darkly",
@@ -238,6 +240,7 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
         "Mommy's Boy",
         "Oopsie",
         "Sister Trick",
+        "Up Close",
         "Up Close VR",
         "Women's World",
     ]:
@@ -246,6 +249,7 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
     if network_name in [
         "Adult Time Films"
     ]:
+        log.debug(f"matched network_name '{network_name}'")
         return network_name_map.get(network_name, network_name)
     if sitename_pretty in [
         *sitename_pretty_map,
@@ -258,6 +262,7 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
         # most scenes have the studio name as the main channel name
         log.debug(f"matched main_channel_name '{main_channel_name}'")
         return channel_name_map.get(main_channel_name, main_channel_name)
+    log.debug("no override matched")
     return None
 
 

--- a/scrapers/AlgoliaAPI/AlgoliaAPI.py
+++ b/scrapers/AlgoliaAPI/AlgoliaAPI.py
@@ -464,6 +464,10 @@ def to_scraped_gallery(api_hit: dict[str, Any], site: str) -> ScrapedGallery | N
         gallery["performers"] = actors_to_performers(actors, site)
     if directors := api_hit.get("directors"):
         gallery["photographer"] = name_values_as_csv(directors)
+    # photosets have their own cover image
+    if picture := api_hit.get("picture"):
+        # just log this out, to aid user in selecting the cover image
+        log.info(f"Cover image: {IMAGE_CDN}/photo_set{picture}")
     return gallery
 
 def gallery_from_set_id(


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [x] galleryByFragment
- [x] galleryByURL

## Examples to test

- https://www.puretaboo.com/en/photo/Up-Close-with-Cubbi-Thompson/124309
- https://www.puretaboo.com/en/photo/Too-Many-Tops/127136
- https://www.puretaboo.com/en/photo/Office-Ms-Conduct/101153

## Short description

This adds a few studio overrides to set the right studio when scraping scenes, galleries, and movies/groups.

Bonus feature: when scraping a gallery, the `picture` property is logged out as a full URL to give the photo set cover image. This can be used by a user to manually select and set the cover image for a photo set.
