### PR TITLE
add studio mapping for Hussie Pass scenes at Adult Time

### DIFF
--- a/scrapers/AdultTime/AdultTime.py
+++ b/scrapers/AdultTime/AdultTime.py
@@ -163,9 +163,19 @@ def fix_url(_url: str) -> str:
 
 channel_name_map = {
     "Age & Beauty": "Age and Beauty",
+    "Black Money Erotica": "Adult Time x Black Money Erotica",
+    "Bratty Sis": "Adult Time x Bratty Sis",
+    "Cuck Hunter": "Adult Time x Cuck Hunter",
+    "Frameleaks": "Adult Time x Frameleaks",
     "Heteroflexible": "HeteroFlexible",
+    "Horny Household": "Adult Time x Horny Household",
     "Hussie Pass": "Adult Time x Hussie Pass",
     "JOI Mom": "J.O.I Mom",
+    "Lady Lazarus": "Adult Time x Lady Lazarus",
+    "LesbianX": "Adult Time x LesbianX",
+    "LucidFlix": "Adult Time x LucidFlix",
+    "Slayed": "Adult Time x Slayed",
+    "Taboo Heat": "Adult Time x Taboo Heat",
     "Vixen": "Adult Time x Vixen",
 }
 """


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [x] galleryByFragment
- [x] galleryByURL

## Examples to test

- https://members.adulttime.com/en/video/hussiepass-channel/BBG-Threesomes-Are-Amazing/244713
- https://members.adulttime.com/en/video/blackmoneyerotica-channel/Arab-Babe-Roxie-Sinner-Takes-On-Monster-Big-Cock/209206
- https://members.adulttime.com/en/video/ladylazarus/Valentines-Day-Blowjob--Anal/219353
- https://members.adulttime.com/en/video/lucidflix-channel/Tru-Kait-Rapture/248138

## Short description

Following my own question in an [Edit comment](https://stashdb.org/edits/7bb3034f-911d-45d1-8024-97d81f05a1c8), I think scraping all `Hussie Pass` scenes published (seem to be all redistributed later) at adulttime.com as `Adult Time x Hussie Pass` seems like a reasonable assumption, and follows the precedent of `Vixen` --> `Adult Time x Vixen` conversion that already exists in this scraper logic.
