### PR TITLE
Update GEVI.py to ignore "none available" in notes field.

### DIFF
--- a/scrapers/GEVI/GEVI.py
+++ b/scrapers/GEVI/GEVI.py
@@ -186,7 +186,8 @@ def performer_from_url(url: str) -> ScrapedPerformer | None:
         performer["death_date"] = f"{death_year[-4:]}-01-01"
 
     if (bio := soup.find("div", string="Notes:")) and (bio := bio.find_next("div")):
-        performer["details"] = bio.get_text(separator="\n")
+    	if bio.get_text(separator="\n") != "none available":
+        	performer["details"] = bio.get_text(separator="\n")
 
     if aliases := soup.find_all("h2"):
         if config.disambiguate_aliases:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Examples to test

List a few links/titles/names/filenames/codes to test
https://gayeroticvideoindex.com/performer/141367  # Performer with "none available"
https://gayeroticvideoindex.com/performer/31139   # Performer with text in notes field

## Short description

Update Scraper to ignore "none available" in the Notes field so it isn't imported to Performer Details.
