### PR TITLE
[FileMetadata] Parse json from stdin buffer instead of text to prevent mojibake

### DIFF
--- a/scrapers/FileMetadata/FileMetadata.py
+++ b/scrapers/FileMetadata/FileMetadata.py
@@ -59,7 +59,7 @@ def scrape_file(path):
 
 
 if __name__ == "__main__":
-    fragment = json.loads(sys.stdin.read())
+    fragment = json.loads(sys.stdin.buffer.read())
     scene_id = fragment["id"]
 
     if "files" not in fragment:


### PR DESCRIPTION
`sys.stdin` is a text-mode stream that decodes bytes using the locale encoding (e.g. CP1252 on Windows), which corrupts non-ASCII characters in scene data (e.g. file names with Japanese characters). Reading from `sys.stdin.buffer` instead retrieves raw bytes, and `json.loads()` always interprets these as UTF-8 regardless of platform or locale settings.