### PR TITLE
Perverformer: add scene scraper

### DIFF
--- a/scrapers/Perverformer.yml
+++ b/scrapers/Perverformer.yml
@@ -31,5 +31,5 @@ xPathScrapers:
       URL: //link[@rel="canonical"]/@href
       Studio:
         Name:
-          fixed: perverformer
+          fixed: Perverformer
 # Last Updated September 21, 2025

--- a/scrapers/Perverformer.yml
+++ b/scrapers/Perverformer.yml
@@ -1,0 +1,35 @@
+name: Perverformer
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - perverformer.com/en/video/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $tags: //main/div[@class="columns"]/div[@class="secondary"]/div[@class="area"]/p/span[@class="nowrap"]
+    scene:
+      Title:
+        selector: //main/div[@class="heading"]/h1
+      Date:
+        selector: //script[@type="application/ld+json"]
+        postProcess:
+          - javascript: |
+              // Parse JSON
+              if (value && value.length) {
+                return JSON.parse(value).uploadDate
+              }
+          - parseDate: 2006-01-02T15:04:05+0000
+      Performers:
+        Name: $tags/a[contains(@href, "/model/")]
+      Tags:
+        Name: $tags/a[not(contains(@href, "/model/"))]
+      Details:
+        selector: //main/div[@class="columns"]/div[@class="secondary"]/div[@class="area"]/span[@class="collapsible-partial"]
+        concat: "\n"
+      Image: //main/div[@class="columns"]/div[@class="primary"]//video/@poster
+      URL: //link[@rel="canonical"]/@href
+      Studio:
+        Name:
+          fixed: perverformer
+# Last Updated September 21, 2025


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://perverformer.com/en/video/two-beautiful-sadists-provoke-pleasure-and-pain
- https://perverformer.com/en/video/foursome-with-2-female-sadists-and-1-latex-doll
- https://perverformer.com/en/video/mistress-has-control-over-orgasms-and-breathing
- https://perverformer.com/en/video/the-harder-the-erection-the-stronger-the-distress

## Short description

Added scene scraper for perverformer.com.
