### PR TITLE
Update vrpornnow.com

### DIFF
--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -35,25 +35,14 @@ xPathScrapers:
       Code:
         selector: *urlSel
         postProcess:
-          - replace:
+          - replace: &pickCode
               - regex: .*/videos/(\d+).*
                 with: $1
       Image:
-        selector: //script[@type="application/ld+json"]
+        selector: *urlSel
         postProcess:
-          - javascript: |
-              if (value && value.length) {
-                // parse JSON
-                const obj = JSON.parse(value);
-                // find WebPage item
-                const webPageItem = obj["@graph"].find(item => item["@type"] === "WebPage");
-                // attempt to pick scene ID from image.url
-                const regex = new RegExp("/uploads/(\\d+)");
-                const matches = regex.exec(webPageItem.image.url);
-                if (matches) {
-                  const sceneId = matches[1]
-                  return `https://www.vrpornnow.com/files/images/${sceneId}/fsk16/${sceneId}_Cover_quer_VR_FSK16.webp`;
-                }
-              }
-              return value
+          - replace: *pickCode
+          - replace:
+              - regex: ^(.*)$
+                with: "https://www.vrpornnow.com/files/images/${1}/fsk16/${1}_Cover_quer_VR_FSK16.webp"
 # Last Updated June 12, 2025

--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -10,7 +10,7 @@ xPathScrapers:
   sceneScraper:
     scene:
       Title: //h1
-      Details: //p[@id="description"]
+      Details: //meta[@name="description"]/@content
       Date:
         selector: //meta[@property="article:published_time"]/@content
         postProcess:

--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -1,8 +1,10 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: VR pornnow
 sceneByURL:
   - action: scrapeXPath
     url:
       - vrpornnow.com/product
+      - vrpornnow.com/videos/
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
@@ -13,12 +15,45 @@ xPathScrapers:
         selector: //meta[@property="article:published_time"]/@content
         postProcess:
           - parseDate: "2006-01-02T15:04:05-07:00"
-      Image: //dl8-video/@poster
       Studio:
         Name:
           fixed: VR pornnow
       Tags:
-        Name: //div[@id="tag-list"]/div
+        Name:
+          selector: >-
+            //div[@id="tag-list"]/div
+            |
+            //div[@class="tags inner-container"]//h2
+          postProcess:
+            - replace:
+                # this is a "hack" to use the h2 "Tags" for a fixed value as well as the actual tags
+                - regex: Tags
+                  with: Virtual Reality
       Performers:
         Name: //div[contains(@class, "actors")]//a
-# Last Updated April 11, 2024
+      URL: &urlSel //meta[@property="og:url"]/@content
+      Code:
+        selector: *urlSel
+        postProcess:
+          - replace:
+              - regex: .*/videos/(\d+).*
+                with: $1
+      Image:
+        selector: //script[@type="application/ld+json"]
+        postProcess:
+          - javascript: |
+              if (value && value.length) {
+                // parse JSON
+                const obj = JSON.parse(value);
+                // find WebPage item
+                const webPageItem = obj["@graph"].find(item => item["@type"] === "WebPage");
+                // attempt to pick scene ID from image.url
+                const regex = new RegExp("/uploads/(\\d+)");
+                const matches = regex.exec(webPageItem.image.url);
+                if (matches) {
+                  const sceneId = matches[1]
+                  return `https://www.vrpornnow.com/files/images/${sceneId}/fsk16/${sceneId}_Cover_quer_VR_FSK16.webp`;
+                }
+              }
+              return value
+# Last Updated June 12, 2025

--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -39,21 +39,10 @@ xPathScrapers:
               - regex: .*/videos/(\d+).*
                 with: $1
       Image:
-        selector: //script[@type="application/ld+json"]
+        selector: *urlSel
         postProcess:
-          - javascript: |
-              if (value && value.length) {
-                // parse JSON
-                const obj = JSON.parse(value);
-                // find WebPage item
-                const webPageItem = obj["@graph"].find(item => item["@type"] === "WebPage");
-                // attempt to pick scene ID from image.url
-                const regex = new RegExp("/uploads/(\\d+)");
-                const matches = regex.exec(webPageItem.image.url);
-                if (matches) {
-                  const sceneId = matches[1]
-                  return `https://www.vrpornnow.com/files/images/${sceneId}/fsk16/${sceneId}_Cover_quer_VR_FSK16.webp`;
-                }
-              }
-              return value
+          - replace: *pickCode
+          - replace:
+              - regex: ^(.*)$
+                with: "https://www.vrpornnow.com/files/images/${1}/fsk16/${1}_Cover_quer_VR_FSK16.webp"
 # Last Updated June 12, 2025

