### PR TITLE
[YouPorn] Fix for 2025, add scrapeByFragment

### DIFF
--- a/scrapers/YouPorn.yml
+++ b/scrapers/YouPorn.yml
@@ -26,7 +26,7 @@ xPathScrapers:
           - parseDate: Published on January 2, 2006
       Image: //meta[@property='og:image']/@content
       Studio:
-        Name: //div[@class='watchTopInfoPanelTable']//a[@href[contains(.,'channel/')]]/text()
+        Name: //div[@class='watchTopInfoPanelTable']//div[@class="submitByLink"]/a/text()
       Tags:
         Name: $tags//a[@href[contains(.,'category/') or contains(.,'porntags/')]]/text()
       Performers:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

Any video from YouPorn

## Short description

Title
