### PR TITLE
Update GroobyNetwork-Partial.yml

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -246,7 +246,7 @@ xPathScrapers:
                 - regex: (https://[^/]*)/.*
                   with: $1
       Image:
-        selector: //link[@rel="canonical"]/@href|//img[contains(@class, "update_thumb thumbs stdimage")]/@src|//img[contains(@class, "update_thumb thumbs stdimage")]/@src0_1x|//div[@class="trailerposter"]/img/@src0
+        selector: //link[@rel="canonical"]/@href|(//img[contains(@class, "update_thumb thumbs stdimage")]/@src)[1]|(//img[contains(@class, "update_thumb thumbs stdimage")]/@src0_1x)[1]|(//img[contains(@class, "mainThumb thumbs stdimage")]/@src)[1]|(//img[contains(@class, "mainThumb thumbs stdimage")]/@src0_1x)[1]|(//div[@class="trailerposter"]/img/@src0)[1]
         concat: "__SEPARATOR__"
         postProcess:
           - replace:


### PR DESCRIPTION
Fix for certain sites (GG) using mainThumb class instead of update_thumb. As it is used for multiple instances in the same page, this will grab the first instance which is always the main update image.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

[List a few links/titles/names/filenames/codes to test](https://www.groobygirls.com/)

## Short description

Grabs the first instance of mainThumb class. GG is returning empty image with update_thumb class. Please modify as required, I only made a draft for a possible fix.
