### PR TITLE
Tested to be working

### DIFF
--- a/scrapers/MilfVr/MilfVr.py
+++ b/scrapers/MilfVr/MilfVr.py
@@ -1,0 +1,65 @@
+import json
+import sys
+import urllib
+import cloudscraper
+
+from py_common import log
+from py_common.util import scraper_args
+
+scraper = cloudscraper.create_scraper()
+
+def searchSceneByName(name: str) -> list:
+    myUrl = "https://www.milfvr.com/search/suggest.json?group=yes&q=" + urllib.parse.quote(name)
+    log.debug(f"myUrl is: {myUrl}")
+
+    getCookies = scraper.get(url='https://milfvr.com')
+
+    myCookies = getCookies.cookies.get_dict()
+    log.debug(f"My cookies are: {myCookies}")
+    
+    myHeaders = {
+          'priority': 'u=1, i'
+          , 'referer': 'https://www.milfvr.com'
+          , 'sec-ch-ua': '"Chromium";v="140", "Not=A?Brand";v="24", "Brave";v="140"'
+          , 'sec-ch-ua-arch': '"x86"'
+          , 'sec-ch-ua-full-version-list': '"Chromium";v="140.0.0.0", "Not=A?Brand";v="24.0.0.0", "Brave";v="140.0.0.0"'
+          , 'sec-ch-ua-mobile': '?0'
+          , 'sec-ch-ua-model': '""'
+          , 'sec-ch-ua-platform': '"Linux"'
+          , 'sec-ch-ua-platform-version': '"6.12.43"'
+          , 'sec-fetch-dest': 'empty'
+          , 'sec-fetch-mode': 'cors'
+          , 'sec-fetch-site': 'same-origin'
+          , 'sec-gpc': '1'
+          , 'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+          , 'x-csrf-token': myCookies['csrfst']
+          , 'x-requested-with': 'XMLHttpRequest'
+        }
+    log.debug(f"My headers are: {myHeaders}")
+
+    result = scraper.get(url=myUrl, headers=myHeaders, cookies=myCookies).json()
+    log.debug(f"Payload is: {result}")
+
+    returnData = []
+    for hit in result:
+        if ('icon' in hit and hit['icon'] == 'movie'):
+          s = {}
+          s['title'] = hit['label']
+          s['url'] = 'https://milfvr.com' + hit['url']
+          returnData.append(s)
+
+    return returnData
+
+if __name__ == "__main__":
+    op, args = scraper_args()
+    returnValue: list
+
+    match op, args:
+        case "scene-by-name", {"name": name} if name:
+            returnValue = searchSceneByName(name)
+        case _:
+            log.error(f"Operation: {op}, arguments: {json.dumps(args)}")
+            sys.exit(1)
+
+    log.debug(f"JSON Return Value: {returnValue}")
+    print(json.dumps(returnValue))

--- a/scrapers/MilfVr/MilfVr.yml
+++ b/scrapers/MilfVr/MilfVr.yml
@@ -1,0 +1,87 @@
+name: MilfVR
+sceneByName:
+  action: script
+  script:
+    - python
+    - MilfVr.py
+    - scene-by-name
+sceneByQueryFragment:
+  action: scrapeXPath
+  scraper: sceneScraper
+  queryURL: "{url}"
+
+jsonScrapers:
+  sceneByName:
+    scene:
+      Title: "#.label"
+      URL:
+        selector: "#.url"
+        postProcess:
+          - replace:
+            - regex: "^"
+              with: "https://www.milfvr.com"
+
+xPathScrapers:
+  sceneScraper:
+    common:
+      $info: &infoSel //div[@class="detail"]
+      $url: &urlSel //link[@rel="canonical"]/@href
+    scene:
+      Title: &titleSel //div[@class="detail__header detail__header-lg"]/h1
+      URL: //link[@rel="canonical"]/@href
+      Date: &dateAttr
+        selector: $info//span[@class="detail__date"]/text()
+        postProcess:
+          - parseDate: 2 January, 2006
+      Details: &detailsAttr
+        selector: //div[@class="detail__txt detail__txt-show_lg"]/text()|//span[@class="more__body"]/text()
+        concat: " "
+      Tags: &tagsAttr
+        Name: $info//div[@class="tag-list__body"]//a/text()
+      Performers: &performersAttr
+        Name: //div[@class="detail__inf detail__inf-align_right"]/div[@class="detail__models"]/a/text()
+      Image: &imageAttr
+        selector: //meta[@property="og:image"]/@content|//div[@class="photo-strip__body"]/div[2]/@data-src
+        postProcess:
+          - replace:
+              - regex: medium.jpg
+                with: large.jpg
+              # TranzVR defaults to smaller covers, but we can grab a bigger one
+              - regex: 472/cover.jpg
+                with: 680/cover.jpg
+              # All of these domains give 403 errors when saving the scraped image
+              # but povr.com has the same images and is totally cool with our scraping
+              - regex: cdns-i.wankzvr.com
+                with: images.povr.com/wvr
+              - regex: images.tranzvr.com
+                with: images.povr.com/tvr
+              - regex: cdns-i.milfvr.com
+                with: images.povr.com/mvr
+              - regex: cdns-i.brasilvr.com
+                with: images.povr.com
+      Studio: &studioAttr
+        Name:
+          selector: *urlSel
+          postProcess:
+            - replace:
+                - regex: ^.*//(?:www.)?([^/]*).*$
+                  with: $1
+            - map:
+                brasilvr.com: BrasilVR
+                milfvr.com: MilfVR
+                tranzvr.com: TranzVR
+                wankzvr.com: WankzVR
+      Code: &codeAttr
+        selector: *urlSel
+        postProcess:
+          - replace:
+              - regex: ^.*-(\d+)$
+                with: $1
+    gallery:
+      Title: *titleSel
+      Date: *dateAttr
+      Details: *detailsAttr
+      Tags: *tagsAttr
+      Performers: *performersAttr
+      Studio: *studioAttr
+      Code: *codeAttr


### PR DESCRIPTION

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [X] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://www.milfvr.com/bye-bye-bro-code-3447589
- https://www.milfvr.com/burning-love-6355821
- https://www.milfvr.com/creampierates-of-the-caribbean-6333089
- https://www.milfvr.com/greene-with-envy-6350141
- https://www.milfvr.com/motherlover-6361989

## Short description

MilfVR already had a scraper (and I stole the sceneByUrl scraper from that) but it was a part of POVR and that meant to have a SceneByName search it would be called POVR but only search milfvr.com. This didn't make sense to me to I created a new scraper just for SceneByName and SceneByFragment for milfvr.com.

If I can use a SceneByURL from another existing scraper as a reference this would clearly be better but I don't believe this is possible. Or if I can name the SceneByName value somehow that would work too. Looking for advice on this one.
