### PR TITLE
Added URL extraction for scene and updated URL for Group.

### DIFF
--- a/scrapers/data18.yml
+++ b/scrapers/data18.yml
@@ -29,6 +29,7 @@ xPathScrapers:
           - replace:
               - regex: (.+?)(?:,\sw\/.+)?(?:\s\(\d{4}\))?(?:\sPorn\sScene)?\s\|\sDATA18
                 with: $1
+      URLs: //div[@id='h1div']/h1/a/@href
       Date:
         selector: //span[b[text()="Release date"]]
         postProcess:
@@ -59,7 +60,7 @@ xPathScrapers:
             - replace:
                 - regex: (.+?)(?:(?:\s#1)?$|(\s)#(\d+))
                   with: $1$2$3
-        URL: $movie/@href
+        URLs: $movie/@href
       Image: //img[@id="playpriimage"]/@src
   movieScraper:
     common:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://www.data18.com/scenes/1177974
- https://www.data18.com/scenes/1346004-good-vibes-only

## Short description

I added URL extraction for the scene if someone ever writes a sceneByName search. More important, I updated the URL node for Group extraction to actually extract the URL.
