### PR TITLE
virtualrealporn: fix date and url scraping; simplify tags scraping

### DIFF
--- a/scrapers/VirtualRealPorn.yml
+++ b/scrapers/VirtualRealPorn.yml
@@ -59,33 +59,34 @@ xPathScrapers:
               - regex: VR [\s\w]+? video$
                 with: ""
       Date: &dateAttr
-        selector: //div[@class="featured_data"]/text()
-        concat: " "
+        selector: //script[@type="application/ld+json" and @class="yoast-schema-graph"]/text()
         postProcess:
-          - replace:
-              - regex: '.* (\w+ \d+, \d{4}).*'
-                with: $1
-          - parseDate: Jan 2, 2006
+          - javascript: |
+              if (value && value.length && value.startsWith('{')) {
+                // parse JSON
+                return JSON.parse(value)["@graph"]
+                  .find(item => item["@type"] === "WebPage")
+                  .datePublished
+                  // return YYYY-MM-DD format from full ISO datetime, e.g. 2024-01-01T12:00:00Z
+                  .substring(0, 10)
+              }
+              // return as-is if not JSON
+              return value
       Details: &detailsSel
         selector: //div[@class="description_container"]/p
         concat: "\n\n"
       Tags:
         Name:
-          selector: //div[@class="metaHolder"]//a/span/text()|//script[@type="application/ld+json"][contains(text(),"genre")]/text()
+          selector: >-
+            //div[@class="metaHolder"]//a/span/text()
+            |
+            //link[@rel="canonical"]/@href
           postProcess:
-            - javascript: |
-                if (value && value.length && value.startsWith('{')) {
-                  // parse JSON
-                  return JSON.parse(value)
-                    .genre
-                    .split(', ')
-                    // can only return one tag, find or default
-                    .find(v => v.toLowerCase() === 'virtual reality')
-                        ?? 'Virtual Reality'
-                } else {
-                  // return (text of tag) as-is
-                  return value
-                }
+            - replace:
+                # the second selector xpath returns a URL, this is a "hack" to get a
+                # fixed tag by converting it to "Virtual Reality"
+                - regex: ^http.*$
+                  with: Virtual Reality
       Performers:
         Name: //div[@class="performers_section"]//div[@class="model-box"]/a/img/@alt
       Studio:
@@ -98,7 +99,7 @@ xPathScrapers:
             - map:
                 VirtualRealAmateurPorn: "VirtualRealAmateur"
       Image: &imageSel //meta[@property="og:image"]/@content
-      URL: //link[@rel="canonical"]/@href
+      URL: //link[@rel="alternate" and @hreflang="x-default"]/@href
       Code: 
         selector: //link[@rel="shortlink"]/@href
         postProcess:
@@ -166,4 +167,7 @@ xPathScrapers:
               }
               return value
       Image: //div[@class="feature_img_model"]/img/@src
-# Last Updated June 2, 2025
+# sites now have age-checking and geoblocking, so we can use CDP (with VPN/proxy) to bypass it
+driver:
+  useCDP: false
+# Last Updated August 5, 2025

--- a/scrapers/VirtualRealTrans.yml
+++ b/scrapers/VirtualRealTrans.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: VirtualRealTrans
 
 sceneByFragment:
@@ -27,44 +28,45 @@ sceneByFragment:
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: &titleDef
+      Title:
         selector: //div[@class="header_video"]//h1
         postProcess:
           - replace:
               - regex: VR [\s\w]+? video$
                 with: ""
-      Date: &dateAttr
-        selector: //div[@class="featured_data"]/text()
-        concat: " "
+      Date:
+        selector: //script[@type="application/ld+json" and @class="yoast-schema-graph"]/text()
         postProcess:
