### PR TITLE
add oopsieanimated.com

### DIFF
--- a/scrapers/AdultTime/AdultTime.yml
+++ b/scrapers/AdultTime/AdultTime.yml
@@ -67,6 +67,7 @@ sceneByURL:
       - nurumassage.com/en/video/
       - officemsconduct.com/en/video/
       - oopsie.com/en/video/
+      - oopsieanimated.com/en/video/
       - outofthefamily.com/en/video/
       - peternorth.com/en/video/
       - povmassage.com/en/video/
@@ -247,4 +248,4 @@ performerByFragment:
     - AdultTime.py
     - girlsway
     - performer-by-fragment
-# Last Updated May 22, 2025
+# Last Updated May 18, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.oopsieanimated.com/en/video/oopsieanimated/Glory-To-The-Hole/282198
- https://www.oopsieanimated.com/en/video/oopsieanimated/Personal-Service/285445
- https://www.oopsieanimated.com/en/video/oopsieanimated/The-Big-Screen/287131

## Short description

Series at Adult Time now has a site/domain, oopsieanimated.com
