### PR TITLE
Update LadyboyGold.yml

### DIFF
--- a/scrapers/LadyboyGold/LadyboyGold.yml
+++ b/scrapers/LadyboyGold/LadyboyGold.yml
@@ -1,6 +1,15 @@
 # yaml-language-server: $schema=../../validator/scraper.schema.json
 name: LadyboyGold (Network)
 performerByURL:
+  # 1) MEMBERS-ONLY URLs → use ladyboygold.py
+  - action: script
+    url:
+      - members.ladyboygold.com
+    script:
+      - python
+      - ladyboygold.py
+      - performer-by-url
+  # 2) PUBLIC URLs → default to scrapeXPath
   - action: scrapeXPath
     url:
       - ladyboygold.com/index.php
@@ -10,6 +19,15 @@ performerByURL:
       - tsraw.com/model/
     scraper: performerScraperTSRaw
 sceneByURL:
+  # 1) MEMBERS-ONLY URLs → use ladyboygold.py
+  - action: script
+    url:
+      - members.ladyboygold.com
+    script:
+      - python
+      - ladyboygold.py
+      - scene-by-url
+  # 2) PUBLIC URLs → default to scrapeXPath
   - action: scrapeXPath
     url:
       - ladyboygold.com/tour
@@ -208,4 +226,4 @@ xPathScrapers:
 
 driver:
   useCDP: true
-# Last Updated December 1, 2025
+# Last Updated December 7, 2025


### PR DESCRIPTION
Added catches for ladyboygold members pages to use separate python script designed to be used on members pages for scene and performer info by URL only.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [X ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test
https://members.ladyboygold.com/show_video.php?galid=23403&section=1418&tpl=show_video8
https://members.ladyboygold.com/index.php?&section=1516&actorid=2229

## Short description

Added catches for ladyboygold members pages to use separate python script designed to be used on members pages for scene and performer info by URL only.
