### PR TITLE
PremiumBukkake.com ensure valid performers

### DIFF
--- a/scrapers/PremiumBukkake/PremiumBukkake.py
+++ b/scrapers/PremiumBukkake/PremiumBukkake.py
@@ -166,7 +166,8 @@ def scrape_info_from_paywalled():
             except Exception:
                 log.warning(f"[DEBUG] UNABLE TO SCRAPE PERFROMER {perf_name} ")
                 pass
-        ret['performers'] = perf
+        if perf and perf[0] is not None:    
+            ret['performers'] = perf
     
     # Add paywalled url
     ret['urls'] = [paywall_url, members_url]

--- a/scrapers/PremiumBukkake/PremiumBukkake.yml
+++ b/scrapers/PremiumBukkake/PremiumBukkake.yml
@@ -9,4 +9,4 @@ sceneByURL:
       - python
       - PremiumBukkake.py
       - query
-# Last Updated February 21, 2025
+# Last Updated September 11, 2025


### PR DESCRIPTION
The PB scraper uses 2 PB sites to build information from, if one of the sites does not exist it falls back on information from the second site. In cases where a performer does not exist on the initial site and there is no URL for the scene on the second site, the performer field had a single entry of "None" which caused "The requested element is null which the schema does not all" error in stash interface.

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://premiumbukkake.com/tour2/updates/Misha-Maver-1-Bukkake-First-Camera.html

before change will cause error, after will provide details correctly.

## Short description

Before assigning the scraped performer array add a check to see if it is valid.
