### PR TITLE
override largest image for devils film

### DIFF
--- a/scrapers/AdultTime/AdultTime.py
+++ b/scrapers/AdultTime/AdultTime.py
@@ -12,6 +12,7 @@ from urllib.request import Request, urlopen
 from AlgoliaAPI.AlgoliaAPI import (
     gallery_from_fragment,
     gallery_from_url,
+    IMAGE_CDN,
     movie_from_url,
     performer_from_fragment,
     performer_from_url,
@@ -312,6 +313,13 @@ def postprocess_scene(scene: ScrapedScene, api_scene: dict[str, Any]) -> Scraped
     """
     if studio_override := determine_studio(api_scene):
         scene["studio"] = { "name": studio_override }
+
+    # override the image for Devils Film scenes
+    if api_scene.get("studio_name") == "Devils Film" \
+        and (images := dig(api_scene, "pictures", ("nsfw", "sfw"), "top")) \
+        and next(iter(images.keys()), None) == "960x544" \
+        and (largest_image := dig(api_scene, "pictures", "resized")):
+        scene["image"] = f"{IMAGE_CDN}/movies{largest_image}"
 
     if _url := scene.get("url"):
         log.debug(f'scene"[url]" (before): {scene["url"]}')


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.devilsfilm.com/en/video/devilsfilm/Things-Are-Looking-Upskirt---Madison-Morgan--Tommy-Pistol/259559
- https://www.devilsfilm.com/en/video/hairyundies/Things-Are-Looking-Upskirt---Pixie-Smalls--Axel-Haze/259558
- https://adulttime.com/en/video/devilsfilm/Things-Are-Looking-Upskirt---Madison-Morgan--Tommy-Pistol/259559
- https://www.futaworld.com/en/video/futaworld-at/Dicks-Diner/248782

## Short description

Devils Film scenes seem to all have a "largest" image that is 960x544, but there is actually a 1920x1281 image available. This change picks the larger image out instead just for Devils Film, other AdultTime studios continue to use the "top" image which seems to always be 1920x1080.
