### PR TITLE
[wallhaven.cc] add imageByFragment that picks up default saved filename

### DIFF
--- a/scrapers/Wallhaven.yml
+++ b/scrapers/Wallhaven.yml
@@ -10,7 +10,7 @@ imageByFragment:
     filename:
       - regex: "[^a-zA-Z\\d\\-._~ ]" # clean filename so that it can construct a valid url
         with: ""
-      - regex: "^.*[ _.\\-]([a-z\\d]{6}).[a-zA-Z\\d]{3,}$" # try to extract ID postfix
+      - regex: "^.*[ _.\\-]([a-z\\d]{6})\\.[a-zA-Z\\d]{3,}$" # try to extract ID postfix
         with: "https://wallhaven.cc/api/v1/w/$1"
   scraper: imageScraper
 


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [X] imageByFragment
- [X] imageByURL

## Examples to test

SFW because NSFW needs account and API token

https://wallhaven.cc/w/9dqojx
https://wallhaven.cc/w/yxd8jk

## Short description

When right-click saving a wallpaper from wallhaven, the default filename has a predictable structure ("wallhaven-<ID>.<ext>"). This change adds image fragment scraping to allow automatically picking up IDs that are a clear and separable postfix to the filename.
