### PR TITLE
PlayboyPlus: add performer search by name, fix image URL, add members URL, strip HTML from descriptions, fix empty studio

### DIFF
--- a/scrapers/PlayboyPlus/PlayboyPlus.yml
+++ b/scrapers/PlayboyPlus/PlayboyPlus.yml
@@ -15,6 +15,12 @@ sceneByURL:
       - python
       - PlayboyPlus.py
       - scene-by-url
+performerByName:
+  action: script
+  script:
+    - python
+    - PlayboyPlus.py
+    - performer-by-name
 performerByURL:
   - action: script
     url:


### PR DESCRIPTION
- [x]  performerByName
- [x]  performerByURL
- [x]  galleryByURL
- [x]  sceneByURL

### Examples to test:
- Performer search: "Amanda Vann"
- Performer by URL: https://www.playboyplus.com/en/model/view/Amanda-Vann/119103
- Gallery by URL: https://www.playboyplus.com/en/update/Playmate-Miss-March-2013-Exclusive---Ashley-Doris/135834
- Scene by URL: https://www.playboyplus.com/en/update/Girls-Just-Wanna-Have-Fun/141924


### Short description:
- Added performerByName support to search performers by name via the Algolia API
- Fixed performer image URLs (PB+ uses the /media/ CDN path, not /actors/)
- Added members.playboyplus.com as a second URL alongside www.playboyplus.com for performers
- Added clean_description() to strip HTML tags from description fields, which the API returns inconsistently
- Fixed gallery and scene studio fields silently failing when the API returns an empty string for studio_name