### PR TITLE
Fix dreamtranny

### DIFF
--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -140,7 +140,6 @@ xPathScrapers:
       Instagram: $modelLinks/a[contains(@href, "instagram")]/@href
       URL: //link[@rel="canonical"]/@href
 # you can use (a suitably configured) CDP to make use of a proxy/VPN to bypass region-based age-restriction
-
 # driver:
 #   useCDP: true
 # Last Updated April 11, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByURL

## Examples to test

### sceneByURL

- https://dreamtranny.com/update/1132/?nats=MC4wLjMuMTUuMC4wLjAuMC4w&step=2
- https://dreamtranny.com/update/1137/

### sceneByName / sceneByQueryFragment

- angel

### performerByURL

- https://dreamtranny.com/models/385/
- https://dreamtranny.com/models/390/

## Short description

Images seems to all be absolute/full URLs now, so naively prepending with the base URL of the site results in a malformed URL. The replace has been altered to only prepend relative URLs, should they occur.

The site has a search feature with HTML results, so `sceneByName` for that with `sceneListScraper` for the HTML results page, each result contains a URL to the scene, so that is used in the `sceneByQueryFragment` and then scraped with the regular `sceneScraper`

I have had issues with accessing the site as it is now appears to be age-restriction blocked in the UK, so I need to use `driver.useCDP: true`. I've put this setting into the scraper, but with it set to `false` as possibly only the UK is affected, and anyone who needs to use a VPN can configure CDP with one and set this to true and replace the scraper in their own stash scraper files
