### PR TITLE
Fix SexLikeReal scraper to find studio name

### DIFF
--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -70,7 +70,7 @@ xPathScrapers:
         Name: //a[starts-with(@href,"/pornstars/")]/text()
       Studio:
         Name:
-          selector: //h3/a[starts-with(@href,"/studios/")]/text()
+          selector: //h2/a[starts-with(@href,"/studios/")]/text()
           postProcess:
             - map:
                 DDFNetworkVR: DDF Network VR
@@ -113,4 +113,4 @@ xPathScrapers:
 #           Domain: .www.sexlikereal.com
 #           Path: /
 #           Value: "true"
-# Last Updated December 27, 2025
+# Last Updated May 5, 2026


### PR DESCRIPTION
I guess they changed an h3 to an h2.

Checked against https://www.sexlikereal.com/scenes/pmv-sit-get-fcked-sitting-cowgirls-compilation-85687

Also verified that the other selectors that include `h3`s still work as-is.