### PR TITLE
Add Sketchy Sex scraper

### DIFF
--- a/scrapers/SketchySex.yml
+++ b/scrapers/SketchySex.yml
@@ -1,0 +1,47 @@
+name: Sketchy Sex
+
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - sketchysex.com/trailer.php?id=
+    scraper: sketchysex
+
+xPathScrapers:
+  sketchysex:
+    scene:
+      Title: //div[@class="name"]
+      Details:
+        selector: //div[@class="VideoDescription"]
+        postProcess:
+          - replace:
+            - regex: \w+\s+\d+(?:st|nd|rd|th)?,\s+\d+\s*-\s*(.*)
+              with: $1
+      Date:
+        selector: //div[@class="date"]
+        postProcess:
+          - replace:
+            - regex: "ADDED:"
+              with: ""
+          - replace:
+            - regex: (\w+)\s+(\d+),\s+(\d+)
+              with: $1 $2, $3
+          - parseDate: Jan 2, 2006
+      Image:
+        selector: //video/@data-setup
+        postProcess:
+          - replace:
+            - regex: .*https://
+              with: https://
+          - replace:
+            - regex: .jpg.*
+              with: .jpg
+          - replace:
+            - regex: -[1-4]x\.
+              with: -full.
+      Studio:
+        Name:
+          fixed: Sketchy Sex
+        URL:
+          fixed: https://www.sketchysex.com
+
+# Last Updated July 21, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

* https://www.sketchysex.com/trailer.php?id=288

## Short description

This adds a scraper for Sketchy Sex, based on the FratX scraper but tweaked for the Sketchy Sex elements.
