### PR TITLE
FuckPassVR: improve description post-processing

### DIFF
--- a/scrapers/FuckPassVR.yml
+++ b/scrapers/FuckPassVR.yml
@@ -45,6 +45,7 @@ xPathScrapers:
       Image: //div[@class="pornstar"]/img/@src
       Gender:
         fixed: Female
+      URLs: //div[@class="pornstar__wrapper"]//div[contains(@class, "shareBtn__shareElement--copy")]/@data-url
     scene:
       Title: //h1[@class='video__title']
       Details:


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByName
- [x] sceneByURL

## Examples to test

### performerByName

- Ava Amira
- Amira
- Cami
- Cami Strella
- Strella

of note, "Ava" does not return any scene (and therefore performer) results, so perhaps there is a 4 character string minimum for the scene search.

### sceneByURL

- https://www.fuckpassvr.com/video/a-tropical-release
- https://www.fuckpassvr.com/video/the-calm-before-the-come
- https://www.fuckpassvr.com/video/rave-misbehave

## Short description

Currently the pseudo headings in the scene description (typically in p and strong tags) do not have a newline added in the postprocessing so it runs on to the following paragraph without any whitespace.

This adds a newline to make the plain text post-processed version match the layout as seen on the page.

If there are HTML entities in the description, these are now unescaped/decoded (if they are in the simple map).
