### PR TITLE
[hegre] performer add weight, tags

### DIFF
--- a/scrapers/Hegre.yml
+++ b/scrapers/Hegre.yml
@@ -139,6 +139,12 @@ xPathScrapers:
           - replace:
               - regex: cm
                 with: ""
+      Weight:
+        selector: //span[@class="label"][contains(text(),"Weight")]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: kg
+                with: ""
       Image:
         selector: //div[@class="details"]//img/@src
         # Newer models allow for 1440x
@@ -149,4 +155,6 @@ xPathScrapers:
       Details:
         selector: //div[@class="description translated-text"]//child::text()
         concat: "\n\n"
-# Last Updated September 17, 2025
+      Tags:
+        Name: //div[contains(@class,"details")]//div[contains(@class,"current-tags")]//a[contains(@class,"tag")]/text()
+# Last Updated October 28, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [X] performerByURL

## Examples to test

https://www.hegre.com/models/hannah?locale=en
https://www.hegre.com/models/julietta?locale=en

## Short description

I noticed the Hegre scraper did not pick up the given performer weight and their tags. These might have been added to the site after the scraper was created.
