### PR TITLE
Adding UKXXXPass scraper for all their sites

### DIFF
--- a/scrapers/UKXXXPass/UKXXXPass.yml
+++ b/scrapers/UKXXXPass/UKXXXPass.yml
@@ -1,0 +1,40 @@
+name: ukxxxpass
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - ukxxxpass.xxx/
+      - splatbukkake.xxx/
+      - ukpornparty.xxx/
+      - sexyukpornstars.xxx/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $movieMeta: //div[contains(@class, "movieMeta")]
+    scene:
+      Title: //div[@class="movieTitle"]/text()
+      Details: $movieMeta/div[1]/text()
+      Studio: 
+        Name: //a[contains(@href, '/movies/studio/')]/text()
+      Date:
+        selector: //div[contains(., "Released on:")]
+        postProcess:
+          - replace:
+            - regex: .+(\d{2}-\d{2}-\d{4}).+
+              with: $1
+          - parseDate: 02-01-2006
+      Performers:
+        Name: $movieMeta//a[contains(@href, "/model/")]/text()
+      Image:
+        # The img link is relative, so construct the full url manually
+        selector: //link[@rel="canonical"]/@href|//div[@class="movieDetailContent"]//img/@src
+        concat: "|"
+        # There seems to be a bug on the web page where the base URL is given as http:/ not
+        # https:// so correct for that as well
+        postProcess:
+          - replace:
+            - regex: (https?:\/\/?)([^|]+)\|(.+)
+              with: https://$2$3
+      Tags:
+        Name: $movieMeta//a[contains(@href, "/category/")]/text()
+# Last Updated September 21, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://ukpornparty.xxx/movie/500/mackenzie-and-loula-enjoy-a-gangbang
- https://splatbukkake.xxx/movie/84/big-boobed-bukkake-with-talula-and-jordan-pryce
- https://sexyukpornstars.xxx/movie/3486/bar-anal

## Short description

This is a new scraper for the UK XXX Pass sites, including SplatBukkake, UK Porn Party and Sexy UK Pornstars

## Notes for reviewer(s)

I'm not sure if there's a way to extract the URL matched for the scraped query, i.e. if the URL is for https://splatbukkake.xxx/, then I can use that URL to fetch the correct studio name and image. At the moment, I'm using a pretty hacky workaround to construct the URL, so I'd be happy to hear if there's a better way to do this
