### PR TITLE
Fix broke straight boys weight selector

### DIFF
--- a/scrapers/BluMedia.yml
+++ b/scrapers/BluMedia.yml
@@ -114,8 +114,12 @@ xPathScrapers:
         selector: //div[@class="model-lft"]//li[contains(., "Weight")]/text()
         postProcess:
           - replace:
-              - regex: .*\((\d*).*
+              - regex: .*\(\d*\s*lb).*
                 with: $1
+              - regex: \d*\s*kg
+                with: ''
+              - regex: '[^\d]'
+                with: ''
           - lbToKg: true
       PenisLength:
         selector: //div[@class="model-lft"]//li[contains(., "Cock")]/text()

--- a/scrapers/BluMedia.yml
+++ b/scrapers/BluMedia.yml
@@ -116,6 +116,7 @@ xPathScrapers:
           - replace:
               - regex: .*\((\d*).*
                 with: $1
+          - lbToKg: true
       PenisLength:
         selector: //div[@class="model-lft"]//li[contains(., "Cock")]/text()
         postProcess: *extractMetric
@@ -189,4 +190,4 @@ xPathScrapers:
           - replace:
               - regex: .*\)\s*(.*)
                 with: $1
-# Last Updated May 30, 2025
+# Last Updated June 7, 2025


### PR DESCRIPTION
Correct Weight selector for Broke Straight Boys performer scraper.

## Scraper type(s)
- [x] performerByURL

## Examples to test

https://www.brokestraightboys.com/model/NTU0/Preston-Scott (weight in lbs)
https://www.brokestraightboys.com/model/NDYy/Ronan-Kennedy (weight in kg and lbs)

## Short description
Fixes #2372 

Original scraper assumed weight in kg.  On investigation of performers pages the following seems consistent:
Performers without a weight unit have weight in lbs.
Performers with both metric and imperial have two values, each followed by the relevant unit.
No performer appears to have a single weight listed in kg.  Where kg is listed, a value in lbs is also listed.  This assumption may be incorrect but could require an exhaustive scrape of each performer to verify.

The new selector removes the kg value, and then all non-numeric characters.  The resulting number, assumed to be in lbs, is converted to kg and returned.