### PR TITLE
Fix r18.dev scraper not matching studio

### DIFF
--- a/scrapers/R18.dev.yml
+++ b/scrapers/R18.dev.yml
@@ -407,7 +407,7 @@ jsonScrapers:
           selector: maker.name
           postProcess:
             - replace:
-                - regex: ^\s*|\s*$
+                - regex: ^\s+|\s+$
                   with: ""
       Performers:
         Name: actresses.#.name


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x] sceneByFragment

## Examples to test

- https://r18.dev/videos/vod/movies/detail/-/combined=bbss00057/json
- https://r18.dev/videos/vod/movies/detail/-/combined=bbss00058/json

## Short description

Sometimes studio name contains a newline at the end, which prevents studio from matching. This fixes the issue by stripping white space from the beginning and end of the studio name.

Processing scene studio:
Replace: '^\\s*|\\s*$' with ''"
Before: bibian\n
After: bibian
[0][Name] = bibian
