### PR TITLE
GroobyVR: pick largest image

### DIFF
--- a/scrapers/GroobyVR.yml
+++ b/scrapers/GroobyVR.yml
@@ -121,5 +121,5 @@ xPathScrapers:
       
 # Use CDP with a configured proxy to bypass region-based age-verification
 driver:
-  useCDP: true
+  useCDP: false
 # Last Updated August 7, 2025

--- a/scrapers/GroobyVR.yml
+++ b/scrapers/GroobyVR.yml
@@ -36,11 +36,14 @@ xPathScrapers:
               - regex: content//
                 with: content/
               # ensure URLs are converted from relative to absolute
-              - regex: ^([a-z]*)(/.*)$
-                with: https://www.groobyvr.com/$1$2
+              - regex: ^(tour/|/tour/)
+                with: https://www.groobyvr.com/tour/
+              # protocol-less URLs to absolute
+              - regex: ^//
+                with: https://
               # the full variant should be the original unscaled image
-              - regex: -\dx
-                with: -full
+              - regex: (\d+)(-\dx)?\.(jpg|jpeg|png|gif)$
+                with: $1-full.$3
       Country: //li/b[text()="Nationality:"]/following-sibling::text()|//li/b[text()="Location:"]/following-sibling::text()
       Ethnicity: //li/b[text()="Ethnicity:"]/following-sibling::text()
       Birthdate:
@@ -74,7 +77,10 @@ xPathScrapers:
         Name:
           fixed: Grooby VR
       Image:
-        selector: //dl8-video/@poster
+        selector: &imageSel >-
+          //dl8-video/@poster
+          |
+          //meta[@property="og:image"]/@content
         postProcess: *imagePostProcess
       Tags: &tags
         Name:
@@ -115,5 +121,5 @@ xPathScrapers:
       
 # Use CDP with a configured proxy to bypass region-based age-verification
 driver:
-  useCDP: false
+  useCDP: true
 # Last Updated August 7, 2025

--- a/scrapers/GroobyVR.yml
+++ b/scrapers/GroobyVR.yml
@@ -30,13 +30,17 @@ xPathScrapers:
         fixed: transgender_female
       Image:
         selector: //div[@class="model_photo"]/img/@src
-        postProcess:
+        postProcess: &imagePostProcess
           - replace:
-              - regex: ^(/.*)
-                with: https://www.groobyvr.com$1
+              # errant double slash
+              - regex: content//
+                with: content/
+              # ensure URLs are converted from relative to absolute
+              - regex: ^([a-z]*)(/.*)$
+                with: https://www.groobyvr.com/$1$2
               # the full variant should be the original unscaled image
-              - regex: 2x
-                with: full
+              - regex: -\dx
+                with: -full
       Country: //li/b[text()="Nationality:"]/following-sibling::text()|//li/b[text()="Location:"]/following-sibling::text()
       Ethnicity: //li/b[text()="Ethnicity:"]/following-sibling::text()
       Birthdate:
@@ -71,12 +75,7 @@ xPathScrapers:
           fixed: Grooby VR
       Image:
         selector: //dl8-video/@poster
-        postProcess:
-          - replace:
-              - regex: content// # errant double slash
-                with: content/
-              - regex: ^/
-                with: https://www.groobyvr.com/
+        postProcess: *imagePostProcess
       Tags: &tags
         Name:
           selector: >-
@@ -117,4 +116,4 @@ xPathScrapers:
 # Use CDP with a configured proxy to bypass region-based age-verification
 driver:
   useCDP: false
-# Last Updated July 18, 2025
+# Last Updated August 7, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByURL
- [x] sceneByURL

## Examples to test

- https://www.groobyvr.com/tour/trailers/Getting-Into-Lolas-Jeans.html
- https://www.groobyvr.com/tour/trailers/Waking-Up-With-Ariel.html
- https://www.groobyvr.com/tour/trailers/Embers-Long-Stretch.html
- https://www.groobyvr.com/tour/trailers/I-Fucked-Gabrielly-Ferraz.html

## Short description

Someone recently pointed out that the "-1x" (or "-2x" or whatever number x) in the image URL can be changed to "-full" to get the largest version. This change does that
