### PR TITLE
[pmvhaven.com] fix: fix error due to spacing issue

### DIFF
--- a/scrapers/PMVHaven/PMVHaven.py
+++ b/scrapers/PMVHaven/PMVHaven.py
@@ -96,14 +96,14 @@ def getVideoById(sceneId):
 
 
 def sceneByFragment(params):
-   """
+    """
     Assumes the video ID or the download hash is in the title or file name of the 
     Stash scene. The default file name when downloading from PMVHaven includes the 
     download hash, so this will first assume the parameter is the download hash. If no 
     results are returned then it will assume the parameter is the video ID and attempt 
     data fetch.
     """
-    
+
     fileName = dig(params, "files", 0, "path")
 
     if not (title := dig(params, "title")):


### PR DESCRIPTION
## Short description

Simply adjusts an indenting and whitespace issue with this script. Fixes an issue where scrapes would always fail with the message `scraper PMVHaven: could not unmarshal json from script output: EOF`. All scrapes are now healthy.

## Test plan

Confirmed the script now works for the given example link:
* https://pmvhaven.com/video/BTLA-vert-dress_68fcd5a62b8c34a0d3d8e74e
