### PR TITLE
Add ENFHub.com

### DIFF
--- a/scrapers/ENFHub/ENFHub.yml
+++ b/scrapers/ENFHub/ENFHub.yml
@@ -49,10 +49,8 @@ xPathScrapers:
       Tags:
         Name:
           selector: //div[@class="flex flex-wrap gap-2 mt-2"]//a[contains(@href,'/tags/')]
-          attribute: text
       Date:
         selector: //script[@type="application/ld+json"][contains(.,"uploadDate")]/text()
-        attribute: text
         postProcess:
           - replace:
               - regex: '^[\s\S]*"uploadDate":"(\d{4}-\d{2}-\d{2})[\s\S]*'


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://enfhub.com/2024/12/cmnf-video-naked-for-the-delivery-guy
https://enfhub.com/2021/09/peculiar-oon-cfnf-video-two-girls-strip-the-third-one-underwater

## Short description

Added XPath scraper to pull video data as well as scene query.
Data pulled from header meta as well as a json field for a full description and upload date.
