### PR TITLE
Babepedia: fix performer-by-name URL encoding

### DIFF
--- a/scrapers/Babepedia/Babepedia.py
+++ b/scrapers/Babepedia/Babepedia.py
@@ -204,11 +204,11 @@ def map_performer_search(performer) -> PerformerSearchResult:
     return result
 
 def performer_by_name(name) -> list[PerformerSearchResult]:
-    url = f"https://www.babepedia.com/ajax-search.php?term={name}"
-    scraped = scraper.get(url)
+    search_term = name.replace('-', ' ')
+    scraped = scraper.get("https://www.babepedia.com/ajax-search.php", params={"term": search_term})
     scraped.raise_for_status()
     data = scraped.json()
-    return list(map(map_performer_search,data))
+    return list(map(map_performer_search, data))
 
 if __name__ == "__main__":
     op, args = scraper_args()


### PR DESCRIPTION

## Scraper type(s)
- [x] performerByName


## What changed:
 `performer_by_name` now uses `params=` to properly URL-encode the search term, and truncates to the first word of the name since the Babepedia API only matches reliably on the start of the name.

## Test:
 Search for `Jessica-Jane Clement` — previously returned `[]`, now returns the correct result.

## Known limitation:
 Hyphenated first names like `Marie-Claude Bourbonnais` may return incomplete or incorrect results due to a Babepedia API limitation outside our control. `performer-by-url` works correctly for these performers.
