### PR TITLE
Fix Motherless scraper to handle deleted videos

### DIFF
--- a/scrapers/Motherless.yml
+++ b/scrapers/Motherless.yml
@@ -36,8 +36,17 @@ xPathScrapers:
   sceneScraper:
     common:
       $meta: //div[@class='media-meta']
+      $error: //div[@class='error-page view-page']
     scene:
-      Title: $meta//h1/text()
+      Title:
+        selector: $meta//h1/text()
+        postProcess:
+          - javascript: |
+              // Check if error page div exists (deleted video)
+              if (context.error && context.error.includes("File not found")) {
+                return null;
+              }
+              return value;
       Date:
         selector: $meta//div[@class='media-meta-stats']/span[not(contains(.,'Views')) and not(contains(.,'Favorites'))]/text()
         postProcess:
@@ -66,4 +75,4 @@ xPathScrapers:
             - replace:
                 - regex: \#
                   with:
-# Last Updated April 01, 2025
+# Last Updated October 17, 2025


### PR DESCRIPTION
## Short description

Motherless returns HTTP 200 with error page content instead of 404 when videos are deleted:

```html
<div class="error-page view-page py-3">
    <h1 class="p-0 m-0">
        File not found. Nothing to see here!
    </h1>
            <p class="reason motherless-red text-huge py-2 m-0">
            • The member has deleted the upload •
        </p>
        <p class="text-huge m-0">
        Here's another image instead...
    </p>
</div>
```

Then below it, a random result is returned. The scraper will use the random result to populate the metadata, instead of a no-op as expected.

This PR adds error detection to prevent scraping replacement content by checking for "File not found" error div and returning null to fail the scrape.

## Examples to test

```
https://motherless.com/46E5D3E
```
