### PR TITLE
GroobyNetwork-Partial add dynamically set poster image scraping

### DIFF
--- a/scrapers/GroobyNetwork-Partial.yml
+++ b/scrapers/GroobyNetwork-Partial.yml
@@ -329,6 +329,4 @@ xPathScrapers:
           postProcess:
             - map:
                 Tags for This Scene: Virtual Reality
-debug:
-  printHTML: true
 # Last Updated December 9, 2025


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.groobygirls.com/tour/trailers/Julia-Janes-Private-Show.html

## Short description

Some scenes have the cover image dynamically set in an embedded script (like some existing sites already in the same scraper). This adds the selector and post-processing to make it work for groobygirls.com and any other site in this scraper.
