### PR TITLE
add affect3dstore.com

### DIFF
--- a/scrapers/Affect3DStore.yml
+++ b/scrapers/Affect3DStore.yml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+name: Affect3DStore
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - affect3dstore.com
+    scraper: affect3DStore
+xPathScrapers:
+  affect3DStore:
+    scene:
+      Title: //h1/span
+      Details:
+        selector: //div[contains(@class, "info-details-xl")]//div[contains(@class, "description")]/descendant::text()
+        concat: "\n\n"
+      Studio:
+        Name: //div[@class="box-inner1"]//span[@class="artist_name_m"]//a/text()
+      Tags:
+        Name: //div[contains(@class, "info-details-xl")]//table[contains(@class, "additional-attributes")]//td[not(@data-th="Artist/Circle")]/a/text()
+      Image: //img[@alt="main product photo"]/@src
+# Last Updated April 22, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://affect3dstore.com/diner-for-three.html
- https://affect3dstore.com/lewd-box-episode-1
- https://affect3dstore.com/raw-footage
- https://affect3dstore.com/corporate-training-2
- https://affect3dstore.com/officer-on-dick-volume-1

## Short description

This adds the affect3dstore.com site. This is a storefront for multiple artists/studios, so it is more like a network site than a single studio. I therefore scraped the artist name as the studio rather than just using a fixed "Affect3D".
