### PR TITLE
Fix duplicate aliases and add bra size to measurements on Babepedia scraper

### DIFF
--- a/scrapers/Babepedia.yml
+++ b/scrapers/Babepedia.yml
@@ -93,11 +93,11 @@ xPathScrapers:
               - regex: ^.*\s(\d+)\skg.*$
                 with: $1
       Measurements:
-        selector: $infoblock//span[@class="label" and text()='Measurements:']/following-sibling::span
-        postProcess:
-          - replace:
-              - regex: (\d*)([a-zA-Z-]*)(\d*-\d*)(.+?)([a-zA-Z]+)(.*)
-                with: $1$5-$3
+        selector: $infoblock//span[@class="label" and text()='Measurements:' or text()='Bra/cup size:']/following-sibling::span
+        concat: " "
+        replace:
+          - regex: ^(\d*)-(\d*)-(\d*) (\d*[A-Z]*).*$
+            with: $4-$2-$3
       FakeTits:
         selector: $infoblock//span[@class="label" and text()='Boobs:']/following-sibling::span
         postProcess:
@@ -118,8 +118,11 @@ xPathScrapers:
               - regex: \s+\(.*
                 with: ""
       Aliases:
-        selector: //span[@class="aliasname"]
-        concat: ", "
+        selector: //h2[@id="aka"]/text()
+        postProcess:
+          - replace:
+              - regex: " -"
+                with: ","
       Tattoos:
         selector: $infoblock//span[@class="label" and text()='Tattoos:']/following-sibling::span
         postProcess:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

Hailey Rose
Mila Azul
Felicity Fey

## Short description

Describe the general changes
Babepedia changed their page layout a little bit. The scraper was updated, but a few things were missed.
Any performer that uses the same name on multiple websites will have multiple entries in the alias list, and it often includes the primary name, which means what is returned by the scraper in those cases can't be saved without cleaning it up after the scrape. I updated the alias scraper to use a different list that doesn't include the primary name, and doesn't include duplicates.
The page changes also included changing how the measurements and bra/cup size are listed. I updated that to correctly replace the first measurement with the bra/cup size, like it did before the page update.