### PR TITLE
FIX performer URL -> URLs deprecation

### DIFF
--- a/validator/scraper.schema.json
+++ b/validator/scraper.schema.json
@@ -529,10 +529,6 @@
           "description": "Must be one of (case insensitive): `male`, `female`, `transgender_male`, `transgender_female`, `intersex`, `non_binary`",
           "allOf": [{ "$ref": "#/definitions/nodeSelector" }]
         },
-        "URL": {
-          "title": "Performer URL",
-          "allOf": [{ "$ref": "#/definitions/nodeSelector" }]
-        },
         "URLs": {
           "title": "Performer URLs",
           "allOf": [{ "$ref": "#/definitions/nodeSelector" }]


### PR DESCRIPTION
## Short description

This PR fixes **URL** -> **URLs** deprecation.

The issue was discovered while using one of the scene scrapers: it couldn’t save a performer correctly because the scraper was sending *URL* instead of *URLs*. As a result, the saved performer didn’t have the URL field filled properly.

Related: https://github.com/stashapp/stash/commit/f26766033e03fba06f2b4bd9d74ea2f0f469b57e