-          - replace:
-              - regex: '.* (\w+ \d+, \d{4}).*'
-                with: $1
-          - parseDate: Jan 2, 2006
-      Details: &detailsSel
+          - javascript: |
+              if (value && value.length && value.startsWith('{')) {
+                // parse JSON
+                return JSON.parse(value)["@graph"]
+                  .find(item => item["@type"] === "WebPage")
+                  .datePublished
+                  // return YYYY-MM-DD format from full ISO datetime, e.g. 2024-01-01T12:00:00Z
+                  .substring(0, 10)
+              }
+              // return as-is if not JSON
+              return value
+      Details:
         selector: //div[@class="description_container"]/p
         concat: "\n\n"
       Tags:
         Name:
-          selector: //div[@class="metaHolder"]//a/span/text()|//script[@type="application/ld+json"][contains(text(),"genre")]/text()
+          selector: >-
+            //div[@class="metaHolder"]//a/span/text()
+            |
+            //link[@rel="canonical"]/@href
           postProcess:
-            - javascript: |
-                if (value && value.length && value.startsWith('{')) {
-                  // parse JSON
-                  return JSON.parse(value)
-                    .genre
-                    .split(', ')
-                    // can only return one tag, find or default
-                    .find(v => v.toLowerCase() === 'virtual reality')
-                        ?? 'Virtual Reality'
-                } else {
-                  // return (text of tag) as-is
-                  return value
-                }
+            - replace:
+                # the second selector xpath returns a URL, this is a "hack" to get a
+                # fixed tag by converting it to "Virtual Reality"
+                - regex: ^http.*$
+                  with: Virtual Reality
       Performers:
         Name: //div[@class="performers_section"]//div[@class="model-box"]/a/img/@alt
       Studio:
-        Name: &studioName
+        Name:
           selector: //meta[@property="og:site_name"]/@content
           postProcess:
             - replace:
@@ -72,19 +74,15 @@ xPathScrapers:
                   with: ""
             - map:
                 VirtualRealAmateurPorn: "VirtualRealAmateur"
-      Image: &imageSel //meta[@property="og:image"]/@content
-      URL: //link[@rel="canonical"]/@href
+      Image: //meta[@property="og:image"]/@content
+      URL: //link[@rel="alternate" and @hreflang="x-default"]/@href
       Code: 
         selector: //link[@rel="shortlink"]/@href
         postProcess:
           - replace:
             - regex: ^https://.*/\?p=
               with:
-      # Movies:
-      #   Name:
-      #     selector: //meta[@property="og:site_name"]/@content|//h1[@class="titleVideo"]
-      #     concat: " - "
-      #   Date: *dateAttr
-      #   Synopsis: *detailsSel
-      #   URL: //meta[@property="og:url"]/@content
-# Last Updated April 29, 2025
+# sites now have age-checking and geoblocking, so we can use CDP (with VPN/proxy) to bypass it
+driver:
+  useCDP: false
+# Last Updated August 5, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://virtualrealtrans.com/vr-trans-porn-video/add-your-sweetness-to-the-box/
- https://virtualrealporn.com/vr-porn-video/perfect-erotic-art/
- https://virtualrealamateurporn.com/vr-amateur-porn-video/squirting-party/
- https://virtualrealgay.com/vr-gay-porn-video/refuge-for-two/
- https://virtualrealpassion.com/vr-female-pov-porn-video/cyberdreams/
- https://virtualrealjapan.com/vr-japanese-video/%E3%80%90part02%E3%80%91sex-education-practice/

## Short description

The published/released date does not appear to be on the page of virtualrealtrans.com scenes, and maybe some/all of the other virtualrealporn network sites. The date is present in a JSON schema object within the page HTML however, so this scrapes it from there using Javascript to pick out the `datePublished` value.

The URL scraping was broken for at least virtualrealtrans, as the canonical link is just to the homepage of the site, not the scene URL. The URL is now taken from an "alternate" link in the header which gives the scene URL.

The tags scraping works, but the "hack" to add a fixed value tag of "Virtual Reality" just needs an xpath result that is always there. It is currently set to a large JSON object (that doesn't get parsed, only blindly converted to "Virtual Reality"). As the xpath query match can be anything, I chose the canonical link as that is short and likely to be on every scene page on every substudio site.
