### PR TITLE
fix groobyvr: add alternate selector for details

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -271,7 +271,10 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details: &detailsVR
-        selector: //div[@class="trailerblock"]/p[not(@class)]/descendant-or-self::*/text()
+        selector: >-
+          //div[@class="trailerblock"]/p[not(@class)]/descendant-or-self::*/text()
+          |
+          //div[@class="trailerpage_info"]//p/descendant-or-self::*/text()
         concat: "\n\n"
       Performers: &performersVR
         Name: //div[@class="trailer_toptitle_left"]//a/text()
@@ -306,4 +309,8 @@ xPathScrapers:
               - regex: ^/
                 with: https://www.transvr.com/
       Tags: *tagsVR
-# Last Updated May 16, 2025
+
+# Use CDP with a configured proxy/CDN to bypass region-based age-verification
+driver:
+  useCDP: false
+# Last Updated July 9, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.groobyvr.com/tour/trailers/Amanda-Riley-In-A-Hot-Sticky-Mess.html

## Short description

Either the scene description has changed or some scenes use a different CSS layout. Whatever the case, this additional selector can now scrape the description.

I have to use CDP configured with a VPN in order to access the site as it has region-based age-verification. I set `driver.useCDP` to `false` however as this issue may only affect a few countries.
