### PR TITLE
Fix Eporner (sceneByURL, sceneByName)

### DIFF
--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -51,35 +51,9 @@ driver:
   cookies:
     - CookieURL: "https://www.eporner.com"
       Cookies:
-        - Name: "ADBp"
-          Domain: "www.eporner.com"
-          Value: "yes"
-          Path: "/"
-    - CookieURL: "https://www.eporner.com"
-      Cookies:
-        - Name: "ADBpcount"
-          Domain: "www.eporner.com"
-          Value: "1"
-          Path: "/"
-    - CookieURL: "https://www.eporner.com"
-      Cookies:
-        # may need replaced
-        - Name: "ap.KEytYDvIqp1"
-          Domain: "www.eporner.com"
-          Value: "true"
-          Path: "/"
-    - CookieURL: "https://www.eporner.com"
-      Cookies:
-        - Name: "EPRNS"
-          Domain: "www.eporner.com"
-          # replace with your EPRNS value
-          Value: ""
-          Path: "/"
-    - CookieURL: "https://www.eporner.com"
-      Cookies:
         - Name: "PHPSESSID"
           Domain: ".eporner.com"
-          # replace with your phpsessid
+          # replace with PHPSESSID from logged in browser
           Value: ""
           Path: "/"
 # Last Updated May 26, 2025

--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -47,4 +47,39 @@ xPathScrapers:
       Image: //meta[@property="og:image"]/@content
       URL: //meta[@property="og:url"]/@content
 
-# Last Updated August 26, 2024
+driver:
+  cookies:
+    - CookieURL: "https://www.eporner.com"
+      Cookies:
+        - Name: "ADBp"
+          Domain: "www.eporner.com"
+          Value: "yes"
+          Path: "/"
+    - CookieURL: "https://www.eporner.com"
+      Cookies:
+        - Name: "ADBpcount"
+          Domain: "www.eporner.com"
+          Value: "1"
+          Path: "/"
+    - CookieURL: "https://www.eporner.com"
+      Cookies:
+        # may need replaced
+        - Name: "ap.KEytYDvIqp1"
+          Domain: "www.eporner.com"
+          Value: "true"
+          Path: "/"
+    - CookieURL: "https://www.eporner.com"
+      Cookies:
+        - Name: "EPRNS"
+          Domain: "www.eporner.com"
+          # replace with your EPRNS value
+          Value: ""
+          Path: "/"
+    - CookieURL: "https://www.eporner.com"
+      Cookies:
+        - Name: "PHPSESSID"
+          Domain: ".eporner.com"
+          # replace with your phpsessid
+          Value: ""
+          Path: "/"
+# Last Updated May 26, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] sceneByName
- [x] sceneByURL

## Examples to test
https://www.eporner.com/video-jjeDsNksaKo/rosa-romano-ti-rompo-il-culo-2006-scene-3/
https://www.eporner.com/video-aWFaj0kfhN5/big-ass-blondie-girl-tries-hard-cocks/

## Short description
- sceneByURL would throw: `scrapeSceneURL: input: scrapeSceneURL Internal system error. Error <runtime error: index out of range [0] with length 0>`

- And sceneByName showed no error, only the No Scenes Found toast and nothing in the logs.
