### PR TITLE
Add latexplaytime to evilangel

### DIFF
--- a/scrapers/EvilAngel/EvilAngel.py
+++ b/scrapers/EvilAngel/EvilAngel.py
@@ -30,6 +30,7 @@ channel_name_map = {
     "AnalPlaytime": "Anal Acrobats",
     "Anal Trixxx": "AnalTriXXX",
     "Jonni Darkko ": "Jonni Darkko XXX",    # trailing space is in the API
+    "LatexPlaytime": "Latex Playtime",
     "Le Wood": "LeWood",
     "Secret Crush ": "Secret Crush",    # trailing space is in the API
 }

--- a/scrapers/EvilAngel/EvilAngel.py
+++ b/scrapers/EvilAngel/EvilAngel.py
@@ -41,6 +41,7 @@ This map just contains overrides when using a channel name as the studio
 serie_name_map = {
     "TransPlaytime": "TS Playground",
     "XXXmailed": "Blackmailed",
+    "Anal.Oil.Latex.": "Latex Playtime",
 }
 """
 Each serie_name requiring a map/override should have a key-value here

--- a/scrapers/EvilAngel/EvilAngel.yml
+++ b/scrapers/EvilAngel/EvilAngel.yml
@@ -6,6 +6,7 @@ sceneByURL:
     url:
       - analacrobats.com/en/video/
       - evilangel.com/en/video/
+      - latexplaytime.com/en/video/
       - jonnidarkkoxxx.com/en/video/
       - pansexualx.com/en/video/
       - pantypops.com/en/video/
@@ -65,6 +66,7 @@ galleryByURL:
     url:
       - evilangel.com/en/photo/
       - evilangel.com/en/video/
+      - latexplaytime.com/en/photo/
       - pansexualx.com/en/photo/
       - transgressivexxx.com/en/photo/
       - tsfactor.com/en/photo/
@@ -95,4 +97,4 @@ performerByFragment:
     - EvilAngel.py
     - evilangel
     - performer-by-fragment
-# Last Updated March 20, 2025
+# Last Updated June 3, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

### sceneByURL

The site features scenes from other studios as well.

- https://www.latexplaytime.com/en/video/latexplaytime/Latex-Pawg-Plugged--Ploughed/232199
- https://www.latexplaytime.com/en/video/latexplaytime/TS-KASEY-KEI-Seduces-Coco-Lovelock/233037
- https://www.latexplaytime.com/en/video/latexplaytime/TOMMY--SUMMER-Lesbian-Anal-Nursing/231297
- https://www.latexplaytime.com/en/video/latexplaytime/GIA-DERZA-Latex-BJ--Anal-Submission/235156
- https://www.latexplaytime.com/en/video/latexplaytime/JEWELZ-BLU-Oil-Drenched-Anal-Hammering/253045

### galleryByURL

The site features galleries from other studios as well.

- https://www.latexplaytime.com/en/photo/JEWELZ-BLU-Oil-Drenched-Anal-Hammering/120197
- https://www.evilangel.com/en/photo/Lydia-Black-Latex-Deepthroat--Anal/97638

## Short description

Adds sceneByURL for latexplaytime.com. The site appears to have galleries too (but each gallery may be behind paywall)
