### PR TITLE
Add gallery by url to bigbootytgirls; add studio code to Trans500 sites

### DIFF
--- a/scrapers/BigBootyTGirls.yml
+++ b/scrapers/BigBootyTGirls.yml
@@ -1,26 +1,48 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: BigBootyTGirls
 sceneByURL:
   - action: scrapeXPath
-    url:
+    url: &urls
       - bigbootytgirls.com
     scraper: sceneScraper
+galleryByURL:
+  - action: scrapeXPath
+    url: *urls
+    scraper: galleryScraper
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: //div[@class="titleBlock2 clear"]/h3/text()
-      Date:
+      Title: &title //div[@class="titleBlock2 clear"]/h3/text()
+      Date: &date
         selector: //span[@class="availdate"]/text()
         postProcess:
           - parseDate: 01/02/2006
-      Details: //span[@class="latest_update_description"]/text()
-      Tags:
+      Details: &details //span[@class="latest_update_description"]/text()
+      Tags: &tags
         Name: //span[@class="update_tags"]/a/text()
-      Performers:
+      Performers: &performers
         Name: //span[@class="tour_update_models"]/a/text()
       Image:
-        selector: //meta[@property="og:image"]/@content
+        selector: &imageSel //meta[@property="og:image"]/@content
       Studio:
         Name:
           fixed: BigBootyTGirls
+      Code: &code
+        selector: *imageSel
+        postProcess:
+          - replace:
+              - regex: .*/content/([^/]+).*
+                with: $1
+  galleryScraper:
+    gallery:
+      Title: *title
+      Date: *date
+      Details: *details
+      Tags: *tags
+      Performers: *performers
+      Studio:
+        Name:
+          fixed: BigBootyTGirls
+      Code: *code
 
-# Last Updated November 08, 2020
+# Last Updated August 7, 2025

--- a/scrapers/Trans500.yml
+++ b/scrapers/Trans500.yml
@@ -4,6 +4,7 @@ sceneByURL:
     url:
       - trans500.com/tour/
       - trans500.com/tour3/
+      - trans500.com/trailers/
     scraper: sceneScraper
   - action: scrapeXPath
     url:
@@ -21,13 +22,19 @@ xPathScrapers:
       Title: //div[@class="col-sm-12"]/p/../h2/text()
       Details: //p[@class="description"]
       Image:
-        selector: //video[@id="my-video"]/@poster
+        selector: &imageSel //video[contains(@id, "my-video")]/@poster
         postProcess:
           - replace:
               - regex: ^
-                with: "http://www.trans500.com"
+                with: "https://www.trans500.com"
       Studio:
         Name: //p[@class="pull-right"]/b/text()
+      Code:
+        selector: *imageSel
+        postProcess: &codePostProcess
+          - replace:
+              - regex: .*/([^/]+)/.*
+                with: $1
 
   sceneScraperEspanol:
     scene:
@@ -48,7 +55,7 @@ xPathScrapers:
         Name: //div[@class="scene-infobrick"][contains(text(), "TSGirls:")]/a/text()
       Details: //section[@id="scene-desc"]/p/text()
       Image:
-        selector: //video/@poster|//meta[@name="twitter:image0"]/@content
+        selector: &imageSelEspanol //video/@poster|//meta[@name="twitter:image0"]/@content
         postProcess:
           - replace:
               - regex: '^http:'
@@ -71,4 +78,7 @@ xPathScrapers:
                   with: "Behind Trans500"
       Tags:  # Either //meta[@name="keywords"]/@content OR: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
         Name: //div[@class="scene-infobrick"][contains(text(), "Categories:")]/a/text()
-# Last Updated January 03, 2023
+      Code:
+        selector: *imageSelEspanol
+        postProcess: *codePostProcess
+# Last Updated August 7, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

- https://www.trans500.com/trailers/Lets-Go-MsRodrigues.html
- https://www.trans500.com/tour3/trailers/All-About-Allison.html
- https://bigbootytgirls.com/updates/A-Dani-Weekend.html

## Short description

The photo sets are mentioned on the tour/trailer pages at bigbootytgirls.com, so it makes sense to scrape the same info as the sceneByURL.

The studio code is in the image URL, so that is now scraped
