### PR TITLE
Make GloryHoleSwallow scraper map member URLs to public

### DIFF
--- a/scrapers/GloryHoleSwallow.yml
+++ b/scrapers/GloryHoleSwallow.yml
@@ -6,6 +6,11 @@ sceneByURL:
       - cumpsters.com
       - spytug.com
       - cumclinic.com
+    queryURL: "{url}"
+    queryURLReplace:
+      url:
+        - regex: \/members\/scenes\/(.*)_vids\.html
+          with: /tour/trailers/$1.html 
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:


### PR DESCRIPTION
Adds a queryURLReplace clause to the GloryHoleSwallow scraper to map members' scene URLs to public scene URLs.

List a few links/titles/names/filenames/codes to test:
`https://gloryholeswallow.com/members/scenes/Irenas-2nd-Interview_vids.html` --> `https://gloryholeswallow.com/tour/trailers/Irenas-2nd-Interview.html`


