### PR TITLE
Updated image extraction to pull cover image rather than one of the s…

### DIFF
--- a/scrapers/VRBangers.yml
+++ b/scrapers/VRBangers.yml
@@ -86,7 +86,7 @@ xPathScrapers:
             - replace:
                 - regex: ^
                   with: "https:"
-      Image: &imageSel //div[contains(@class, "single-video-poster__preview")]/img/@src|//meta[@property="og:image"]/@content
+      Image: &imageSel //section[@id='video-page-banner']/picture/div[contains(concat(' ',normalize-space(@class),' '),' app-image ')]/img/@src
       URL: //link[@rel="canonical"]/@href
     gallery:
       Title: *titleAttr
@@ -142,4 +142,4 @@ xPathScrapers:
 # you can use (a suitably configured) CDP to make use of a proxy/VPN to bypass region-based age-restriction
 # driver:
 #   useCDP: true
-# Last Updated April 11, 2025
+# Last Updated Sept 10, 2025


### PR DESCRIPTION
…ample images.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://vrconk.com/video/god-of-war-freya-a-porn-parody/
https://arporn.com/video/special-after-party/
https://vrbangers.com/video/panty-hunter/

Images were pulling sample images which were inconsistent. I've updated it to retrieve the cover art. 
