### PR TITLE
Add freeuse to teamskeet api

### DIFF
--- a/scrapers/Teamskeet/Teamskeet.yml
+++ b/scrapers/Teamskeet/Teamskeet.yml
@@ -9,8 +9,9 @@ sceneByURL:
       - mylf.com/movies/
       - app.mylf.com/movies/
       - swappz.com/movies/
+      - freeuse.com/movies/
     action: script
     script:
       - python
       - TeamskeetAPI.py
-# Last Updated December 01, 2024
+# Last Updated June 23, 2025

--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -242,6 +242,8 @@ if tags:
         # inconsistent use on TeamSkeet since it was added as a tag
         if tag == "Pumps":
             tags[i] = "Woman's Heels"
+        if tag.lower() == "null":
+            tags.pop(i)
 
 #fix for TeamKseet including HTML tags in Description
 CLEANR = re.compile('<.*?>') 

--- a/scrapers/Teamskeet/TeamskeetAPI.py
+++ b/scrapers/Teamskeet/TeamskeetAPI.py
@@ -155,8 +155,12 @@ elif 'swappz.com' in scene_url:
     ORIGIN = 'https://www.swappz.com'
     REFERER = 'https://www.swappz.com/'
     API_BASE = 'https://tours-store.psmcdn.net/swap_bundle/_search?size=1&q=id:'
+elif 'freeuse.com' in scene_url:
+    ORIGIN = 'https://www.freeuse.com'
+    REFERER = 'https://www.freeus.com/'
+    API_BASE = 'https://tours-store.psmcdn.net/freeusebundle/_search?size=1&q=id:'
 else:
-    log.error('The URL is not from a Teamskeet, MYLF, SayUncle or Swappz URL (e.g. teamskeet.com/movies/*****)')
+    log.error('The URL is not from a Teamskeet, MYLF, Freeuse, SayUncle or Swappz URL (e.g. teamskeet.com/movies/*****)')
     sys.exit(1)
 
 # check for member access token
@@ -260,8 +264,8 @@ scrape['image'] = scene_api_json.get('img')
 if IS_MEMBER:
     scrape['performers'] = [{"name": x.get('name')}
         for x in scene_api_json.get('models')]
-# handle swappz performers differently
-elif 'swappz.com' in scene_url:
+# handle swappz and freeuse performers differently
+elif any(u in scene_url for u in ['swappz.com','freeuse.com']):
     scrape['performers'] = [{"name": x.get('title')}
         for x in scene_api_json.get('models')]
 else:
@@ -286,4 +290,5 @@ if 'sayuncle.com' in scene_url:
 
 if use_local == 0:
     save_json(scene_api_json, scene_url)
+log.debug(json.dumps(scene_api_json))
 print(json.dumps(scrape))


### PR DESCRIPTION
Added freeuse.com to Teamskeet API scene by URL scraper.
Resolves #2402 

## Scraper type(s)
- [x] sceneByURL

## Examples to test
https://www.freeuse.com/movies/the-new-man-of-the-house
https://www.freeuse.com/movies/stock-market-fever
https://www.freeuse.com/movies/freeuse-me-all-day-long-lilys-fathers-day-gift


## Short description

Added freeuse.com to scene by URL scraper.
Modified python to allow and handle scenes from freeuse.com.
Found a scene that has no tags that was returning the literal string "null" as a tag.  Added check to remove "null" in the returned tags.
Now dumping JSON returned from the API to the log to make it simpler to make possible future changes based on JSON structure.

Need to determine:  Is this implementation returning the highest possible resolution for the scene image.