### PR TITLE
Add site to evilangel.py site_map

### DIFF
--- a/scrapers/EvilAngel/EvilAngel.py
+++ b/scrapers/EvilAngel/EvilAngel.py
@@ -50,6 +50,7 @@ Each serie_name requiring a map/override should have a key-value here
 site_map = {
     "christophclarkonline": "Christoph Clark Online",
     "christophsbignaturaltits": "Christoph's Big Natural Tits",
+    "cockchokingsluts": "Cock Choking Sluts",
     "gapingangels": "Gaping Angels",
     "iloveblackshemales": "I Love Black Shemales",
     "jakemalone": "Jake Malone",

--- a/scrapers/EvilAngel/EvilAngel.yml
+++ b/scrapers/EvilAngel/EvilAngel.yml
@@ -97,4 +97,4 @@ performerByFragment:
     - EvilAngel.py
     - evilangel
     - performer-by-fragment
-# Last Updated June 3, 2025
+# Last Updated May 11, 2026


### PR DESCRIPTION
Adds `cockchokingsluts` to the `site_map` list so it's detected as a studio name. In the API response, it appears before `jakemalone`, so will now take priority.

As reported [on Discord](https://discord.com/channels/559159668438728723/651418567475986432/1502630531270185072), a scene ([NSFW scene link](https://www.evilangel.com/en/video/evilangel/Gang-Bang-My-Face-05-Scene-04/16932)) was having the wrong studio scraped ([NSFW scrape](https://scrape-ci.feederbox.cc/scene?id=76nVEEc8mk6j1)).

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [x] galleryByFragment
- [x] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

[NSFW scene link](https://www.evilangel.com/en/video/evilangel/Gang-Bang-My-Face-05-Scene-04/16932)
