### PR TITLE
Performer now scraping from both RealJamVR and PornCornVR

### DIFF
--- a/scrapers/RealjamVR/RealJamVR.yml
+++ b/scrapers/RealjamVR/RealJamVR.yml
@@ -14,11 +14,11 @@ sceneByURL: &byURL
   - action: scrapeXPath
     url:
       - realjamvr.com/scene/
-    scraper: sceneScraperRealJamVr
+    scraper: sceneScraper
   - action: scrapeXPath
     url:
       - porncornvr.com/scene
-    scraper: sceneScraperPornCornVr
+    scraper: sceneScraper
 galleryByURL: *byURL
 performerByURL:
   - action: scrapeXPath
@@ -28,7 +28,7 @@ performerByURL:
     scraper: performerScraper
 
 xPathScrapers:
-  sceneScraperRealJamVr:
+  sceneScraper:
     scene:
       Title: &title
         selector: //h1
@@ -37,70 +37,16 @@ xPathScrapers:
               - regex: ^\s+(.+)\s+$
                 with: $1
       URL:
-        selector: //a[@class='btn btn-m1']/@href
+        # incredible amounts of jank
+        # scrape the address png with an alt containing the site name, the most consistent between sites
+        selector: //img[contains(@src, "address.png")]/@alt | //a[@class='btn btn-m1']/@href
+        concat: "|"
         postProcess:
           - replace:
-              - regex: .+next=(.+)
-                with: https://realjamvr.com$1
-      Date: &date
-        selector: //div[@class="specs-icon"]/following-sibling::strong
-        postProcess:
-          # both date formats are used interchangeably
-          # e.g.
-          # Jan. 2, 2006
-          # January 2, 2006
-          # Sept. 2, 2024
-          - replace:
-              - regex: ([\w]{3})([^\ ]+)?(.*)
-                with: $1$3
-          - parseDate: Jan 2, 2006
-      Performers: &performers
-        Name:
-          selector: //a[contains(@href, 'actor')][contains(text(), 'VR')]
-          postProcess:
-            - replace:
-              - regex: (.+)\sVR.+
-                with: $1
-      Tags: &tags
-        Name:
-          selector: //a[starts-with(@href, "/scenes") and @class="tag"]/text() | //div[not(@class)]/div[@class="specs-icon"]
-          postProcess:
-            - replace:
-                # use the duration "specs-icon" as a fixed value replacement "hack"
-                - regex: \d+:\d+:\d+
-                  with: Virtual Reality
-      Details: &details
-        selector: //div[contains(@class, "collapse-content-wrapper")]/div[contains(@class, "collapse-content")]
-      Image:
-        selector: //*[@id="video-player"]//@poster
-      Studio: &studio
-        Name:
-          selector: //title
-          postProcess:
-            - replace:
-                - regex: '(.*)\| ([^\|]+VR)$'
-                  with: $2
-    gallery:
-      Title: *title
-      Date: *date
-      Performers: *performers
-      Tags: *tags
-      Details: *details
-      Studio: *studio
-  sceneScraperPornCornVr:
-    scene:
-      Title: &title
-        selector: //h1
-        postProcess:
-          - replace:
-              - regex: ^\s+(.+)\s+$
-                with: $1
-      URL:
-        selector: //a[@class='btn btn-m1']/@href
-        postProcess:
-          - replace:
-              - regex: .+next=(.+)
-                with: https://porncornvr.com$1
+              - regex: (.+)\|.+\?next=(.+)
+                with: https://$1.com$2
+          - javascript: |
+              return value.toLowerCase()
       Date: &date
         selector: //div[@class="specs-icon"]/following-sibling::strong
         postProcess:

--- a/scrapers/RealjamVR/RealJamVR.yml
+++ b/scrapers/RealjamVR/RealJamVR.yml
@@ -14,12 +14,11 @@ sceneByURL: &byURL
   - action: scrapeXPath
     url:
       - realjamvr.com/scene/
-    scraper: sceneScraper
-  - action: scrapeXPath
-    url:
       - porncornvr.com/scene
     scraper: sceneScraper
+
 galleryByURL: *byURL
+
 performerByURL:
   - action: scrapeXPath
     url:
@@ -127,4 +126,4 @@ xPathScrapers:
       Image: //div[contains(@class, "actor-view")]//img/@src
       Piercings: //div[span[text()="Piercing:"]]/text()
       Tattoos: //div[span[text()="Tattoo:"]]/text()
