### PR TITLE
Update Minnano-AV.py

### DIFF
--- a/scrapers/Minnano-AV/Minnano-AV.py
+++ b/scrapers/Minnano-AV/Minnano-AV.py
@@ -37,7 +37,7 @@ XPATHS = {
     ),
     "h1_kanji": '//section[@class="main-column details"]/h1/text()',
     "h1_romaji": '//section[@class="main-column details"]/h1/span/text()',
-    "aliases": "//span[text()='別名']/following-sibling::p/text()",
+    "aliases": "//section[@class=\"main-column details\"]/h1/text()|//span[text()='別名']/following-sibling::p/text()",
     "origin": "//span[text()='出身地']/../p/a/text()",
     "name": '//section[@class="main-column details"]/h1/span/text()',
     "search_url": '../h2[@class="ttl"]/a/@href',


### PR DESCRIPTION
The last refactor changed the aliases xpath. After the change, it is possible for the aliases xpath to return only one match, and in that case, `get_xpath_result` returns the match as string `_result[0]` instead of a length 1 list. Which result in the scraper failing to scrape aliases when `for alias in aliases_xpath_result:` iterates over characters of the string. 

Reverted the aliases to the old xpath which parse the aliases list and h1. It should return at least 2 results. Any duplication should be taken cared by the fact that aliases is a set.