### PR TITLE
Added tag extraction initially for Nookie.com but tested on others to…

### DIFF
--- a/scrapers/TugPass.yml
+++ b/scrapers/TugPass.yml
@@ -65,6 +65,8 @@ xPathScrapers:
       Performers: *performers
       Title: *title
       URL: *url
+      Tags:
+        Name: //div[@id='desc-container']/a[@class='pill-link']
       Image:
         selector: >
           //link[@rel="canonical"]/@href 


### PR DESCRIPTION
… work as well.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://nookies.com/video/3257/a-good-stretching-coco-scorpio
- https://nookies.com/video/3208/the-missing-towel-justine-jakobs

## Short description

Added Tag extraction for generally for nookie.com
