### PR TITLE
Update PMVHaven Video ID regex

### DIFF
--- a/scrapers/PMVHaven/PMVHaven.yml
+++ b/scrapers/PMVHaven/PMVHaven.yml
@@ -6,7 +6,7 @@ sceneByURL:
     queryURL: https://pmvhaven.com/api/videos/{url}
     queryURLReplace:
       url:
-        - regex: .*([a-z0-9]{24}).*
+        - regex: .*([a-f0-9]{24}).*
           with: $1
     scraper: sceneScraper
 sceneByFragment:
@@ -14,7 +14,7 @@ sceneByFragment:
   queryURL: https://pmvhaven.com/api/videos/{filename}
   queryURLReplace:
     filename:
-      - regex: .*([a-z0-9]{24}).*
+      - regex: .*([a-f0-9]{24}).*
         with: $1
   scraper: sceneScraper
 


### PR DESCRIPTION
Whenever you access a video by it's `_id` (the 24-char hex string in the video's name, file name, and/or URL), the 24-char string always matches `[a-f0-9]{24}` (not `[a-z0-9]{24}`). The old regex still works, but this one is more precise, and will likely work to omit some false positives.

I validated this by doing a scripted check of all the videos available on PMVHaven's API (basically, paginated my way thru the entire possible publicly available catalogue using the [/api/videos](https://pmvhaven.com/api-docs#videos) endpoint). Every single video returned from this check had a `_id` field that matched `^[a-f0-9]{24}$`.

Off topic for this PR, but the `/api/videos/:id` endpoint accepts [3 possible inputs](https://pmvhaven.com/api-docs#videos), as per their API docs:

> Get detailed information about a specific video. The id can be the video's _id, oldId (legacy PMVHaven ID for migrated videos), or key.

The `_id` field refers to the freshly-created (as of the new PMVHaven update circa November/December 2025?) video ID, the `_oldId` field is sometimes present on videos returned from the `/api/videos` endpoint (and it refers to the value of the `_id` field for this video, prior to the migration-- all videos got new `_id` fields after the migration, although the `_oldId` seems to be interchangeable with the migrated `_id` field for backwards compatibility I guess).

The `key` field is also present in all videos. The value present in that field varies between "new" (created after the migration) and "old" (created before the migration) videos.

For new videos, the value of the `key` field seems to be the URL path to the video (relative to `pmvhaven.com`, e.g. a recently created video has the value `videos/pmvcade_-_PMVcades_House_Party_1767794830481_ldct9mwr.mp4`, which can be prefixed w/ the `pmvhaven.com` domain to get a direct link to the video file itself).

For old videos, the value of the `key` field seems to be an older internal hex string (identical in format to the migrated `_id` field, `[a-f0-9]{24}`). I think before the migration, when downloading files from PMVHaven, they would be saved like `<title>_<key>.mp4`, where `<key>` back then would have been the `[a-f0-9]{24}` string.

I'm not sure if it's possible, but it could be nice UX to make the scraper try all the matching hex strings within a given Scene's title, filenames, and/or URLs (simple enough to extract). That way, if one match leads to an invalid / old / stale result, it's possible another match could lead to the correct one.
