### PR TITLE
Carib-JP: Update Title Source and Image Source

### DIFF
--- a/scrapers/Caribbeancom-JP.yml
+++ b/scrapers/Caribbeancom-JP.yml
@@ -24,8 +24,7 @@ xPathScrapers:
     common:
       $movieinfo: //div[@class="movie-info section"]
     scene:
-      Title: /html/head/title/text()
-      # //div[contains(@class,"heading")]/h1/text()
+      Title: //div[@id="moviepages"]//div[@class="heading"]/h1/text()
       Details: //div[contains(@class,"movie-info")]//p
       URL:
         selector: //link[@hreflang="en-US"]/@href|//script[contains(.,"posterImage = '/moviepages/'+movie_id+'/images/")]
@@ -56,7 +55,7 @@ xPathScrapers:
         postProcess:
           - replace:
               - regex: index\.html$
-                with: images/l.jpg
+                with: images/l_l.jpg
               - regex: en\.caribbeancom
                 with: www.caribbeancom
               - regex: eng/moviepages


### PR DESCRIPTION
## Scraper type(s)

- [x] sceneByFragment
- [x] sceneByURL


## Examples to test

Japanese Version
https://www.caribbeancom.com/moviepages/080422-003/index.html
https://www.caribbeancom.com/moviepages/072013-387/index.html

English Version
https://en.caribbeancom.com/eng/moviepages/080422-003/index.html
https://en.caribbeancom.com/eng/moviepages/072013-387/index.html

## Short description

1. Similar to #2431, the title of the webpage contains a lot of redundant data.
2. This PR also updates the image source to `l_l.jpg`. This image is show on the Japanese version of the webpage. It would be more suitable to use it. FYI, the old one is show on the English version of the webpage.

