### PR TITLE
Add Code Section for JavDB and Update Title Section

### DIFF
--- a/scrapers/javdb.yml
+++ b/scrapers/javdb.yml
@@ -74,16 +74,9 @@ xPathScrapers:
         #      with: "?locale=en"
   sceneScraper:
     scene:
-      Title:
-        selector: //strong[text()='ID:']/../span
-        concat: "|"
-        postProcess:
-          - replace:
-              - regex: \|
-                with: ""
+      Title: //strong[@class="current-title"]/text()
+      Code: //a[@title="Copy ID"]/@data-clipboard-text
       Date: //strong[text()='Released Date:']/../span/text()
-      Details:
-        selector: //strong[@class="current-title"]/text()
       Director: //strong[text()='Director:']/../span/a/text()
       Tags:
         Name: //strong[text()='Tags:']/../span/a/text()


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByQueryFragment
- [x] sceneByURL


## Examples to test
https://javdb.com/v/0edYxE (Or 060725-001)
https://javdb.com/v/a8yJBr (Or GESY-075)
https://javdb.com/v/z451qz

## Short description

This PR does the following changes to the sceneScraper. The result should now consistent with other JAV providers.

- Scrape `Code` from the Copy ID button
- Remove `Details` section (JavDB does not provide detail information)
- Update `Title` from the `current-title` element