### PR TITLE
Add sceneByFragment scraper

### DIFF
--- a/scrapers/MyMemberSite/MyMemberSite.yml
+++ b/scrapers/MyMemberSite/MyMemberSite.yml
@@ -110,6 +110,13 @@ galleryByURL:
       - whatlizannelikes.com/photosets/
       - yourfitcrush.com/photosets/
 
+sceneByFragment:
+  action: script
+  script:
+    - python
+    - MyMemberSite.py
+    - scene-by-url
+
 sceneByURL:
   - action: script
     script:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://yourfitcrush.com/videos/319-solo-naked-full-of-chokolad-on-my-body-play-with-toy
https://members.baebihel.com/videos/229-as-soon-as-im-home-from-school-all-i-want-to-do-is-masturbate

## Short description

Added a `sceneByFragment` scraper to the existing MyMemberSite scraper. No changes are made to the scraper's python script as it simply uses the existing `sceneByURL` code. This change just allows it to be used in the scene tagger view instead of only being used on an individual scene, which was useful for me after bulk downloading videos.
