### PR TITLE
Fix TMDB scraper date format to use ISO 8601 standard

### DIFF
--- a/scrapers/TMDB.yml
+++ b/scrapers/TMDB.yml
@@ -34,7 +34,7 @@ xPathScrapers:
           - replace:
               - regex: \(.*$
                 with:
-          - parseDate: 02/01/2006
+          - parseDate: 2006-01-02
       Synopsis: &details //div[@class='header_info']/div[@class='overview']/p
       URL: //meta[@name='og:url']/@content
       FrontImage: &image


### PR DESCRIPTION
Fix date format to resolve Stash error: "date must be in YYYY-MM-DD form"

Update parseDate format in TMDB scraper from US format (02/01/2006) to ISO 8601 standard (2006-01-02). This fixes the Stash validation error that requires dates in YYYY-MM-DD format.

The change affects all date fields in both movieScraper and sceneScraper through the &date anchor reference.

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test
- https://www.themoviedb.org/movie/550-fight-club
- https://www.themoviedb.org/movie/13-forrest-gump
- https://www.themoviedb.org/movie/278-the-shawshank-redemption

## Short description
Fixed parseDate format to output YYYY-MM-DD dates, resolving Stash validation error. Changed from 02/01/2006 (MM/DD/YYYY) to 2006-01-02 (YYYY-MM-DD) format.
