### PR TITLE
Improve studio matching in blowpass

### DIFF
--- a/scrapers/Blowpass/Blowpass.py
+++ b/scrapers/Blowpass/Blowpass.py
@@ -42,6 +42,7 @@ Each serie_name requiring a map/override should have a key-value here
 """
 
 site_map = {
+    "sunlustxxx": "Sun Lust XXX",
 }
 """
 Each site found in the logic should have a key-value here
@@ -65,6 +66,13 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
         f"sitename_pretty: {sitename_pretty}, "
     )
 
+    if serie_name in [
+        *serie_name_map,
+        "Blowbanged",
+        "Squirting Orgies",
+    ]:
+        log.debug(f"matched serie_name '{serie_name}'")
+        return serie_name_map.get(serie_name, serie_name)
     # steps through api_scene["availableOnSite"], and picks the first match
     if site_match := next(
         (site for site in available_on_site if site in site_map),
@@ -72,11 +80,6 @@ def determine_studio(api_object: dict[str, Any]) -> str | None:
     ):
         log.debug(f"matched site '{site_match}'")
         return site_map.get(site_match, site_match)
-    if serie_name in [
-        *serie_name_map,
-    ]:
-        log.debug(f"matched serie_name '{serie_name}'")
-        return serie_name_map.get(serie_name, serie_name)
     if main_channel_name:
         log.debug(f"matched main_channel_name '{main_channel_name}'")
         # most scenes have the studio name as the main channel name

--- a/scrapers/Blowpass/Blowpass.yml
+++ b/scrapers/Blowpass/Blowpass.yml
@@ -36,4 +36,58 @@ sceneByQueryFragment:
     - Blowpass.py
     - blowpass
     - scene-by-query-fragment
-# Last Updated January 30, 2025
+galleryByFragment:
+  action: script
+  script:
+    - python
+    - Blowpass.py
+    - blowpass
+    - gallery-by-fragment
+galleryByURL:
+  - action: script
+    url:
+      - 1000facials.com/en/photo/
+      - 1000facials.com/en/video/
+      - blowpass.com/en/photo/
+      - blowpass.com/en/video/
+      - immorallive.com/en/photo/
+      - immorallive.com/en/video/
+      - mommyblowsbest.com/en/photo/
+      - mommyblowsbest.com/en/video/
+      - onlyteenblowjobs.com/en/photo/
+      - onlyteenblowjobs.com/en/video/
+      - throated.com/en/photo/
+      - throated.com/en/video/
+    script:
+      - python
+      - Blowpass.py
+      - blowpass
+      - gallery-by-url
+performerByURL:
+  - action: script
+    url:
+      - 1000facials.com/en/pornstar/
+      - blowpass.com/en/pornstar/
+      - immorallive.com/en/pornstar/
+      - mommyblowsbest.com/en/pornstar/
+      - onlyteenblowjobs.com/en/pornstar/
+      - throated.com/en/pornstar/
+    script:
+      - python
+      - Blowpass.py
+      - performer-by-url
+performerByName:
+  action: script
+  script:
+    - python
+    - Blowpass.py
+    - blowpass
+    - performer-by-name
+performerByFragment:
+  action: script
+  script:
+    - python
+    - Blowpass.py
+    - blowpass
+    - performer-by-fragment
+# Last Updated May 23, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByName
- [x] performerByFragment
- [x] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] galleryByFragment
- [x] galleryByURL

## Examples to test

- https://www.blowpass.com/en/video/blowpass/Maddy-OReillys-12-Guy-Blowbang/132228
- https://www.blowpass.com/en/video/blowpass/Jessie-And-Addison-Have-Young-Squirting-Pussies/77319
- https://www.blowpass.com/en/video/blowpass/Birthday-Goodies/75734

## Short description

I checked through the Blowpass sub-studios and adjusted the studio matching slightly for the 3 scenarios above.

Bonus: added performer and gallery scraping for all sites.
