### PR TITLE
move groobyvr to own scraper to allow scene search

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -51,10 +51,6 @@ performerByURL:
     url:
       - transnificent.com/tour/models
     scraper: performerScraper7
-  - action: scrapeXPath
-    url:
-      - groobyvr.com/tour/models
-    scraper: performerScraper8
 sceneByURL:
   - action: scrapeXPath
     url: &urls
@@ -85,10 +81,6 @@ sceneByURL:
       - transgasm.com
       - transnificent.com
     scraper: sceneScraper
-  - action: scrapeXPath
-    url:
-      - groobyvr.com
-    scraper: sceneScraperGroobyVR
   - action: scrapeXPath
     url:
       - transvr.com
@@ -205,19 +197,6 @@ xPathScrapers:
         fixed: transgender_male
       Image: *image3x
       Birthdate: *birthdate
-  performerScraper8:
-    performer:
-      Name: *name
-      Gender: *gender
-      Image: *image
-      Country: *country
-      Ethnicity: *ethnicity
-      Birthdate: *birthdate
-      Height:
-        selector: //li/b[text()="Height:"]/following-sibling::text()
-        postProcess:
-          - feetToCm: true
-      Measurements: //li/b[text()="Breast Size:"]/following-sibling::text()
   sceneScraper:
     scene:
       Title: &title //p[@class="trailertitle"]/text()|//div[@class="trailer_toptitle_left"]/text()[last()]
@@ -291,51 +270,38 @@ xPathScrapers:
       Studio: *studio
       Tags:
         Name: *tagsSel
-  sceneScraperGroobyVR:
-    scene:
-      Title: *title
-      Date: &dateVR
-        selector: //div[@class="set_meta"]//b[contains(.,"Added")]/following-sibling::text()[1]
-        postProcess:
-          - parseDate: January 2, 2006
-      Details: &detailsVR
-        selector: //div[contains(@class,"trailerpage_description")]//*/text()
-        concat: "\n\n"
-      Performers: &performersVR
-        Name: //div[@class="trailer_toptitle_left"]//a/text()
-      Studio: *studio
-      Image:
-        selector: &imageSelVR //dl8-video/@poster
-        postProcess:
-          - replace:
-              - regex: content// # errant double slash
-                with: content/
-              - regex: ^/
-                with: https://www.groobyvr.com/
-      Tags: &tagsVR
-        Name:
-          selector: //div[@class="set_tags"]/ul/li/text()|//div[@class="set_tags"]/ul/li//a/text()
-          postProcess:
-            - map:
-                Tags for This Scene: Virtual Reality
   sceneScraperTransVR:
     scene:
       Title: //dl8-video/@title
-      Date: *dateVR
-      Details: *detailsVR
-      Performers: *performersVR
+      Date:
+        selector: //div[@class="set_meta"]//b[contains(.,"Added")]/following-sibling::text()[1]
+        postProcess:
+          - parseDate: January 2, 2006
+      Details:
+        selector: //div[contains(@class,"trailerpage_description")]//*/text()
+        concat: "\n\n"
+      Performers:
+        Name: //div[@class="trailer_toptitle_left"]//a/text()
       Studio: *studio
       Image:
-        selector: *imageSelVR
+        selector: //dl8-video/@poster
         postProcess:
           - replace:
               - regex: content// # errant double slash
                 with: content/
               - regex: ^/
                 with: https://www.transvr.com/
-      Tags: *tagsVR
+      Tags:
+        Name:
+          selector: >-
+            //div[@class="set_tags"]/ul/li/text()
+            |
+            //div[@class="set_tags"]/ul/li//a/text()
+          postProcess:
+            - map:
+                Tags for This Scene: Virtual Reality
 
 # Use CDP with a configured proxy to bypass region-based age-verification
 driver:
   useCDP: false
-# Last Updated July 11, 2025
+# Last Updated July 17, 2025

