### PR TITLE
Handle case where Aylo returns unreasonably short heights

### DIFF
--- a/scrapers/AyloAPI/scrape.py
+++ b/scrapers/AyloAPI/scrape.py
@@ -285,8 +285,10 @@ def to_scraped_performer(
 
     # All remaining fields are only available when scraped directly
     if height := performer_from_api.get("height"):
-        # Convert to cm
-        performer["height"] = str(round(height * 2.54))
+        # Aylo sometimes returns unreasonably small heights for performers
+        if height > 5:
+            # Convert to cm
+            performer["height"] = str(round(height * 2.54))
 
     if weight := performer_from_api.get("weight"):
         # Convert to kg


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

* https://www.realitydudes.com/model/21257/will

## Short description

The Aylo API will sometimes return heights of 0' 2" for performers, or about 5cm tall. This is clearly wrong and causes validation errors within Stash-Box as a result. So to fix this a minimum height of 5" is set to filter out the ones clearly too small.
