### PR TITLE
AyloAPI: add proxy option

### DIFF
--- a/scrapers/AyloAPI/scrape.py
+++ b/scrapers/AyloAPI/scrape.py
@@ -157,6 +157,9 @@ def __api_request(url: str, headers: dict) -> dict | None:
         with open("api_response.json", "w", encoding="utf-8") as f:
             json.dump(api_response, f, indent=2)
 
+    if "result" not in api_response:
+        log.error(f"Invalid API response: {json.dumps(api_response, indent=None)}")
+        return None
     return api_response["result"]
 
 


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByName
- [x] performerByFragment
- [x] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [x] galleryByFragment
- [x] galleryByURL

## Examples to test

### performerByURL

- https://www.transangels.com/model/454541/andylynn-payne
- https://www.brazzersnetwork.com/pornstar/478611/gatita-veve/

### sceneByURL

- https://www.brazzers.com/video/11264861/helping-hands
- https://www.realitykings.com/scene/9824321/fucking-my-cameraman

### groupByURL

- https://www.transsensual.com/movie/11435461/salacious-ts-encounters-3

## Short description

Aylo API has been geo-blocked for age verification in the UK, and possibly other regions, since at least as far back as 3rd Oct 2025.

From Discord:

> Ronnie711 — 03/10/2025 19:03
Can confirm that aylo have changed the rules again … API has been geoblocked in the UK for the past week

This change allows a user to add their own `config.ini` to their `AyloAPI` scraper directory, with the `https_proxy` option populated, e.g. I have it like this:

```ini
# User Agent to use for the requests
user_agent = Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0

# Scrape markers when using 'Scrape with...'
scrape_markers = False

# Minimum similarity ratio to consider a match when searching
minimum_similarity = 0.75

# Debug mode will save the latest API response to disk
debug = True

# Proxy option to allow user configuring proxy with VPN to bypass geo-restrictions, e.g.
# https_proxy = http://localhost:8888
https_proxy = http://gluetun:8888
```

This is because I have a `gluetun` container running in the same Docker stack that provides a VPN-configured proxy to the headless Chrome container that is used as the CDP client (unrelated to this change, just giving some context).

With this `config.ini` file in place with the above content, the AyloAPI-dependent scrapers make use of my gluetun-provided proxy connection (with VPN configured) and the API response is no longer a 403 with age/geo restriction error blurb.