-# Last Updated Sept 19, 2025
+# Last Updated Sept 25, 2025

--- a/scrapers/RealjamVR/RealJamVR.yml
+++ b/scrapers/RealjamVR/RealJamVR.yml
@@ -14,11 +14,12 @@ sceneByURL: &byURL
   - action: scrapeXPath
     url:
       - realjamvr.com/scene/
+    scraper: sceneScraperRealJamVr
+  - action: scrapeXPath
+    url:
       - porncornvr.com/scene
-    scraper: sceneScraper
-
+    scraper: sceneScraperPornCornVr
 galleryByURL: *byURL
-
 performerByURL:
   - action: scrapeXPath
     url:
@@ -27,7 +28,7 @@ performerByURL:
     scraper: performerScraper
 
 xPathScrapers:
-  sceneScraper:
+  sceneScraperRealJamVr:
     scene:
       Title: &title
         selector: //h1
@@ -54,7 +55,71 @@ xPathScrapers:
                 with: $1$3
           - parseDate: Jan 2, 2006
       Performers: &performers
-        Name: //div[contains(text(),"Starring:")]//a[contains(@href,"/actor/")]
+        Name:
+          selector: //a[contains(@href, 'actor')][contains(text(), 'VR')]
+          postProcess:
+            - replace:
+              - regex: (.+)\sVR.+
+                with: $1
+      Tags: &tags
+        Name:
+          selector: //a[starts-with(@href, "/scenes") and @class="tag"]/text() | //div[not(@class)]/div[@class="specs-icon"]
+          postProcess:
+            - replace:
+                # use the duration "specs-icon" as a fixed value replacement "hack"
+                - regex: \d+:\d+:\d+
+                  with: Virtual Reality
+      Details: &details
+        selector: //div[contains(@class, "collapse-content-wrapper")]/div[contains(@class, "collapse-content")]
+      Image:
+        selector: //*[@id="video-player"]//@poster
+      Studio: &studio
+        Name:
+          selector: //title
+          postProcess:
+            - replace:
+                - regex: '(.*)\| ([^\|]+VR)$'
+                  with: $2
+    gallery:
+      Title: *title
+      Date: *date
+      Performers: *performers
+      Tags: *tags
+      Details: *details
+      Studio: *studio
+  sceneScraperPornCornVr:
+    scene:
+      Title: &title
+        selector: //h1
+        postProcess:
+          - replace:
+              - regex: ^\s+(.+)\s+$
+                with: $1
+      URL:
+        selector: //a[@class='btn btn-m1']/@href
+        postProcess:
+          - replace:
+              - regex: .+next=(.+)
+                with: https://porncornvr.com$1
+      Date: &date
+        selector: //div[@class="specs-icon"]/following-sibling::strong
+        postProcess:
+          # both date formats are used interchangeably
+          # e.g.
+          # Jan. 2, 2006
+          # January 2, 2006
+          # Sept. 2, 2024
+          - replace:
+              - regex: ([\w]{3})([^\ ]+)?(.*)
+                with: $1$3
+          - parseDate: Jan 2, 2006
+      Performers: &performers
+        Name:
+          selector: //a[contains(@href, 'actor')][contains(text(), 'VR')]
+          postProcess:
+            - replace:
+              - regex: (.+)\sVR.+
+                with: $1
       Tags: &tags
         Name:
           selector: //a[starts-with(@href, "/scenes") and @class="tag"]/text() | //div[not(@class)]/div[@class="specs-icon"]


### PR DESCRIPTION

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

[List a few links/titles/names/filenames/codes to test]

https://realjamvr.com/scene/threesome-anal-teacher-for-stepsister/
https://realjamvr.com/scene/slutty-housewife-bunny-madison/

https://porncornvr.com/scene/latex-doll-ember-snow/
https://porncornvr.com/scene/threesome-passion-girls-prefer-anal-2/

## Short description

I don't love this pull request. Nearly everything works for both RealJam and PornCorn with two exceptions which is why there are two scrapers. The URL extraction hard codes the base URL. This is really only used if you use Scene Search By Name.  As far as I can tell I can't have two "search by name" items listed in the same Yaml file (one for PornCorn one for RealJam) created in the drop down even though I'd use the same Python code.  I really feel like this could be better consolidated but I suspect it's my inexperience that's creating the issue. Help would be appreciated. 
