### PR TITLE
Add Date selector to Explicite-Art scrapers

### DIFF
--- a/scrapers/ExpliciteArt.yml
+++ b/scrapers/ExpliciteArt.yml
@@ -32,6 +32,13 @@ xPathScrapers:
         Name:
           fixed: Explicite Art
       Title: //div[@class="header"]//h1 #//head/title
+      Date:
+        selector: $info
+        postProcess:
+          - replace:
+              - regex: '^.+?(\d+)\sdays\sago.*$'
+                with: $1
+          - subtractDays: true
 
   galleryScraper:
     common:
@@ -46,4 +53,11 @@ xPathScrapers:
         Name:
           fixed: Explicite Art
       Title: //div[@class="header"]//h1 #//head/title
-# Last Updated November 14, 2020
+      Date:
+        selector: $info
+        postProcess:
+          - replace:
+              - regex: '^.+?(\d+)\sdays\sago.*$'
+                with: $1
+          - subtractDays: true
+# Last Updated May 27, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] galleryByURL

## Examples to test
### Scenes
https://www.explicite-art.com/visitor/video/hard-anal-fuck-and-submission-for-a-shy-french-teen-girl-2-2-2883.html
https://www.explicite-art.com/visitor/video/tender-lesbian-video-with-an-arabic-beauty-and-a-french-babe-2198.html
https://www.explicite-art.com/visitor/video/hairy-french-teen-fucked-hard-2-2-3224.html
### Galleries
https://www.explicite-art.com/visitor/gallerie/lovely-french-teen-naked-3439.html
https://www.explicite-art.com/visitor/gallerie/photos-french-make-up-artist-seduced-by-porn-actress-stripping-nude-131.html
https://www.explicite-art.com/visitor/gallerie/hairy-pussy-french-teen-first-time-masturbation-3202.html
## Short description
Added Date selector to sceneByURL and galleryByURL scrapers, using "subtractDays" postProcess.

A sampling of scenes and galleries all have the X days ago format.  There may be a case where this isn't so, but I've not discovered it.