### PR TITLE
Fix Girls Out West description paragraph spacing

### DIFF
--- a/scrapers/GirlsOutWest.yml
+++ b/scrapers/GirlsOutWest.yml
@@ -23,8 +23,8 @@ xPathScrapers:
       Title: &title
         selector: //meta[@property='og:title']/@content
       Details: &details
-        selector: //div[@class='description']//p
-        concat: '\n\n'
+        selector: //div[@class='description']//p//text()
+        concat: "\n\n"
       Performers: &performers
         Name:
           selector: //div[h5[contains(.,'Featuring')] and @class='tags']//a
@@ -104,4 +104,4 @@ driver:
           Value: "5"
           Path: "/"
 
-# Last Updated June 03, 2024
+# Last Updated June 22, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

https://tour.girlsoutwest.com/trailers/Lexi-Ruby-Tuesday-Yard-Work.html
https://tour.girlsoutwest.com/trailers/Arcadia-Hunny-Love-Nest.html

## Short description

After a change to the website's format, the current community scraper for Girls Out West incorrectly parses the paragraph scraping of the scene descriptions, merging multiple separate paragraphs into a single paragraph. This update fixes that problem.