### PR TITLE
[JAVlibrary] Fixes for site updates

### DIFF
--- a/scrapers/JavLibrary_python/JavLibrary_python.yml
+++ b/scrapers/JavLibrary_python/JavLibrary_python.yml
@@ -23,8 +23,10 @@ sceneByURL:
     url:
       - www.javlibrary.com/
       - javlibrary.com/
+      - www.javlib.com/
+      - javlib.com/
     script:
       - python
       - JavLibrary_python.py
       - validSearch
-# Last Updated March 4, 2025
+# Last Updated January 24, 2026


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test:

URL: https://www.javlibrary.com/en/javme3jdza.html
ID: WAAA-611 or WAAA for multiple results

## Short description

- Fixed URL matching due to site changes (./v= -> /jav#). 
- Fixed single search result matches which now redirect to video page automatically. 
- Removed label definition as it's not used in Stash resulting in log warning. 
- Added retry support to try again in case of Cloudflare delays.
