### PR TITLE
Fix XHamster scene scraping

### DIFF
--- a/scrapers/Xhamster.yml
+++ b/scrapers/Xhamster.yml
@@ -46,7 +46,7 @@ xPathScrapers:
     common:
       $player: //div[@class="width-wrap with-player-container"]
     scene:
-      Title: $player/h1
+      Title: $player//h1
       Details: //div[@class="ab-info controls-info__item xh-helper-hidden"]/p
       URL: //meta[@property='og:url']/@content|//meta[@name='twitter:url']/@content
       Date:
@@ -59,7 +59,7 @@ xPathScrapers:
       Image: //link[@as="image"]/@href
       Studio:
         Name:
-          selector: $player/nav//a[contains(@href,"/channels/")]/span
+          selector: $player/nav//a[contains(@href,"/channels/")]//div[contains(@class,"content")]/span
       Tags:
         Name:
           selector: $player/nav//a[contains(@href,"/categories/") or contains(@href,"/tags/")]

--- a/scrapers/Xhamster.yml
+++ b/scrapers/Xhamster.yml
@@ -45,8 +45,8 @@ xPathScrapers:
   sceneScraper:
     common:
       $player: //div[@class="width-wrap with-player-container"]
-      $creator: $player/nav//a[contains(@href,"/creators/")]//div[contains(@class,"content")]/span
-      $user: $player/nav//a[contains(@href,"/users/")]//div[contains(@class,"content")]/span
+      $creator: //div[@class="width-wrap with-player-container"]/nav//a[contains(@href,"/creators/")]//div[contains(@class,"content")]/span
+      $user: //div[@class="width-wrap with-player-container"]/nav//a[contains(@href,"/users/")]//div[contains(@class,"content")]/span
     scene:
       Title: $player//h1
       Details: //div[@class="ab-info controls-info__item xh-helper-hidden"]/p

--- a/scrapers/Xhamster.yml
+++ b/scrapers/Xhamster.yml
@@ -45,6 +45,8 @@ xPathScrapers:
   sceneScraper:
     common:
       $player: //div[@class="width-wrap with-player-container"]
+      $creator: $player/nav//a[contains(@href,"/creators/")]//div[contains(@class,"content")]/span
+      $user: $player/nav//a[contains(@href,"/users/")]//div[contains(@class,"content")]/span
     scene:
       Title: $player//h1
       Details: //div[@class="ab-info controls-info__item xh-helper-hidden"]/p
@@ -59,11 +61,11 @@ xPathScrapers:
       Image: //link[@as="image"]/@href
       Studio:
         Name:
-          selector: $player/nav//a[contains(@href,"/channels/")]//div[contains(@class,"content")]/span
+          selector: $player/nav//a[contains(@href,"/channels/")]//div[contains(@class,"content")]/span | $creator | $user
       Tags:
         Name:
           selector: $player/nav//a[contains(@href,"/categories/") or contains(@href,"/tags/")]
       Performers:
         Name:
-          selector: $player/nav//a[contains(@href,"/pornstars/")]
+          selector: $player/nav//a[contains(@href,"/pornstars/")] | $creator | $user
 # Last Updated February 17, 2024

--- a/scrapers/Xhamster.yml
+++ b/scrapers/Xhamster.yml
@@ -68,4 +68,4 @@ xPathScrapers:
       Performers:
         Name:
           selector: $player/nav//a[contains(@href,"/pornstars/")] | $creator | $user
-# Last Updated February 17, 2024
+# Last Updated May 28, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

https://xhamster.com/videos/horny-for-cock-gogo-fukme-paris-the-muse-destiny-mira-seduce-van-until-they-get-what-they-want-brazzers-xhRZgf3
https://xhamster.com/videos/stepmom-gives-a-good-blowjob-to-her-stepson-in-his-bed-xhDYAmQ
https://xhamster.com/videos/unplanned-sex-sharing-bed-between-stepson-and-his-stepmom-xhorEYJ

## Short description

- Fix scraping title correctly.
- Add creators and users scraping to be used as performers and studios.