### PR TITLE
fix Details scraping

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -226,11 +226,36 @@ xPathScrapers:
         postProcess:
           - parseDate: January 2, 2006
       Details: &details
+        # Grooby Network sites use a p tag for the scene description, where each subsequent
+        # paragraph is a nested span tag, so they need to be captured separately.
+        # There doesn't appear to be a way to capture the text of all child elements
+        # (e.g. <a> <em> <strong>) to get the full text of each paragraph, while also
+        # ignoring the nested span tags.
+        # So instead, the entire text of the p tag is captured, and then the newlines are
+        # recreated in the post-processing step.
         selector: //div[@class="trailerpage_info"]/p[not(@class)]
         postProcess:
-          - replace:
-              - regex: (\.)([A-Za-z\"])
-                with: "$1\n\n$2"
+          - javascript: |
+              if (value && value.length > 0) {
+                const result = [];
+                for (let i = 0; i < value.length; i++) {
+                  const character = value[i];
+                  if (
+                    character === '.'
+                    && i !== value.length - 1 // not the last character
+                    && !value.slice(i + 1).startsWith('XXX') // not a .XXX domain
+                    && !value.slice(i + 1).startsWith('com') // not a .com domain
+                    && !value.slice(i + 1).startsWith(' ') // not the end of a sentence
+                    && !value.slice(i + 1).startsWith('.') // not consecutive dots
+                  ) {
+                    result.push(character, '\n\n');
+                  } else {
+                    result.push(character);
+                  }
+                }
+                return result.join('').trim();
+              }
+              return value;
       Performers: &performers
         Name: //div[@class="setdesc"]//a/text()
       Studio: &studio


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

| scenario | link |
|---------|----|
| 2 paragraphs | https://www.groobygirls.com/tour/trailers/Eat-This-Instead.html |
| 2 paragraphs (with em tag in 2nd paragraph) | https://www.groobygirls.com/tour/trailers/Does-My-Bum-Look-Big-in-This.html |
| 2 paragraphs (with link text as domain) | https://www.groobygirls.com/tour/trailers/A-Solo-Composition.html |
| 3 paragraphs | https://www.groobygirls.com/tour/trailers/Daisy-in-Bloom.html |
| 3 paragraphs (with link in first paragraph) | https://www.groobygirls.com/tour/trailers/A-Surprise-Return.html |

## Short description

Grooby Network sites use a p tag for the scene description, where each subsequent paragraph is a nested span tag. This layout is tricky to parse when either the p or span tags themselves contain nested elements, e.g. a tags (links), em tags (italic), etc.

Currently the scraper will add two newlines surround link text, or text inside em tags, where really the text of these child elements should be captured together with the text of the p or span tags.

In this simplified fix, the entire p tag text contents is captured, and then the resulting text will contain link and em text in each "paragraph", and the line breaks between "paragraphs" (p and each nested span) can be recreated via logic to add newlines after dots as long as:

- the following string is not:
  - XXX
  - com
  - (a space)
  - another dot (e.g. ellipsis)
- the dot in question is not at the end of the string
