### PR TITLE
AdultPrime fix scraping tags

### DIFF
--- a/scrapers/AdultPrime.yml
+++ b/scrapers/AdultPrime.yml
@@ -76,8 +76,7 @@ xPathScrapers:
         Name: $scene//b[contains(.,"Studio")]/a | $scene//b[contains(.,"Studio")]/following-sibling::a
       Tags:
         Name:
-          selector: $scene//b[contains(.,"Niches")]/following-sibling::text()
-          split: ", "
+          selector: $scene//b[contains(.,"Niches")]/following-sibling::a
 
   secondarySite:
     common:


### PR DESCRIPTION
Fix for AdultPrime scraper, currently it fails to scrape tags

## Scraper type(s)
- [x] sceneByURL

## Examples to test

https://adultprime.com/studios/video?id=136163
