### PR TITLE
Update Eporner.yml

### DIFF
--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -17,7 +17,7 @@ sceneByFragment:
   queryURL: https://www.eporner.com/video-{filename}/ # Scrapes data on video so long as the EPORNER video id is in the filename
   queryURLReplace:
     filename:
-      - regex: '(EPORNER\.COM - \[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
+      - regex: '(\[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
         with: $2
   scraper: singleSceneScrape
 

--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -55,24 +55,24 @@ xPathScrapers:
       Image: //meta[@property="og:image"]/@content
       URL: //meta[@property="og:url"]/@content
     sceneScraper:
-    scene:
-      Title:
-        selector: //*[@id="video-info"]/h1/text()
-      Date:
-        selector: //script[contains(.,"uploadDate")]/text()
-        postProcess:
-          - replace:
-              - regex: .*uploadDate":\s"(\d{4}-\d{2}-\d{2})T.*
-                with: $1
-          - parseDate: 2006-01-02
-      Performers:
-        Name: //*[@id="video-info-tags"]/ul//li[@class='vit-pornstar starw']/a/text()
-      Tags:
-        Name: //*[@id="video-info-tags"]/ul//li[@class='vit-category' or @class='vit-tag']/a/text()
-      Studio:
-        Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
-      Image: //meta[@property="og:image"]/@content
-      URL: //meta[@property="og:url"]/@content
+      scene:
+        Title:
+          selector: //*[@id="video-info"]/h1/text()
+        Date:
+          selector: //script[contains(.,"uploadDate")]/text()
+          postProcess:
+            - replace:
+                - regex: .*uploadDate":\s"(\d{4}-\d{2}-\d{2})T.*
+                  with: $1
+            - parseDate: 2006-01-02
+        Performers:
+          Name: //*[@id="video-info-tags"]/ul//li[@class='vit-pornstar starw']/a/text()
+        Tags:
+          Name: //*[@id="video-info-tags"]/ul//li[@class='vit-category' or @class='vit-tag']/a/text()
+        Studio:
+          Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
+        Image: //meta[@property="og:image"]/@content
+        URL: //meta[@property="og:url"]/@content
   singleSceneScrape:
     scene:
       Title: //div[@id = 'video-info']/h1/text()

--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -17,7 +17,7 @@ sceneByFragment:
   queryURL: https://www.eporner.com/video-{filename}/ # Scrapes data on video so long as the EPORNER video id is in the filename
   queryURLReplace:
     filename:
-      - regex: '(.*\[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
+      - regex: '(.*\[)(\w+)(\]{1}.*)'
         with: $2
   scraper: sceneScraper
 

--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -12,6 +12,14 @@ sceneByQueryFragment:
   action: scrapeXPath
   queryURL: "{url}"
   scraper: sceneScraper
+sceneByFragment:
+  action: scrapeXPath
+  queryURL: https://www.eporner.com/video-{filename}/ # Scrapes data on video so long as the EPORNER video id is in the filename
+  queryURLReplace:
+    filename:
+      - regex: '(EPORNER\.COM - \[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
+        with: $2
+  scraper: singleSceneScrape
 
 xPathScrapers:
   sceneSearch:
@@ -46,6 +54,32 @@ xPathScrapers:
         Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
       Image: //meta[@property="og:image"]/@content
       URL: //meta[@property="og:url"]/@content
+    sceneScraper:
+    scene:
+      Title:
+        selector: //*[@id="video-info"]/h1/text()
+      Date:
+        selector: //script[contains(.,"uploadDate")]/text()
+        postProcess:
+          - replace:
+              - regex: .*uploadDate":\s"(\d{4}-\d{2}-\d{2})T.*
+                with: $1
+          - parseDate: 2006-01-02
+      Performers:
+        Name: //*[@id="video-info-tags"]/ul//li[@class='vit-pornstar starw']/a/text()
+      Tags:
+        Name: //*[@id="video-info-tags"]/ul//li[@class='vit-category' or @class='vit-tag']/a/text()
+      Studio:
+        Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
+      Image: //meta[@property="og:image"]/@content
+      URL: //meta[@property="og:url"]/@content
+  singleSceneScrape:
+    scene:
+      Title: //div[@id = 'video-info']/h1/text()
+      Performers:
+        Name: //li[@class='vit-pornstar starw']/a/text()
+      Tags:
+        Name: //li[@class='vit-category']/a/text()
 
 driver:
   cookies:
