### PR TITLE
XVideos: Support the JDownloader filename pattern

### DIFF
--- a/scrapers/Xvideos.yml
+++ b/scrapers/Xvideos.yml
@@ -18,6 +18,10 @@ sceneByFragment:
       # title_of_scene [id-here].mp4
       - regex: '.*\[([0-9a-zA-Z]{4,})\]\..+'
         with: $1
+      # expect an ID at the beginning followed by an underscore, as saved by
+      # JDownloader by default
+      - regex: '^([0-9a-zA-Z]{4,})_.+'
+        with: $1
       # or expects a numeric id at the end of the filename
       # title_of_scene42069.mp4
       - regex: '^.*?(\d+)\..+$'


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

kvllkkf5aa2_Redhead Angelina Blue. Part 2. Her second lesson, following her Master instruction to masturbate in her tight ropes..mp4
uufkfuc6ba0_Beautiful student has to take her exam.,but she is in trouble, when she is cheating on her exam. Part 1. Her teacher humiliates her, punishes her..mp4

## Short description

JDownloader puts the code at the beginning, at least by default, so this PR checks for that in addition to the previously accepted patterns.