### PR TITLE
Update Tag matcher for Rule34Video

### DIFF
--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -58,11 +58,8 @@ xPathScrapers:
                 with: $1
       Tags:
         Name:
-          selector: $article//div[text()="Categories" or text()="Tags"]/following-sibling::a//text()
-          postProcess:
-            - replace:
-                - regex: '^\+.+Suggest$'
-                  with: ""
+          selector: $article//div[@data-suggest-type="tag"]//a[contains(@class, "tag_item") and not(contains(@class, "tag_item_suggest"))]/text()
+          
       Studio:
         Name: $article//div[text()="Artist"]/following-sibling::a/span
         URL: $article//div[text()="Artist"]/following-sibling::a/@href


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)

- [X] sceneByURL


## Examples to test

List a few links/titles/names/filenames/codes to test

Tested `https://rule34video.com/video/3175158/pmv-overwatch-void-palace/` and `https://rule34video.com/video/4379485/ellie-finds-a-toy-no-wm-parkingbelt-4k60fps/`, verified tags now download and other data still imports

## Short description

Fix the CSS selector to pull correctly from the new page layout. Scopes to the `@data-suggest-type="tag"` div and then grabs text from each `tag_item` element.
Fixes #2747 