### PR TITLE
Prepend the scene category to William Higgins titles

### DIFF
--- a/scrapers/Williamhiggins.yml
+++ b/scrapers/Williamhiggins.yml
@@ -17,7 +17,9 @@ xPathScrapers:
     scene:
       Performers:
         Name: //span[@class="model-info-label"]/following-sibling::a
-      Title: //p[@class="video-detailinfo"]/span
+      Title:
+        selector: //p[@class="video-detailinfo"]/text() | //p[@class="video-detailinfo"]/span
+        concat: ": "
       Date:
         selector: //span[@class="date_field_video"]/text()
         postProcess:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://www.williamhiggins.com/set/detail/23070501

## Short description

This prepends the scene category for all scenes which should allow for scenes which share the same name to be better disambiguated. This does not make any further changes to the category after it is retrieved, leaving it as-is to match what users see on the website.

This is a proposal from a discussion on naming conventions for William Higgins sites: https://discourse.stashapp.cc/t/william-higgins-naming/1952
