### PR TITLE
feat(py_common): add conversion functions for feet to cm and lb to kg

### DIFF
--- a/scrapers/py_common/util.py
+++ b/scrapers/py_common/util.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Iterable, Mapping, TypeVar
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 import json
+import re
 import sys
 
 
@@ -117,6 +118,75 @@ def replace_at(obj: dict, *path: str, replacement: Callable[[T], T]) -> dict:
                 return d
 
     return inner(obj, *path)  # type: ignore
+
+
+def feet_to_cm(value: str) -> str:
+    """
+    Converts a string representing height (feet and inches) to centimeters.
+
+    Examples handled:
+    - "5'7\"" -> "170"
+    - "5ft 7in" -> "170"
+    - "6'" -> "183"
+
+    :param value: The string to parse
+    :return: The height in cm as a string, rounded to the nearest integer.
+             Returns empty string if input is empty or if no numbers found.
+    """
+    if not value:
+        return ""
+
+    FOOT_IN_CM = 30.48
+    INCH_IN_CM = 2.54
+
+    filtered = re.findall(r"\d+", value)
+
+    if len(filtered) == 0:
+        return ""
+
+    feet = 0.0
+    inches = 0.0
+
+    if len(filtered) > 0:
+        feet = float(filtered[0])
+    if len(filtered) > 1:
+        inches = float(filtered[1])
+
+    length = feet * FOOT_IN_CM + inches * INCH_IN_CM
+    return str(round(length))
+
+
+def lb_to_kg(value: str) -> str:
+    """
+    Converts a string representing weight (pounds) to kilograms.
+
+    Examples handled:
+    - "120 lbs" -> "54"
+    - "130.5" -> "59"
+    - "Weight: 115 lbs" -> "52"
+
+    :param value: The string to parse
+    :return: The weight in kg as a string, rounded to the nearest integer.
+             Returns empty string if input is empty or on failure.
+    """
+    if not value:
+        return ""
+
+    LB_IN_KG = 0.45359237
+
+    try:
+        # Try direct conversion first (fastest)
+        weight = float(value)
+    except ValueError:
+        # Try extracting the first float number found in the string
+        match = re.search(r"(\d+(\.\d+)?)", value)
+        if match:
+            weight = float(match.group(1))
+        else:
+            return ""
+
+    weight *= LB_IN_KG
+    return str(round(weight))
 
 
 def is_valid_url(url):


### PR DESCRIPTION
This PR extends `py_common.util` to include common conversion functions for post-processing:

- feet_to_cm
- lb_to_kg

Follows same calculations as built-in FeetToCm and LbToKg post-processing functions for consistency: https://github.com/stashapp/stash/blob/b23c3cd61872e29590a617b72695efe3bf63fd4c/pkg/scraper/mapped.go#L590-L623