### PR TITLE
Improve bang.com

### DIFF
--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
 name: Bang
 sceneByURL:
   - action: scrapeXPath
@@ -25,6 +26,12 @@ performerByURL:
       - bang.com/pornstar
       - bangpremium.com/pornstar
     scraper: performerScraper
+galleryByURL:
+  - action: scrapeXPath
+    url:
+      - bang.com/photos/
+      - bangpremium.com/photos/
+    scraper: sceneScraper
 xPathScrapers:
   sceneSearch:
     common:
@@ -44,24 +51,20 @@ xPathScrapers:
                 with: https://www.bang.com
   sceneScraper:
     common:
+      $escapedJson: //div[@data-live-name-value="Video:RelatedPhotos"]/@data-live-props-value
       $movie: //div[@data-controller="video-entry"]//a[contains(@href,"/dvd/")]//div[contains(@class,"name")]/span[1]
       $performer: //p[contains(@class,"capitalize") and contains(text(),"With:")]/a[contains(@href,"/pornstar/")]
+      $title: //meta[@property="og:title"]/@content
     scene:
-      Title: //meta[@property="og:title"]/@content
+      Title: $title
       Details: //meta[@name="description"]/@content
       Image:
         selector: //meta[@property="og:image"]/@content
-      Date:
-        selector: //p[contains(text(),"Date:")]/text()
-        postProcess:
-          - replace:
-              - regex: \w+:\s*(\w+\s)(\d+),(\s\d{4}).*
-                with: $1$2$3
-          - parseDate: Jan 2 2006
+      Date: //meta[@property="video:release_date"]/@content
       Tags:
         Name:
           selector: //a[@class="genres"]
-      Performers:
+      Performers: &performers
         Name: $performer
         URLs:
           selector: $performer/@href
@@ -69,7 +72,7 @@ xPathScrapers:
       Studio:
         Name:
           selector: //a[starts-with(@href, "/originals/")]/text()
-          postProcess:
+          postProcess: &studioReplace
             - replace:
                 - regex: ^yngr\.com$
                   with: "YNGR"
@@ -78,6 +81,51 @@ xPathScrapers:
         URL:
           selector: $movie/@href
           postProcess: *prependHost
+      Code:
+        selector: //meta[@property="og:video"]/@content
+        postProcess:
+          - replace:
+              - regex: .*/(\d+)/.*
+                with: $1
+    gallery:
+      Title: $title
+      Details: //meta[@name="twitter:description"]/@content
+      Date:
+        selector: $escapedJson
+        postProcess:
+          - replace:
+              - regex: .*releaseDate[^\d]*(\d{4}-\d{2}-\d{2}).*
+                with: $1
+      Performers: *performers
+      Tags:
+        Name:
+          selector: $escapedJson
+          postProcess:
+            - javascript: |
+                if (value?.length) {
+                  console.debug("Parsing tags from JSON");
+                  var tags = [];
+                  // replace HTMLescaped quotes and parse JSON
+                  var json = JSON.parse(value.replace(/&quot;/g, '"'));
+                  if (json?.relatedVideo?.genres?.length) {
+                    tags.push(...json.relatedVideo.genres);
+                  }
+                  if (json?.relatedVideo?.actions?.length) {
+                    tags.push(...json.relatedVideo.actions.map(a => a.name));
+                  }
+                  return tags;
+                }
+          split: ","
+      Studio:
+        Name:
+          selector: //a[contains(@href, "/originals/")]/text()
+          postProcess: *studioReplace
+      Code:
+        selector: $escapedJson
+        postProcess:
+          - replace:
+              - regex: .*identifier[^\d]*(\d+).*
+                with: $1
   movieScraper:
     common:
       $details: //div[@class="w-full"][1]
@@ -134,4 +182,4 @@ xPathScrapers:
           - replace:
               - regex: \?.+$
                 with: ""
-# Last Updated September 26, 2025
+# Last Updated May 8, 2026

--- a/scrapers/Bang.yml
+++ b/scrapers/Bang.yml
@@ -20,6 +20,10 @@ groupByURL:
       - bang.com/dvd
       - bangpremium.com/dvd
     scraper: movieScraper
+performerByName:
+  action: scrapeXPath
+  queryURL: https://www.bang.com/pornstars?term={}
+  scraper: performerSearch
 performerByURL:
   - action: scrapeXPath
     url:
@@ -154,6 +158,14 @@ xPathScrapers:
           - replace:
               - regex: /front\.jpg?.*$
                 with: "/back.jpg"
+  performerSearch:
+    common:
+      $performers: //div[contains(@class, "search_container")]
+    performer:
+      Name: $performers//a//span
+      URLs:
+        selector: $performers//a/@href
+        postProcess: *prependHost
   performerScraper:
     common:
       $overlay: //div[@class="flex flex-col md:items-start items-center"]


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByName
- [x] sceneByURL
- [x] galleryByURL

## Examples to test

### performerByName

This was hard for me to test via stash due to region age verification blocking, but I checked the search page via a proxy in a browser and the xpaths resolve in browser console. Try these search terms:

- ava
- amira
- dimov

### sceneByURL

- https://www.bang.com/video/aZ43VtZ-rKkMA5dA/ava-amiras-explosive-bang-surprise-curves-cum-and-pure-pleasure
- https://www.bang.com/video/aWbat_X9EPcRBlrp/gorgeous-isa-bella-ravaged-by-a-huge-dick
- https://www.bang.com/video/aLoe8aUOHsDtDuPL/ava-amira-rides-and-gets-rammed-by-a-thick-black-cock
- https://www.bang.com/video/Zvx5H9SLobI9AJCi/cubbi-thompson-gets-her-huge-tits-covered-in-cum

### galleryByURL

- https://www.bang.com/photos/aZ43VtZ-rKkMA5dA/ava-amiras-explosive-bang-surprise-curves-cum-and-pure-pleasure
- https://www.bang.com/photos/aZS7dZ8muAToBBSH/meagan-moore-gets-rammed-hard-and-squirts

## Short description

- added galleryByURL
- added Code to sceneByURL
- added performerByName
