### PR TITLE
AdultDVDMarketPlace CDP Age Prompt Click-through

### DIFF
--- a/scrapers/AdultDvdMarketPlace.yml
+++ b/scrapers/AdultDvdMarketPlace.yml
@@ -70,4 +70,9 @@ xPathScrapers:
       Tags:
         Name: //span[text()="Category:"]/following-sibling::a
 
-# Last Updated September 07, 2020
+driver:
+  useCDP: true
+  clicks:
+    - xpath: //a[contains(text(), "ENTER")]
+
+# Last Updated May 25, 2025


### PR DESCRIPTION
## Scraper type(s)
Config update for all xPath scrapers.

## Examples to test

[sceneByURL: Rough Love 3](https://www.adultdvdmarketplace.com/dvd_view_416507.html)

## Short description

Add click on "ENTER" button when scraping.
Quick'n'dirty fix that adds unnecessary overhead, should move to a script in the future that calls "www.adultdvdmarketplace.com/xcart/adult_dvd/disclaimer.php?action=enter" once before scraping.
