### PR TITLE
Small tweak to regex to address failed image extraction

### DIFF
--- a/scrapers/NaughtyAmerica.yml
+++ b/scrapers/NaughtyAmerica.yml
@@ -63,7 +63,7 @@ jsonScrapers:
                   name = name.slice(prefix.length);
                 }
                 name = name.replace(/teaser|trailer$/, '');
-                return `https://images1.naughtycdn.com/cms/nacmscontent/v1/scenes/${prefix}/${name}/scene/horizontal/1279x852c.webp`;
+                return `https://images4.naughtycdn.com/cms/nacmscontent/v1/scenes/${prefix}/${name}/scene/horizontal/1279x852c.webp`;
               }
               return null;
     gallery:


### PR DESCRIPTION


## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

- https://www.naughtyamerica.com/scene/an-after-school-fuck-with-mia-malkova-24423
- https://www.naughtyamerica.com/scene/2cst-juliakimberchadrem-31457
- https://www.naughtyamerica.com/scene/your-sexy-girlfriend-megan-rain-is-ready-to-try-anal-32739
- https://www.naughtyamerica.com/scene/mfhm-juliachadrem-31369

## Short description

First, it looks like NaughtyAmerica.yml and NaughtyAmericaVR.yml are both set to scrape NaughtyAmericaVR.com. Not sure if that's intentional.

I updated NaughtyAmerica.yml because it appeared to have issues extracting scene images. Very small update to the regex.
