### PR TITLE
[Pornhub] Find amateur channels by exact name

### DIFF
--- a/scrapers/Pornhub.yml
+++ b/scrapers/Pornhub.yml
@@ -1,7 +1,7 @@
 name: Pornhub
 performerByName:
   action: scrapeXPath
-  queryURL: https://www.pornhub.com/pornstars/search?search={}
+  queryURL: https://www.pornhub.com/video/search?search={}&o=mr
   scraper: performerSearch
 performerByURL:
   - action: scrapeXPath
@@ -54,9 +54,9 @@ xPathScrapers:
         Name: $searchThumb//div[contains(@class, "usernameWrap")]/a[matches(@href, "/(channels|model|pornstar)/")]
   performerSearch:
     performer:
-      Name: //div[@class="wrap"]/div[@class="thumbnail-info-wrapper"]/a[@class="title"]/text()
+      Name: //div[@class="userCardNameBlock"]//a[@class="username"]/text()
       URL:
-        selector: //div[@class="wrap"]/div[@class="thumbnail-info-wrapper"]/a[@class="title"]/@href
+        selector: //div[@class="userCardNameBlock"]//a[@class="username"]/@href
         postProcess:
           - replace:
               - regex: ^


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

"carolina jackson"
"blake core"

## Short description

The current scraper uses `/pornstars/search?search=`; this only returns registered pornstars and no amateur channels. Using `/video/search?search=`, when supplied with the exact (case insensitive) name of the channel, finds amateur channels that the current method does not find, while still also finding registered pornstars by exact name.

Example of the issue: rip videos with a yt-dlp wrapper api, scrape scene by fragment which prompts to create a new performer for that channel with just the name, now you go to scrape the performer by name and nothing of relevance shows up. So you need to open up the video, go to file info, click the pornhub url, go to the channel, copy its link, put it into stash, then scrape performer by url.

With this change, these channels can be scraped easily. The scene scrape already filled in the exact name of the performer, so scraping the performer is a 2 click process.

The big downside is that `/video/search?search=` only returns 1 channel result and only by exact letter-by-letter match; this would mean simply searching for the performer by hand would work a lot worse.

Personally, this tradeoff is worth it for me. But I imagine it may not be the case for others. Regardless, I thought to make a PR and leave it as draft so others can use it or maybe if the tradeoff is worth for the majority of people, even merged.

Sidenote: the added `&o=mr` orders results by most recent; for this we of course dont care about video results, but ordering by most recent takes less processing time to return a response compared to most relevant which is the default.