### PR TITLE
MyMemberSite: fix URL parsing for sites hosted on mymember.site domain

### DIFF
--- a/scrapers/MyMemberSite/MyMemberSite.py
+++ b/scrapers/MyMemberSite/MyMemberSite.py
@@ -72,7 +72,7 @@ def __parse_url(api_url: str, scraped_url: str) -> str:
     path = urlparse(scraped_url).path
     if not (
         match := re.match(
-            r"^\/(?P<type>videos|photosets)\/(?P<id>\d+)(?:-(?P<name>.+))?$", path
+            r"\/(?P<type>videos|photosets)\/(?P<id>\d+)(?:-(?P<name>.+))?$", path
         )
     ):
         log.error(f"Unable to parse URL '{scraped_url}'")


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [x] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://bondageliberation.com/videos/977-squeeze-an-orange
- https://mymember.site/rubbobjectdoll/videos/28-my-girlfriend-told-me-i-look-like-a-super-hero

## Short description

Fixes URL parsing for sites hosted on mymember.site domain which is now broken due https://github.com/stashapp/CommunityScrapers/pull/2525/commits/006832ad59fffa3289de2bddf6c93aad1de9af49.
