### PR TITLE
Added SearchByURL to JAVDatabase and replaced reference to 404 scraper

### DIFF
--- a/scrapers/JavDatabase.yml
+++ b/scrapers/JavDatabase.yml
@@ -42,7 +42,7 @@ xPathScrapers:
     common:
       $infobox: //div[@class="movietable"]/div[@class="row"][1]
     group:
-      Name: *title
+      Name: //h1
       Synopsis: $infobox/div[2]/p[1]/text()
       Date:
         selector: $infobox//p[b[contains(.,'Release Date:')]]/text()
@@ -74,14 +74,14 @@ xPathScrapers:
           - replace:
               - regex: '^\s+|\s+$'
                 with: ''
-      Director: *director
-      FrontImage: *image
+      Director: //td[contains(.,'Director:')]/following-sibling::td
+      FrontImage: //meta[@property='og:image']/@content
       Studio:
         Name:
           selector: $infobox//p[b[contains(.,'Studio:')]]//a/text()
         URL:
           selector: $infobox//p[b[contains(.,'Studio:')]]//a/@href
-      URL: *url
+      URLs: //div[h2[contains(.,'/Idols')]]//a/@href
 
   performerScraper:
     common:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [X] sceneByName
- [X] sceneByQueryFragment
- [ ] sceneByFragment
- [/] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

## Short description

Added sceneByName so user can enter a JAV Code to search with manually if the parser fails to detect a proper JAV Code in the filename. Modified sceneByURL to make this functionality possible, as the majority of this scraper's function is constructing the URL from a JAV Code due to the simplistic structure of URL's for this website. This process requires sceneByName, sceneByQueryFragment, and sceneByURL. The first two of which were written by myself, and the last which just needed a scraper reference changed.