### PR TITLE
fix(Redgifs): scene-by-name passes string to to_scraped_scene expecting dict

### DIFF
--- a/scrapers/Redgifs/Redgifs.py
+++ b/scrapers/Redgifs/Redgifs.py
@@ -179,7 +179,8 @@ if __name__ == "__main__":
         case "scene-by-url" | "scene-by-query-fragment", {"url": url}:
             result = scene_by_url(url)
         case "scene-by-name", {"name": identifier}:
-            result = [s for s in [to_scraped_scene(identifier.strip())] if s]
+            data = fetch_data(identifier.strip())
+            result = [to_scraped_scene(data)] if data else []
         case "scene-by-fragment", fragment:
             result = scene_by_fragment(fragment)
         case "image-by-url", {"url": url}:


### PR DESCRIPTION
## Summary

The `scene-by-name` handler in `scrapers/Redgifs/Redgifs.py` passes the raw `identifier` string directly to `to_scraped_scene()`, but that function expects the JSON dict returned by the RedGIFs API (`{"gif": {...}, "user": {...}}`).

When invoked, the function fails at line 44 trying to do `data["gif"]` on a string:

```python
case "scene-by-name", {"name": identifier}:
    result = [s for s in [to_scraped_scene(identifier.strip())] if s]
                                            ^^^^^^^^^^^^^^^^^^
                                            # string, not the expected dict
```

Stash surfaces this as `scraper script error: exit status 69`.

## Reproduce

In Stash UI, on a scene, run the Redgifs scraper by name. The scraper exits with status 69 and Stash logs show:

```
TypeError: string indices must be integers, not 'str'
  File "Redgifs.py", line 44, in to_scraped_scene
    gif = data["gif"]
```

## Fix

Call `fetch_data()` first (same pattern used by `scene_by_url()` directly above), then pass the resulting dict to `to_scraped_scene()`:

```python
case "scene-by-name", {"name": identifier}:
    data = fetch_data(identifier.strip())
    result = [to_scraped_scene(data)] if data else []
```

## Test plan

- [x] Manual scrape by name in Stash UI on a known scene — succeeds and returns tags/title/date/url
- [x] Scrape by URL (unchanged path) — still works
- [x] Invalid identifier — `fetch_data()` returns `None`, result is empty list, no crash