### PR TITLE
Add Next Door Hookups to list of supported URL scrapers

### DIFF
--- a/scrapers/NextDoorStudios/NextDoorStudios.yml
+++ b/scrapers/NextDoorStudios/NextDoorStudios.yml
@@ -10,6 +10,7 @@ sceneByURL:
       - nextdoorcasting.com/en/video
       - nextdoorfilms.com/en/video
       - nextdoorhomemade.com/en/video
+      - nextdoorhookups.com/en/video
       - nextdoormale.com/en/video
       - nextdoororiginals.com/en/video
       - nextdoorraw.com/en/video


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

* https://www.nextdoorhookups.com/en/video/nextdoorhookups/In-the-Pokey/62032

## Short description

This just adds the Next Door Hookups domain to the list of supported url prefixes for the URL scraper for Next Door Studios.