### PR TITLE
Omits the period separator in the scraper url for old style urls with…

### DIFF
--- a/scrapers/Xvideos.yml
+++ b/scrapers/Xvideos.yml
@@ -11,7 +11,7 @@ sceneByURL:
 sceneByFragment:
   action: scrapeXPath
   scraper: sceneScraper
-  queryURL: https://www.xvideos.com/video.{filename}/x
+  queryURL: https://www.xvideos.com/video{filename}/x
   queryURLReplace:
     filename:
       # xvideos id is of format [a-z0-9]{6,11} (6ch from 2007, 11ch from 2026)
@@ -20,7 +20,7 @@ sceneByFragment:
       # expects an id in square brackets before extension, as saved by yt-dlp by default
       # title_of_scene [id-here].mp4
       - regex: '.*\[([a-z0-9]{6,11})\]\..+'
-        with: $1
+        with: ".$1"
       # expect an ID at the beginning followed by an underscore, as saved by
       # JDownloader by default
       - regex: '^([a-z0-9]{6,11})_.+'
@@ -29,11 +29,11 @@ sceneByFragment:
       # or expects a numeric id at the end of the filename
       # title_of_scene42069.mp4
       # - regex: '^.*?(\d{7})\..+$'
-      #   with: $1
+      #   with: ".$1"
       # if no id is found in the filename (there is still a file extension)
       # clear the filename so that it doesn't leak
       - regex: .*\.[^\.]+$
-        with:
+        with: "."
 
 xPathScrapers:
   sceneScraper:
@@ -64,4 +64,4 @@ xPathScrapers:
               - regex: '[\S\s]+"uploadDate"\s*:\s*"(\d+-\d{2}-\d{2})[^"]+"[\S\s]+'
                 with: $1
           - parseDate: 2006-01-02
-# Last Updated August 15, 2024
+# Last Updated April 24, 2026


### PR DESCRIPTION
… numeric ids.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

## Short description

Describe the general changes
