### PR TITLE
Update CorbinFisher.yml scene description scraping

### DIFF
--- a/scrapers/CorbinFisher.yml
+++ b/scrapers/CorbinFisher.yml
@@ -27,8 +27,12 @@ xPathScrapers:
         Name: //div[@class="modelFeaturing"]//a
         URL: //div[@class="modelFeaturing"]//a/@href
       Details:
-        selector: //div[@class="description"]/p
+        selector: //div[@class="description"]/p//text() | //div[@class="description"]/p//br
         concat: "\n\n"
+        postProcess:
+          - replace:
+              - regex: <br\s*\/?> 
+                with: "\n"
       Image:
         selector: //img[@height="815"]/@src0_1x
       Studio:


### PR DESCRIPTION
See discussion on stashdb [here](https://stashdb.org/edits/ad26535c-391c-4330-9db3-2d80d30012e0)

The current corbinfisher scraper doesn't always scrape scene description consistently. The p element for descriptions contains a mix of text content and `<br/>` elements. This update should use both elements and properly replaces the br elements with line breaks accordingly.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test
- https://corbinfisher.com/tour/trailers/Mario-Fucks-Josh-remastered.html

## Short description

The existing CF scraper flattens all the text with no line breaks. See a discussion at this stashdb edit [here](https://stashdb.org/edits/ad26535c-391c-4330-9db3-2d80d30012e0). This update will also preserve the `<br/>` elements present in the `<p>` element and replace them with line breaks appropriately so the text structure will be preserved in stashapp and stashdb.
