### PR TITLE
refactor: update AD4X scraper and improve data extraction

### DIFF
--- a/scrapers/AD4X.yml
+++ b/scrapers/AD4X.yml
@@ -7,15 +7,18 @@ sceneByURL:
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
+    common:
+      $next_data: //script[@id="__NEXT_DATA__"]
     scene:
       Title: //div[contains(@class, 'section-title')]
       Details: //div[contains(@class,'description')]
       Date:
-        selector: //script[contains(text(), '"publish_date"')]/text()
+        selector: $next_data/text()
         postProcess:
           - replace:
-              - regex: .+publish_date":"(\d{4})\/(\d{2})\/(\d{2}).+
-                with: $1-$2-$3
+              - regex: '.+"content":{(?:[^}]+)"publish_date":"(\d{4}\/\d{2}\/\d{2}).+'
+                with: $1
+          - parseDate: 2006/01/02
       Image:
         selector: //meta[@property="og:image"]/@content
       Performers:
@@ -24,9 +27,9 @@ xPathScrapers:
         Name:
           fixed: AD4X
       Code:
-        selector: //script[contains(text(), '"id"')]/text()
+        selector: $next_data/text()
         postProcess:
           - replace:
-            - regex: .+"id":(\d+).+
+            - regex: '.+"content":{(?:[^}]+)"id":(\d+).+'
               with: $1
 # Last Updated September 26, 2025

--- a/scrapers/AD4X.yml
+++ b/scrapers/AD4X.yml
@@ -2,21 +2,31 @@ name: AD4X
 sceneByURL:
   - action: scrapeXPath
     url:
-      - ad4x.com/tour
+      - ad4x.com/en/videos
+      - ad4x.com/videos
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
     scene:
-      Title: //title
-      Details:  //div[contains(@class,'description')]
+      Title: //div[contains(@class, 'section-title')]
+      Details: //div[contains(@class,'description')]
       Date:
-        selector: //span[@class='date']
+        selector: //script[contains(text(), '"publish_date"')]/text()
         postProcess:
-          - parseDate: 01/02/2006
-      Image: //video/@poster
+          - replace:
+              - regex: .+publish_date":"(\d{4})\/(\d{2})\/(\d{2}).+
+                with: $1-$2-$3
+      Image:
+        selector: //meta[@property="og:image"]/@content
       Performers:
-        Name: //span[contains(text(),'Starring')]/following-sibling::a/text()
+        Name: //div[contains(@class, 'model-thumb')]/following-sibling::h5/text()
       Studio:
         Name:
           fixed: AD4X
-# Last Updated March 27, 2024
+      Code:
+        selector: //script[contains(text(), '"id"')]/text()
+        postProcess:
+          - replace:
+            - regex: .+"id":(\d+).+
+              with: $1
+# Last Updated September 26, 2025

--- a/scrapers/FrancescoMalcom.yml
+++ b/scrapers/FrancescoMalcom.yml
@@ -41,8 +41,7 @@ xPathScrapers:
 driver:
   useCDP: true
   cookies:
-    - CookieURL: "https://francescomalcom.com/"
-      Cookies:
+    - Cookies:
         - Name: "splash"
           Domain: "francescomalcom.com"
           Value: "1"

--- a/scrapers/FrancescoMalcom.yml
+++ b/scrapers/FrancescoMalcom.yml
@@ -1,0 +1,30 @@
+name: Francesco Malcom
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - https://francescomalcom.com/product
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //title/text()
+        postProcess:
+          - replace:
+              - regex: (.+) - FrancescoMalcom.com official content
+                with: $1
+      Details: //p[@class="desc"]
+      Date:
+        fixed: 2021-09-15
+      Image:
+        selector: //meta[@property="og:image"]/@content
+      Studio:
+        Name:
+          fixed: Francesco Malcom
+      Code:
+        selector: //script[contains(text(), 'processedLink')]/text()
+        postProcess:
+          - replace:
+            - regex: .+product\/(\d+)\/.+
+              with: $1
+# Last Updated September 26, 2025

--- a/scrapers/FrancescoMalcom.yml
+++ b/scrapers/FrancescoMalcom.yml
@@ -1,8 +1,9 @@
+# Jank ModelCentro scraper
 name: Francesco Malcom
 sceneByURL:
   - action: scrapeXPath
     url:
-      - https://francescomalcom.com/product
+      - francescomalcom.com/product
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:
@@ -13,18 +14,37 @@ xPathScrapers:
           - replace:
               - regex: (.+) - FrancescoMalcom.com official content
                 with: $1
-      Details: //p[@class="desc"]
-      Date:
-        fixed: 2021-09-15
+      Details: //meta[@name="description"]/@content
+      # only date available is last update of page
       Image:
-        selector: //meta[@property="og:image"]/@content
+        selector: //div[@class="ac-p-poster"]/@style
+        postProcess:
+          - replace:
+            - regex: 'background-image: url\("(.*)"\);'
+              with: $1
       Studio:
         Name:
           fixed: Francesco Malcom
+      Performers:
+        Name:
+          fixed: Francesco Malcom
+      Tags:
+        Name:
+          fixed: "Missing Performer (Female)"
       Code:
         selector: //script[contains(text(), 'processedLink')]/text()
         postProcess:
           - replace:
             - regex: .+product\/(\d+)\/.+
               with: $1
+
+driver:
+  useCDP: true
+  cookies:
+    - CookieURL: "https://francescomalcom.com/"
+      Cookies:
+        - Name: "splash"
+          Domain: "francescomalcom.com"
+          Value: "1"
+          Path: "/"
 # Last Updated September 26, 2025


### PR DESCRIPTION
Refactor the AD4X scraper to enhance URL coverage and data extraction. Update the scene scraping logic to support additional URL paths, including 'ad4x.com/en/videos' and 'ad4x.com/videos'. Modify the XPath for 'Title' to target 'section-title' div for improved accuracy. Change the 'Date' selector to extract publication date from script tags and reformat it to 'YYYY-MM-DD'. Adjust 'Image' scraper to use the 'og:image' meta tag for better reliability. Update 'Performers' XPath to fetch names from 'model-thumb' associated elements. Add scraping for 'Code' using a new selector, parsing the ID from script tags. Update metadata with the latest modification date; enhances data integrity and adaptability.