--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -15,12 +15,9 @@ xPathScrapers:
         selector: //meta[@property="article:published_time"]/@content
         postProcess:
           - parseDate: "2006-01-02T15:04:05-07:00"
-      Studio:
-        Name:
-          fixed: VR pornnow
       Tags:
         Name:
-          selector: >-
+          selector: &tagsSel >-
             //div[@id="tag-list"]/div
             |
             //div[@class="tags inner-container"]//h2
@@ -29,19 +26,40 @@ xPathScrapers:
                 # this is a "hack" to use the h2 "Tags" for a fixed value as well as the actual tags
                 - regex: Tags
                   with: Virtual Reality
+      Studio:
+        Name:
+          selector: *tagsSel
+          concat: ", "
+          postProcess:
+            - javascript: |
+                if (value?.toLowerCase().includes("cgi")) {
+                  return "VR Pornnow CGI"
+                }
+                return "VR Pornnow"
       Performers:
         Name: //div[contains(@class, "actors")]//a
-      URL: &urlSel //meta[@property="og:url"]/@content
+      URL: //meta[@property="og:url"]/@content
       Code:
-        selector: *urlSel
+        selector: &jsonSel //script[@type="application/ld+json"]
         postProcess:
-          - replace: &pickCode
-              - regex: .*/videos/(\d+).*
-                with: $1
+          - javascript: &codeParse |
+              if (value?.length) {
+                // parse JSON
+                const obj = JSON.parse(value);
+                // find WebPage item
+                const webPageItem = obj["@graph"].find(item => item["@type"] === "WebPage");
+                // attempt to pick scene ID from image.url
+                const regex = new RegExp("\/([A-Za-z0-9]+)_Cover");
+                const matches = regex.exec(webPageItem.image.url);
+                if (matches) {
+                  return matches[1];
+                }
+              }
+              return ""
       Image:
-        selector: *urlSel
+        selector: *jsonSel
         postProcess:
-          - replace: *pickCode
+          - javascript: *codeParse
           - replace:
               - regex: ^(.*)$
                 with: "https://www.vrpornnow.com/files/images/${1}/fsk16/${1}_Cover_quer_VR_FSK16.webp"

--- a/scrapers/VRpornnow.yml
+++ b/scrapers/VRpornnow.yml
@@ -39,10 +39,21 @@ xPathScrapers:
               - regex: .*/videos/(\d+).*
                 with: $1
       Image:
-        selector: *urlSel
+        selector: //script[@type="application/ld+json"]
         postProcess:
-          - replace: *pickCode
-          - replace:
-              - regex: ^(.*)$
-                with: "https://www.vrpornnow.com/files/images/${1}/fsk16/${1}_Cover_quer_VR_FSK16.webp"
+          - javascript: |
+              if (value && value.length) {
+                // parse JSON
+                const obj = JSON.parse(value);
+                // find WebPage item
+                const webPageItem = obj["@graph"].find(item => item["@type"] === "WebPage");
+                // attempt to pick scene ID from image.url
+                const regex = new RegExp("/uploads/(\\d+)");
+                const matches = regex.exec(webPageItem.image.url);
+                if (matches) {
+                  const sceneId = matches[1]
+                  return `https://www.vrpornnow.com/files/images/${sceneId}/fsk16/${sceneId}_Cover_quer_VR_FSK16.webp`;
+                }
+              }
+              return value
 # Last Updated June 12, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://vrpornnow.com/videos/126-match-starring-karina-king/ --> note that this scene has the wrong cover image shown on the page for a different scene, this scraper improvement corrects that and picks the correct cover
- https://vrpornnow.com/videos/101-the-pleasure-retreat-starring-novella-night/
- https://vrpornnow.com/videos/dreams-come-true-cgi-passthrough/ --> this is a scene in the CGI sub-studio

## Short description

These changes includes:
- picking the correct scene image cover even if the web page shows a cover from a different scene (probably a niche case, but example above)
- adds Studio Code
- adds fixed tag `Virtual Reality` as well as the dynamically scraped tags
- adds current scene URL prefix
- picks URL from meta
- adds logic to determine studio (for CGI scenes, by presence of tag)
