### PR TITLE
BrandNewAmateurs: restrict URL scope to /trailers/ pages

### DIFF
--- a/scrapers/BrandNewAmateurs.yml
+++ b/scrapers/BrandNewAmateurs.yml
@@ -2,7 +2,7 @@ name: "Brand New Amateurs"
 sceneByURL:
   - action: scrapeXPath
     url:
-      - brandnewamateurs.com
+      - brandnewamateurs.com/trailers/
     scraper: sceneScraper
 xPathScrapers:
   sceneScraper:


### PR DESCRIPTION
## Scraper type(s)

- [x] sceneByURL


## Examples to test

- https://brandnewamateurs.com/trailers/Z91.html
- https://brandnewamateurs.com/scenes/Z91_vids.html

## Short description


The scraper currently matches all `brandnewamateurs.com` URLs, including `/scenes/` paths which are members-area pages with different HTML structure. This causes XPath errors when users attempt to scrape those URLs.

Restricted the URL match to `brandnewamateurs.com/trailers/` so the scraper only fires on public pages it can actually parse.