@@ -56,4 +90,4 @@ driver:
           # replace with PHPSESSID from logged in browser
           Value: ""
           Path: "/"
-# Last Updated May 26, 2025
+# Last Updated May 30, 2025

--- a/scrapers/Eporner.yml
+++ b/scrapers/Eporner.yml
@@ -17,9 +17,9 @@ sceneByFragment:
   queryURL: https://www.eporner.com/video-{filename}/ # Scrapes data on video so long as the EPORNER video id is in the filename
   queryURLReplace:
     filename:
-      - regex: '(\[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
+      - regex: '(.*\[)(\w+)(\]{1}.*)' # Filename must start with "EPORNER.COM - " followed by the video id in square brackets (see any EPORNER video url for example)
         with: $2
-  scraper: singleSceneScrape
+  scraper: sceneScraper
 
 xPathScrapers:
   sceneSearch:
@@ -54,33 +54,7 @@ xPathScrapers:
         Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
       Image: //meta[@property="og:image"]/@content
       URL: //meta[@property="og:url"]/@content
-    sceneScraper:
-      scene:
-        Title:
-          selector: //*[@id="video-info"]/h1/text()
-        Date:
-          selector: //script[contains(.,"uploadDate")]/text()
-          postProcess:
-            - replace:
-                - regex: .*uploadDate":\s"(\d{4}-\d{2}-\d{2})T.*
-                  with: $1
-            - parseDate: 2006-01-02
-        Performers:
-          Name: //*[@id="video-info-tags"]/ul//li[@class='vit-pornstar starw']/a/text()
-        Tags:
-          Name: //*[@id="video-info-tags"]/ul//li[@class='vit-category' or @class='vit-tag']/a/text()
-        Studio:
-          Name: //*[@id="video-info-tags"]/ul/li[@class='vit-uploader']/a/text()
-        Image: //meta[@property="og:image"]/@content
-        URL: //meta[@property="og:url"]/@content
-  singleSceneScrape:
-    scene:
-      Title: //div[@id = 'video-info']/h1/text()
-      Performers:
-        Name: //li[@class='vit-pornstar starw']/a/text()
-      Tags:
-        Name: //li[@class='vit-category']/a/text()
-
+      
 driver:
   cookies:
     - CookieURL: "https://www.eporner.com"
@@ -90,4 +64,4 @@ driver:
           # replace with PHPSESSID from logged in browser
           Value: ""
           Path: "/"
-# Last Updated May 30, 2025
+# Last Updated June 1, 2025


### PR DESCRIPTION
Allows for use of Eporner scraping tool using the tagger tool, or the "Scrape With..." button within an individual scene's page, so long as "EPORNER.COM - [videoidfromurlhere]" are in a given scene's filename.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

EPORNER.COM - [TM1JDrf9Ykg] Leana Lovings - Nerdy (2160)
EPORNER.COM - [yXPCMxo3gI2] Abbey Rains Nerd Girls - Abbey Rain creampie nerd redhead (1080)
EPORNER.COM - [whatevercodeisinhere] followed by anything else .fileextension

## Short description

Describe the general changes

Eporner.yaml community scraper can now pull all media info for a video so long as the videoid is in the filename i.e. EPORNER.COM - [videoid] etc, as prepended when downloading any content through the website's user interface. This should work in the Edit tab of an individual scene, or in the Tagger section of the Scenes tab when selecting Eporner.