### PR TITLE
wallhaven.cc scraper

### DIFF
--- a/scrapers/Wallhaven.yml
+++ b/scrapers/Wallhaven.yml
@@ -1,0 +1,47 @@
+name: Wallhaven
+imageByURL:
+  - action: scrapeJson
+    url: 
+      - wallhaven.cc/w/
+    scraper: imageScraper
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        - regex: '^https://wallhaven.cc/w/(.+)$'
+          with: https://wallhaven.cc/api/v1/w/$1
+
+jsonScrapers:
+  imageScraper:
+    image:
+      Title:
+        selector: '[[[data.tags.#(category=="Models")#]|@flatten.#(name!="model")#,data.tags.#(category=="Pornstars")#,[data.tags.#(category%"*Characters")#]|@flatten.#(name!="anime girls")#]|@flatten.#.name,[data.tags.#(category=="Companies & Logos")#,data.tags.#(category=="Photographers")#,data.tags.#(category=="Artists")#]|@flatten.0.name,[[[[[[data.tags.#(category!="Models")#]|@flatten.#(category!="Pornstars")#]|@flatten.#(category!%"*Characters")#]|@flatten.#(category!="Photographers")#]|@flatten.#(category!="Artists")#]|@flatten.#(category!="Companies & Logos")#.name]|@flatten]|@flatten'
+        concat: " "
+      Code: data.id
+      Date:
+        selector: data.created_at
+        postProcess:
+          - replace:
+            - regex: '^(\d{4}-\d{2}-\d{2}).*'
+              with: $1
+      Details:
+        selector: '[data.category,data.purity,data.uploader.username]'
+        concat: " "
+      Photographer:
+        selector: '[data.tags.#(category=="Photographers")#,data.tags.#(category=="Artists")#]|@flatten.0.name'
+      URLs:
+        selector: '[data.url,data.short_url]'
+      Studio:
+        Name:
+          selector: '[data.tags.#(category=="Companies & Logos")#,data.tags.#(category=="Photographers")#,data.tags.#(category=="Artists")#]|@flatten.0.name'
+      Tags:
+        Name:
+          selector: '[!"wallpaper",[[[[[data.tags.#(category!="Models")#]|@flatten.#(category!="Pornstars")#]|@flatten.#(category!%"*Characters")#]|@flatten.#(category!="Photographers")#]|@flatten.#(category!="Artists")#]|@flatten.#(category!="Companies & Logos")#.name]|@flatten'
+      Performers:
+        Name:
+          selector: '[[data.tags.#(category=="Models")#]|@flatten.#(name!="model")#,data.tags.#(category=="Pornstars")#,[data.tags.#(category%"*Characters")#]|@flatten.#(name!="anime girls")#]|@flatten.#.name'
+
+# NSFW needs account and API key
+#driver:
+#  headers:
+#    - Key: X-API-Key
+#      Value: <API-Key>

--- a/scrapers/Wallhaven.yml
+++ b/scrapers/Wallhaven.yml
@@ -3,11 +3,12 @@ imageByURL:
   - action: scrapeJson
     url: 
       - wallhaven.cc/w/
+      - whvn.cc/
     scraper: imageScraper
     queryURL: "{url}"
     queryURLReplace:
       url:
-        - regex: '^https://wallhaven.cc/w/(.+)$'
+        - regex: .+([\w\d]{6})$
           with: https://wallhaven.cc/api/v1/w/$1
 
 jsonScrapers:


### PR DESCRIPTION
## Scraper type(s)
- [X] imageByURL

## Examples to test

SFW because NSFW needs account and API token

https://wallhaven.cc/w/9dqojx
https://wallhaven.cc/w/yxd8jk

## Short description

I know this a a REALLY niche use case, but I needed a scraper for Wallhaven wallpapers, so I figured I might as well share it, maybe someone else has a use for it. In my experience, Wallhaven has a huge amount of very well-tagged NSFW wallpapers.

Some key points:
* the title is cobbled together, roughly `Persons (Model, Pornstar, Character)` + `Producers (Brand, Phorographer, Artist)` + `all other tags`
* studio is either first company tag (to pick up studios like MetArt), first photographer tag (e.g. Hegre is just "Peter Hegre"), or first artist tag (for drawn / rendered content)
* Performers should be all tags from the categories Models, Pornstars or Characters, but some other tags are organized wrong in the site and pop up there as well, can't fix that
* access to NSFW content needs an account on the site and an API key configured in the currently commented out driver section, otherwise they will not be visible

I know the GJSON expressions are a mess, but GSJON queries really need boolean operator support, and as far as I can tell, there isn't, so this nasty trick of nesting arrays will have to do.
