### PR TITLE
Heyzo-JP: Update Title Source

### DIFF
--- a/scrapers/Heyzo-JP.yml
+++ b/scrapers/Heyzo-JP.yml
@@ -21,9 +21,14 @@ xPathScrapers:
   sceneScraper:
     common:
       $table: //div[@class="info-bg"]/table/tbody/tr
+      $metadata: //div[@id="movie"]/script[@type="application/ld+json"]
     scene:
-      Title: /html/head/title/text()
-      URL: 
+      Title:
+        selector: $metadata/text()
+        postProcess:
+          - javascript: |
+              return JSON.parse(value)?.name ?? null;
+      URL:
         selector: /html/head/meta[@property="og:url"]/@content
         postProcess:
           - replace:


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByFragment
- [x] sceneByURL


## Examples to test
https://www.heyzo.com/moviepages/3430/index.html
https://www.heyzo.com/moviepages/1638/index.html

## Short description
The title of the webpage contains a lot of redundant data. This PR update title source to a script object. Close to what we have in heyzo.yml
