### PR TITLE
CruelGirlfriend: Add fragment scraper and URL datum

### DIFF
--- a/scrapers/CruelGirlfriend.yml
+++ b/scrapers/CruelGirlfriend.yml
@@ -4,6 +4,16 @@ sceneByURL:
     url:
       - cruelgf.com/Clip.php
     scraper: sceneScraper
+sceneByFragment:
+  action: scrapeXPath
+  scraper: sceneScraper
+  queryURL: https://cruelgf.com/Clip.php?clip_no={filename}
+  queryURLReplace:
+    filename:
+      - regex: ^(\d+).mp4$
+        with: $1
+      - regex: .*[a-z]CG(\d+)H?.mp4
+        with: $1
 xPathScrapers:
   sceneScraper:
     common:
@@ -71,6 +81,7 @@ xPathScrapers:
       Studio:
         Name:
           fixed: Cruel Girlfriend
+      URL: //html/head/meta[@property="og:url"]/@content
       Code:
         selector: $script
         postProcess:
@@ -79,4 +90,4 @@ xPathScrapers:
                 with: $1
               - regex: "^{.+" #cleanup on non matches
                 with:
-# Last Updated January 06, 2023
+# Last Updated November 4, 2025


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://cruelgf.com/Clip.php?clip_no=1190
CG1190H.mp4
LaylaCG1257H.mp4

## Short description

Adds a `sceneByFragment` scraper variant reusing the xpath scraper for CruelGirlfriend, also adds a URL cleanup to the scraper based on the opengraph meta tags for the page
