### PR TITLE
Xvideos: harden fragment ID extraction and fallback

### DIFF
--- a/scrapers/Xvideos.yml
+++ b/scrapers/Xvideos.yml
@@ -21,18 +21,22 @@ sceneByFragment:
       # title_of_scene [id-here].mp4
       - regex: '.*\[([a-z0-9]{6,11})\]\..+'
         with: ".$1"
+      # expect a numeric ID at the beginning followed by an underscore, as saved by
+      # an older version of JDownloader by default
+      - regex: "^([0-9]{6,11})_.+"
+        with: $1
       # expect an ID at the beginning followed by an underscore, as saved by
       # JDownloader by default
-      - regex: '^([a-z0-9]{6,11})_.+'
-        with: $1
+      - regex: "^([a-z0-9]{6,11})_.+"
+        with: ".$1"
       # removed since it doesnt work with video. format
       # or expects a numeric id at the end of the filename
       # title_of_scene42069.mp4
       # - regex: '^.*?(\d{7})\..+$'
       #   with: ".$1"
       # if no id is found in the filename (there is still a file extension)
-      # clear the filename so that it doesn't leak
-      - regex: .*\.[^\.]+$
+      # only clear likely file extensions (1-5 chars), not ".<id>"
+      - regex: '(?i).*\.[a-z0-9]{1,5}$'
         with: "."
 
 xPathScrapers:
@@ -64,4 +68,4 @@ xPathScrapers:
               - regex: '[\S\s]+"uploadDate"\s*:\s*"(\d+-\d{2}-\d{2})[^"]+"[\S\s]+'
                 with: $1
           - parseDate: 2006-01-02
-# Last Updated April 24, 2026
+# Last Updated May 6, 2026


### PR DESCRIPTION
Changes:

- Add numeric-leading JDownloader filename rule: ^([0-9]{6,11})_.+ -> $1.
- Keep alphanumeric-leading rule separate and dot-prefixed: ^([a-z0-9]{6,11})_.+ -> .$1.
- Preserve yt-dlp bracketed ID rule with dot-prefixed replacement.
- Tighten fallback extension cleanup to probable extensions only: (?i).*\.[a-z0-9]{1,5}$ -> .
- Update scraper timestamp comment to May 6, 2026.

Risks / assumptions:

- ID lower bound remains 6 for compatibility with existing plugin behavior.
- Numeric and alphanumeric collision handling depends on rule order (numeric rule intentionally first).
- Unknown filename formats that miss all ID rules still fall back to video./x behavior (pre-existing).
- If very short dot-suffix IDs (<=5) exist in the future, fallback may treat them as extensions.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

30107781_culona en el gym perfecta.mp4
24205607_culo gym.mp4
uukvteb9147_Young Fashion Model Turned Humiliated Bondage Slave.mp4


## Short description

Describe the general changes
