### PR TITLE
AmateurAllure: fix date and image scraping

### DIFF
--- a/scrapers/AmateurAllure.yml
+++ b/scrapers/AmateurAllure.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: AmateurAllure
 galleryByURL:
   - action: scrapeXPath
@@ -28,6 +29,10 @@ xPathScrapers:
       Date: &dateAttr
         selector: //div[@class="backgroundcolor_info"]//div[@class='cell update_date']
         postProcess:
+          # pages have the date in "Added: MM/DD/YYYY" format, e.g. "Added: 08/29/2025"
+          - replace:
+              - regex: "Added:"
+                with: ""
           - parseDate: 01/02/2006
       Details: &detailsSel //span[@class='update_description']
       Tags: &tagsAttr
@@ -58,14 +63,22 @@ xPathScrapers:
               - regex: ^([^|]+)\|(.+)
                 with: "${1}/search.php?st=advanced&qall=&qany=&qex=$2"
           - subScraper:
-              selector: //div[@id="logo"]//a/@href | //img/@srcset
+              selector: //div[@id="logo"]//a/@href | //img/@srcset | //img/@src0_1x
               concat: "|"
               postProcess:
                 - replace:
+                    # errant double slash
+                    - regex: content//
+                      with: content/
+                    # regex for srcset entries to get the highest resolution image
                     - regex: ^([^|]+amateurallure[^|]+)\|.+(/content/contentthumbs/\d+/\d+/[^/]+\.jpg) 1920w
                       with: $1$2
-                    - regex: "[124]x"
-                      with: "full"
+                    # regex for src0_1x entries
+                    - regex: ^([^|]+amateurallure[^|]+)\|.+(/content/contentthumbs/\d+/\d+/[^/]+\.jpg)
+                      with: $1$2
+                    # to get the full size image, but this can be portrait so not always ideal for a scene image
+                    # - regex: "[124]x"
+                    #   with: "full"
       Studio: *studioAttr
   amateurAllureClassics:
     common:
@@ -103,4 +116,4 @@ xPathScrapers:
       Tags: *classicTags
       Studio: *classicStudio
       Image: //meta[@property="og:image"]/@content
-# Last Updated September 27, 2024
+# Last Updated December 22, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.amateurallure.com/tour/scenes/Amateur-Allure-Introduces-Isa-Bella-Gorgeous-Server-Loves-Sucking-Fucking-and-Swallowing_vids.html
- https://www.amateurallure.com/tour/scenes/Sexy-Barista-Scarlette-Moon-Looks-to-Whip-Up-Some-Desires_vids.html
- https://www.amateurallure.com/tour/scenes/Pre-Auditions-13-Lola-Foxx-Anikka-Albrite-Trinity-St-Clair-Adelyn-Rose-and-Kaci-Starr-Give-Head_vids.html

## Short description

The date and image scraping was not working in at least some scenes. This fixes that.
