### PR TITLE
Add enf-cmnf.cc

### DIFF
--- a/scrapers/ENF_CMNF/ENF_CMNF.yml
+++ b/scrapers/ENF_CMNF/ENF_CMNF.yml
@@ -1,0 +1,42 @@
+name: "ENF-CMNF.cc"
+
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - enf-cmnf.cc/20
+    scraper: sceneScraper
+    
+sceneByName:
+  action: scrapeXPath
+  queryURL: https://enf-cmnf.cc/?s={}
+  scraper: searchScraper
+  
+sceneByQueryFragment:
+  action: scrapeXPath
+  queryURL: "{url}"
+  scraper: sceneScraper
+
+xPathScrapers:
+  searchScraper:                 # search-results page
+    common:
+      $card: //article[contains(@class,"post")]
+    scene:
+      Title: $card//h2[@itemprop="headline"]/a/text()
+      URL: $card//h2[@itemprop="headline"]/a/@href
+      Image: $card//img[contains(@class,"attachment-large")]/@src
+
+  sceneScraper:                # detail page
+    common:
+      $content: //div[contains(@class,"entry-content")]
+    scene:
+      Title: //h1[@class="entry-title"]/text()
+      Details:
+        # pull all <p> tags, but avoid the HTML5 error message.
+        selector: $content//p[not(@class)]//text()
+        concat: " "
+      Image: $content//video/@poster
+      URL: //link[@rel="canonical"]/@href
+      Date:
+        selector: //meta[@property="article:published_time"]/@content
+        postProcess:
+          - parseDate: "2006-01-02T15:04:05Z07:00"


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [X] sceneByName
- [X] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://enf-cmnf.cc/2025/11/anime-enf-oon-video-warrior-girl-loses-her-clothes-fighting-tentacle-monster-and-gets-empowered-by-mans-erection/
https://enf-cmnf.cc/2025/11/nip-video-brunette-girl-with-perfect-boobs-rides-a-mechanical-bull/

## Short description

Similar to the ENFHub. This pulls from URL or query.
