### PR TITLE
Add Frenchtwinks studio code and fix details

### DIFF
--- a/scrapers/Frenchtwinks.yml
+++ b/scrapers/Frenchtwinks.yml
@@ -15,7 +15,7 @@ xPathScrapers:
             - regex: .*\/(\d+)\/\d+\.jpg
               with: "fta$1"
       Details:
-        selector: //div[@class="vid_txt_block2 vid_txt_block2017"]/article/h2 | //div[@class="vid_txt_block2 vid_txt_block2017"]/article/p//text() | //div[@class="vid_txt_block2 vid_txt_block2017"]/article/p//br
+        selector: //div[@class="vid_txt_block2 vid_txt_block2017"]/article/*/text()
         concat: "\n\n"
       Date:
         selector: //time[@datetime]


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

* https://www.french-twinks.com/en/gay-porn-videos/in-the-backstage-01 (fta1080)
* https://www.french-twinks.com/en/gay-porn-videos/paul-and-gabriel-break-the-routine (fta984)

## Short description

This fixes an issue that existed when scraping the details where linebreaks were lost and the subtitle appeared smashed at the start of the description. This changes it to properly pull line breaks so the details match what is displayed visually on the site.

This also adds studio codes for French Twinks. These can be verified by looking at the `contentUrl` in the JSON-LD for the `VideoObject`.
