### PR TITLE
fix: ScrapeWithURL crash on invalid result

### DIFF
--- a/scrapers/ScrapeWithURL/ScrapeWithURL.py
+++ b/scrapers/ScrapeWithURL/ScrapeWithURL.py
@@ -83,8 +83,8 @@ for url in urls:
             result = scrape_scene(url)
             result = filter_nones(result)
             log.debug(f"result {result}")
-            print(json.dumps(result))
             if result:
+                print(json.dumps(result))
                 break
         except Exception:
             continue

--- a/scrapers/ScrapeWithURL/ScrapeWithURL.yml
+++ b/scrapers/ScrapeWithURL/ScrapeWithURL.yml
@@ -6,4 +6,4 @@ sceneByFragment:
   script:
     - python
     - ScrapeWithURL.py
-# Last Updated October 19, 2025
+# Last Updated November 23, 2025


### PR DESCRIPTION
## Short description

Fixes an issue where ScrapeWithURL would crash and hang up the scraping process whenever one of the many urls did not return a valid result. Resolved by only printing the results when it's not None.
