### PR TITLE
feat(AlgoliaAPI): add endowment parsing and unit conversion

### DIFF
--- a/scrapers/AlgoliaAPI/AlgoliaAPI.py
+++ b/scrapers/AlgoliaAPI/AlgoliaAPI.py
@@ -173,15 +173,6 @@ def scene_url(site: str, sitename: str, url_title: str, clip_id: str) -> str:
     "Generates URL for a scene"
     return f"{homepage_url(site.lower())}/en/video/{sitename.lower()}/{url_title}/{clip_id}"
 
-def parse_endowment(performer_from_api: dict[str, Any], gender: str | None) -> dict[str, Any] | None:
-    "Parses penis length if gender is male"
-    if (
-        gender == "male"
-        and (endowment := dig(performer_from_api, "attributes", "endowment"))
-    ):
-        return {"penis_length": feet_to_cm("0'" + endowment.strip())}
-    return None
-
 def to_scraped_performer(performer_from_api: dict[str, Any], site: str) -> ScrapedPerformer:
     "Helper function to convert from Algolia's API to Stash's scraper return type"
     performer: ScrapedPerformer = {}
@@ -203,8 +194,8 @@ def to_scraped_performer(performer_from_api: dict[str, Any], site: str) -> Scrap
         performer["height"] = feet_to_cm(height.strip())
     if weight := dig(performer_from_api, "attributes", "weight"):
         performer["weight"] = lb_to_kg(weight.strip())
-    if endowment := parse_endowment(performer_from_api, performer.get("gender")):
-        performer.update(endowment)
+    if endowment := dig(performer_from_api, "attributes", "endowment"):
+        performer["penis_length"] = feet_to_cm("0'" + endowment.strip())
     if home := dig(performer_from_api, "attributes", "home"):
         performer["country"] = guess_nationality(home.strip())
     if performer_from_api.get("has_pictures") and (pictures := performer_from_api.get("pictures")):


### PR DESCRIPTION
This PR adds endowment field parsing and unit conversion for performer height/weight into `AlgoliaAPI`.

I'm not sure if some sites that use this already have metric values for height/weight or if endowment is limited to `penis_size` or if it is used differently for females so additional input is welcome.

I tried spot checking with some of the scrapers that used this but all the performers I tried to test had no weight/height/endowment values - needs additional testing.

The only site i managed to test is `chaosmen.com` where it functions as expected.