### PR TITLE
fix selectors for rule34video.com

### DIFF
--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -57,15 +57,10 @@ xPathScrapers:
               - regex: '.+thumbnailUrl": "(http[^"]+)".+'
                 with: $1
       Tags:
-        Name:
-          selector: $article//div[text()="Categories" or text()="Tags"]/following-sibling::a//text()
-          postProcess:
-            - replace:
-                - regex: '^\+.+Suggest$'
-                  with: ""
+        Name: //a[@class="tag_item"]
       Studio:
-        Name: $article//div[text()="Artist"]/following-sibling::a/span
-        URL: $article//div[text()="Artist"]/following-sibling::a/@href
+        Name: $article//div[text()="Artist"]/following-sibling::span/a/span
+        URL: $article//div[text()="Artist"]/following-sibling::span/a/@href
 debug:
   printHTML: true
 # see configuration notes in https://discourse.stashapp.cc/t/ddos-guard-for-scrapers/2369
@@ -109,4 +104,4 @@ driver:
           Value: "1"
           Domain: "rule34video.com"
           Path: "/"
-# Last Updated July 2, 2025
+# Last Updated May 19, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://rule34video.com/videos/3063279/jackerman-mother-s-warmth-ep-2-60fps/
- https://rule34video.com/videos/3070735/ff7-tifa-bare-thighjob-bulgings/
- https://rule34video.com/video/3092765/selina-s-sabotage-jackerman/

## Short description

This fixes the selectors for Tags and Studio
