### PR TITLE
Declare 'value_parts' variable before referencing it

### DIFF
--- a/scrapers/EmbeddedMetadata/embedded-metadata.py
+++ b/scrapers/EmbeddedMetadata/embedded-metadata.py
@@ -225,6 +225,7 @@ def process_image(image_path: str):
 			for list_value in value:
 				value_parts.extend(list_value.split(','))
 		else:
+			value_parts = []
 			value_parts.extend(value.split(','))
 
 		for value_part in value_parts:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [X] imageByFragment
- [ ] imageByURL

## Examples to test

Any image with entries in any of the following EXIF tags: Exif.Image.XPKeywords, EXIF:XPKeywords, Iptc.Application2.Keywords, IPTC:Keywords

## Short description

Declaring 'value_parts' variable under both 'if' and 'else' to avoid 'else' referencing undeclared variable.

This can probably be more elegant, but I truly know very little about python so wanted to make as few changes as possible.