--- a/scrapers/GroobyVR.yml
+++ b/scrapers/GroobyVR.yml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+name: GroobyVR
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - groobyvr.com/tour/models
+    scraper: performerScraper
+sceneByURL:
+  - action: scrapeXPath
+    url: &urls
+      - groobyvr.com
+    scraper: sceneScraper
+sceneByName:
+  action: scrapeXPath
+  queryURL: https://www.groobyvr.com/tour/search.php?qall={}
+  scraper: sceneSearchResultsScraper
+sceneByQueryFragment:
+  action: scrapeXPath
+  queryURL: "{url}"
+  scraper: sceneScraper
+galleryByURL:
+  - action: scrapeXPath
+    url: *urls
+    scraper: sceneScraper
+xPathScrapers:
+  performerScraper:
+    performer:
+      Name: //h3[@class="modelname"]/text()|//div[@class="model_profile_name"]/text()
+      Gender:
+        fixed: transgender_female
+      Image:
+        selector: //div[@class="model_photo"]/img/@src
+        postProcess:
+          - replace:
+              - regex: ^(/.*)
+                with: https://www.groobyvr.com$1
+              - regex: 2x
+                with: 3x
+      Country: //li/b[text()="Nationality:"]/following-sibling::text()|//li/b[text()="Location:"]/following-sibling::text()
+      Ethnicity: //li/b[text()="Ethnicity:"]/following-sibling::text()
+      Birthdate:
+        selector: //li//b[text()="Birthday:"]/following-sibling::text()
+        postProcess:
+          - replace: &removeOrdinal
+              - regex: (\d)(st|nd|rd|th)
+                with: $1
+          - parseDate: 2 January
+          - parseDate: 2 Jan
+          - parseDate: January 2
+          - parseDate: Jan 2
+      Height:
+        selector: //li/b[text()="Height:"]/following-sibling::text()
+        postProcess:
+          - feetToCm: true
+      Measurements: //li/b[text()="Breast Size:"]/following-sibling::text()
+  sceneScraper:
+    scene:
+      Title: &title //p[@class="trailertitle"]/text()|//div[@class="trailer_toptitle_left"]/text()[last()]
+      Date: &date
+        selector: //div[@class="set_meta"]//b[contains(.,"Added")]/following-sibling::text()[1]
+        postProcess:
+          - parseDate: January 2, 2006
+      Details: &details
+        selector: //div[contains(@class,"trailerpage_description")]//*/text()
+        concat: "\n\n"
+      Performers: &performers
+        Name: //div[@class="trailer_toptitle_left"]//a/text()
+      Studio: &studio
+        Name:
+          fixed: Grooby VR
+      Image:
+        selector: //dl8-video/@poster
+        postProcess:
+          - replace:
+              - regex: content// # errant double slash
+                with: content/
+              - regex: ^/
+                with: https://www.groobyvr.com/
+      Tags: &tags
+        Name:
+          selector: >-
+            //div[@class="set_tags"]/ul/li/text()
+            |
+            //div[@class="set_tags"]/ul/li//a/text()
+          postProcess:
+            - map:
+                Tags for This Scene: Virtual Reality
+    gallery:
+      Title: *title
+      Date: *date
+      Details: *details
+      Performers: *performers
+      Studio: *studio
+      Tags: *tags
+  sceneSearchResultsScraper:
+    common:
+      $video: //div[@class="sexyvideo"]
+    scene:
+      Title: $video/h4
+      Details: $video/p[@class="photodesc"]
+      Date:
+        selector: $video/p[@class="dateadded"]//text()
+        postProcess:
+          - replace: *removeOrdinal
+          - parseDate: 2 Jan 2006
+      Performers:
+        Name: //div[@class="modelnamecontainer"]//a/text()
+      Image: $video//img/@src
+      URL:
+        selector: $video/h4/a/@href
+        postProcess:
+          - replace:
+              - regex: ^(//www\..*)
+                with: https:$1
+      
+# Use CDP with a configured proxy to bypass region-based age-verification
+driver:
+  useCDP: false
+# Last Updated July 17, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

### sceneByURL

- https://www.groobyvr.com/tour/trailers/Dicking-Down-Gigi-Ravine.html
- https://www.groobyvr.com/tour/trailers/A-Katt-In-Your-Lap.html

### sceneByName

- katt
- lap

Note that when the search results have more than 1 scene, the list of performers is repeated for each scene. I'm not sure if there is a way around this? This only affects the searchByName results list, and the searchByQueryFragment just scrapes the individual scene page normally.

### galleryByURL

this uses scene URLs, so the sceneByURLs above

### performerByURL

- https://www.groobyvr.com/tour/models/Cailey-Katts.html

## Short description

This adds a scene search for groobyvr.com. As a scraper file appears to only support a single sceneByName queryURL (and seems to have no per-domain ability), it made sense to move this scraper out of the (rather messy) GroobyNetwork-Partial scraper into its own one.


