### PR TITLE
Support sfw urls CorbinFisher.yml

### DIFF
--- a/scrapers/CorbinFisher.yml
+++ b/scrapers/CorbinFisher.yml
@@ -3,7 +3,7 @@ sceneByURL:
   - action: scrapeXPath
     url:
       - corbinfisher.com/sfw/trailers
-      - corbinfisher.com/tour/sfw/trailers
+      - corbinfisher.com/tour/trailers
     scraper: sceneScraper
 
 performerByURL:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

## Short description
All /tour/ urls seems to be blocked.
Just replacing it with sfw seems to be working for now, so added it to supported urls

