### PR TITLE
Remove support for fistingcentral.com from GammaEntertainment to FistingInferno

### DIFF
--- a/scrapers/FistingInferno/FistingInferno.yml
+++ b/scrapers/FistingInferno/FistingInferno.yml
@@ -4,6 +4,7 @@ sceneByURL:
   - action: script
     url:
       - fistinginferno.com/en/video/
+      - fistingcentral.com/en/video/
     script:
       - python
       - ../Algolia/Algolia.py
@@ -32,9 +33,10 @@ galleryByURL:
   - action: script
     url:
       - fistinginferno.com/en/photo/
+      - fistingcentral.com/en/photo/
     script:
       - python
       - ../Algolia/Algolia.py
       - fistinginferno
       - gallery
-# Last Updated September 24, 2023
+# Last Updated August 13, 2025

--- a/scrapers/GammaEntertainment.yml
+++ b/scrapers/GammaEntertainment.yml
@@ -12,7 +12,6 @@ sceneByURL:
       - currycreampie.com/
       - devonlee.com/
       - dylanryder.com/
-      - fistingcentral.com/
       - gapingangels.com/
       - girlsandstuds.com/
       - grannyghetto.com/
@@ -126,7 +125,6 @@ xPathScrapers:
                 eroticax: EroticaX
                 evilangel: Evil Angel
                 familycreep: Family Creep
-                fistingcentral: Fisting Central
                 gapingangels: Gaping Angels
                 girlsandstuds: Girls And Studs
                 grannyghetto: Granny Ghetto
@@ -176,4 +174,4 @@ xPathScrapers:
         Name: //a[contains(@class, 'GA_Id_headerLogo')]/span[@class='linkMainCaption']/text()
       FrontImage: //a[@class='frontCoverImg']/@href
       BackImage: //a[@class='backCoverImg']/@href
-# Last Updated May 12, 2025
+# Last Updated August 13, 2025


### PR DESCRIPTION
GammaEntertainment no longer supports fistingcentral.com, and no valid metadata can be retrieved.
## Short description

example:

https://www.fistingcentral.com/en/movie/Maniacal/82278
https://www.fistinginferno.com/en/movie/Maniacal/82278
