### PR TITLE
Improve CarnalPlus scraper

### DIFF
--- a/scrapers/CarnalPlus.yml
+++ b/scrapers/CarnalPlus.yml
@@ -67,7 +67,7 @@ xPathScrapers:
               - regex: -1x.*?\.jpg
                 with: -full.jpg
               - regex: width=1500
-                with: width=1920
+                with: width=9999
       URL: &url //link[@rel="canonical"]/@href
       Date: &dateSubscraper
         # We need to scrape the network site to get the date, but this scraper


### PR DESCRIPTION
This PR
- Scrapes 1920px cover from both, studio and network site
- Removes custom title handling from studio site. This is to standardize titles between studio and network site.
- Dig performer name from image alt so no character name is used.
- Ensures that performer is scraped more often