### PR TITLE
[Babepedia] Fix performerByName search with Python script

### DIFF
--- a/scrapers/Babepedia/Babepedia.py
+++ b/scrapers/Babepedia/Babepedia.py
@@ -1,0 +1,40 @@
+import json
+import re
+import os
+import sys
+import cloudscraper
+import urllib
+
+from py_common import log
+from py_common.util import scraper_args
+
+scraper = cloudscraper.create_scraper()
+
+def performerName(_name: str, _site: str):
+    myHeaders = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'}
+    url = "https://www.babepedia.com/ajax-search.php?term=" + urllib.parse.quote(_name)
+    results = scraper.get(url, headers=myHeaders)
+    data = results.json()
+    
+    ret = []
+    for hit in data:
+        p = {}
+        p['name'] = hit['label']
+        pUrl = "https://www.babepedia.com/babe/" + hit['value'].replace(' ', '_')
+        p['url'] = pUrl
+        ret.append(p)
+    
+    return ret
+
+if __name__ == "__main__" or __name__.endswith("Babepedia"):
+    op, args = scraper_args()
+
+    match op, args:
+        case "performer-by-name", {"name": name, "extra": extra} if name and extra:
+            log.debug(f"Name is: {name} and extra is: {extra}")
+            sites = extra
+            ret = performerName(name, sites)
+            print(json.dumps(ret))
+        case _:
+            log.error(f"Operation: {op}, arguments: {json.dumps(args)}")
+            sys.exit(1)

--- a/scrapers/Babepedia/Babepedia.yml
+++ b/scrapers/Babepedia/Babepedia.yml
@@ -1,8 +1,11 @@
 name: Babepedia
 performerByName:
-  action: scrapeXPath
-  queryURL: https://www.babepedia.com/search/{}
-  scraper: performerSearch
+  action: script
+  script:
+    - python
+    - Babepedia.py
+    - babepedia
+    - performer-by-name
 performerByURL:
   - action: scrapeXPath
     url:
@@ -10,24 +13,6 @@ performerByURL:
     scraper: performerScraper
 
 xPathScrapers:
-  performerSearch:
-    performer:
-      Name:
-        selector: //span[@class="results"]//a[contains(@href, '/babe/')]|//h1[@id="babename"]
-        postProcess:
-          - replace:
-              - regex: "aka(\\s+[A-Z]+)"
-                with: " aka $1"
-
-      URL:
-        selector: //span[@class="results"]//a[contains(@href, '/babe/')]/@href|//meta[@property='og:url']/@content
-        postProcess:
-          - replace:
-              - regex: ^
-                with: https://www.babepedia.com
-              - regex: https:\/\/www\.babepedia\.comhttps:\/\/www\.babepedia\.com
-                with: https://www.babepedia.com
-
   performerScraper:
     common:
       $infoblock: //div[@id="personal-info-block"]
@@ -148,3 +133,9 @@ xPathScrapers:
               - regex: _thumb\d+
                 with: ""
       Details: //p[@id="biotext"]
+driver:
+  # Requires CDP to get by the "consent" screen, along with a "CONSENT" cookie with a value of "Y" for each top level URL
+  useCDP: true
+  headers:
+    - Key: User-Agent
+      Value: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36


### PR DESCRIPTION
Wrote small python script which requires cloudscraper to all Performer Search by Name.

## Scraper type(s)
- [X] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Short description

Performer search by name appeared to be broken. I wrote some small Python script to use the php search to retrieve the JSON data and parse for search results.
