### PR TITLE
Add Helix Studios to the AdultEmpireCash scraper

### DIFF
--- a/scrapers/AdultEmpireCash.yml
+++ b/scrapers/AdultEmpireCash.yml
@@ -48,6 +48,7 @@ movieByURL:
       - elegantangel.com/
       - filthykings.com/
       - forbiddenfruitsfilms.com/
+      - helixstudios.com/
       - lewood.com/
       - rodneymoorestore.com
       - severesexfilms.com/


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

* Scenes
  * https://www.helixstudios.com/1725721/helix-studios-testing-the-tutor-streaming-scene-video.html
* Movies
  * https://www.helixstudios.com/4826020/twink-confessions-3-porn-videos.html

## Short description

It looks like they recently switched from their own system to using AdultEmpireCash. I tested it out locally and the scraper appears to work, though there are two issues that I noticed so far:

1. There are new scene covers for all of the scenes
2. Formatting appears to have been stripped during the migration, so paragraphs are no longer separated

I have also confirmed that the movie scraper works with the new Helix Studios website. Unfortunately with the migration comes new problems:

1. The synopsis appears to have been migrated, but there is some garbage showing up ahead of it in the scraped description.
2. The release dates are all wrong. Movies released in 2017 are showing up as 2024.