### PR TITLE
Add URL Scene Scraper for Else Cinema

### DIFF
--- a/scrapers/ElseCinema.yml
+++ b/scrapers/ElseCinema.yml
@@ -26,6 +26,8 @@ xPathScrapers:
                 with:
       Performers:
         Name: //a[contains(@href,'/performers')]/li
+      Tags:
+        Name: //ul/a[contains(@href,'/categories')]/li
       Image:
         selector: //link/@imagesrcset
         postProcess:

--- a/scrapers/ElseCinema.yml
+++ b/scrapers/ElseCinema.yml
@@ -34,6 +34,7 @@ xPathScrapers:
           - replace:
               - regex: '^([^\?]+).+'
                 with: $1
+      Director: //span/a[contains(@href,'/directors/')]
       Studio:
         Name:
           fixed: Else Cinema

--- a/scrapers/ElseCinema.yml
+++ b/scrapers/ElseCinema.yml
@@ -1,0 +1,39 @@
+name: ElseCinema
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - elsecinema.com
+    scraper: sceneScraper
+
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //div[contains(@class,"my-3")]/img/@name
+      Date:
+        selector: //script[@type='application/ld+json' and contains(., 'dateCreated')]/text()
+        postProcess:
+          - replace:
+              - regex: .*dateCreated(?:[\"\s:])+(\d+-\d+-\d+) .*
+                with: $1
+          - parseDate: 2006-01-02
+      Details:
+        selector: //script[contains(.,"window.__NUXT")]/text()
+        postProcess:
+          - replace:
+              - regex: .*,synopsis_clean(?:[\s:])+\"(.*)\",short_synopsis.*
+                with: $1
+              - regex: \\
+                with:
+      Performers:
+        Name: //a[contains(@href,'/performers')]/li
+      Image:
+        selector: //link/@imagesrcset
+        postProcess:
+          - replace:
+              - regex: '^([^\?]+).+'
+                with: $1
+      Studio:
+        Name:
+          fixed: Else Cinema
+
+# Last Updated June 1, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://elsecinema.com/movies/hey-siro
https://elsecinema.com/movies/naked-kitchen-ep-1
https://elsecinema.com/movies/private-dancer
https://elsecinema.com/movies/straight-man-porn

## Short description
New URL  Scene Scraper for Else Cinema (elsecinema.com).  Loosely based on the similar site "Lust Cinema", but some selectors are distinct enough that an individual scraper makes sense.