### PR TITLE
Scrape NSFW cover from Karups

### DIFF
--- a/scrapers/Karups.yml
+++ b/scrapers/Karups.yml
@@ -35,6 +35,10 @@ xPathScrapers:
         selector: //div[@class="content-information-description"]/p/text()
       Image: &image
         selector: //video[@id="player"]/@poster|//div[@class="video-poster"]/img/@src
+        postProcess:
+          - replace:
+              - regex: \/thumbs_pg\/
+                with: /thumbs/
 
   galleryScraper:
     gallery:
@@ -52,4 +56,4 @@ driver:
           Domain: "www.karups.com"
           Value: "true"
           Path: "/"
-# Last Updated March 28, 2024
+# Last Updated November 28, 2025


### PR DESCRIPTION
Scrape NSFW cover instead of the SFW cover which might be just awfully censored.
NSFW covers are used on the members page and for example Indexxx/theNude also uses them.

Examples:
https://www.karups.com/video/dirty-milf-pov-59305.html
https://media.karups.com/thumbs_pg/060000/059305-feat_lg.jpg
->
https://media.karups.com/thumbs/060000/059305-feat_lg.jpg

https://www.karups.com/video/sleep-tight-59256.html
https://media.karups.com/thumbs_pg/060000/059256-feat_lg.jpg
->
https://media.karups.com/thumbs/060000/059256-feat_lg.jpg