### PR TITLE
add EvilErotic (evilerotic.com and tgirlshouse.com)

### DIFF
--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -70,6 +70,8 @@ xPathScrapers:
           - replace:
               - regex: (\d+)\s*KG.*
                 with: $1
+      Gender:
+        fixed: female
   sceneScraper:
     scene:
       Title: //h1[@class="vd-title"]

--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -2,7 +2,7 @@
 name: Evil Erotic
 performerByName:
   action: scrapeJson
-  queryURL: "https://evilerotic.com/models/{}"
+  queryURL: "https://evilerotic.com/api/search?q={}"
   scraper: performerSearchScraper
 performerByURL:
   - action: scrapeXPath

--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -1,11 +1,30 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
 name: Evil Erotic
+sceneByName:
+  action: scrapeJson
+  queryURL: "https://evilerotic.com/api/search?q={}"
+  scraper: sceneSearchScraper
+sceneByQueryFragment:
+  action: scrapeXPath
+  queryURL: "{url}"
+  scraper: sceneScraper
 sceneByURL:
   - action: scrapeXPath
     url:
       - evilerotic.com/videos/
       - tgirlshouse.com/videos/
     scraper: sceneScraper
+jsonScrapers:
+  sceneSearchScraper:
+    scene:
+      Title: videos.#.title
+      Image: videos.#.image
+      URLs:
+        selector: videos.#.slug
+        postProcess:
+          - replace:
+              - regex: "^(.+)$"
+                with: "https://evilerotic.com/videos/${1}"
 xPathScrapers:
   sceneScraper:
     scene:

--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+name: Evil Erotic
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - evilerotic.com/videos/
+      - tgirlshouse.com/videos/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h1[@class="vd-title"]
+      Details:
+        selector: //div[@class="vid-desc-collapse"]/div/p
+        concat: "\n\n"
+      URLs: //meta[@property="og:url"]/@content
+      Date:
+        selector: //script[@type="application/ld+json"]/text()
+        postProcess:
+          - javascript: |
+              if (value?.length) {
+                const json = JSON.parse(value);
+                if (json?.uploadDate) {
+                  return json.uploadDate.substring(0, 10);
+                }
+              }
+      Image:
+        selector: //meta[@property="og:image"]/@content
+        postProcess:
+          # Remove (scaled-down) resolution from image URL, e.g.
+          # https://example.com/wp-content/uploads/2026/05/Example-Something-768x432.webp
+          # becomes (854x480)
+          # https://example.com/wp-content/uploads/2026/05/Example-Something.webp
+          - replace:
+              - regex: -\d+x\d+
+                with: ""
+      Studio:
+        Name: //meta[@property="og:site_name"]/@content
+      Tags:
+        Name: //h2[text()="Tags"]/following-sibling::div/a/text()
+      Performers:
+        Name: //div[@class="vd-meta-models"]/a/text()
+# Last Updated May 21, 2026

--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
 name: Evil Erotic
+performerByName:
+  action: scrapeJson
+  queryURL: "https://evilerotic.com/models/{}"
+  scraper: performerSearchScraper
 performerByURL:
   - action: scrapeXPath
     url:
@@ -19,6 +23,16 @@ sceneByURL:
       - evilerotic.com/videos/
     scraper: sceneScraper
 jsonScrapers:
+  performerSearchScraper:
+    performer:
+      Name: models.#.name
+      Image: models.#.image
+      URLs:
+        selector: models.#.slug
+        postProcess:
+          - replace:
+              - regex: "^(.+)$"
+                with: "https://evilerotic.com/models/${1}"
   sceneSearchScraper:
     scene:
       Title: videos.#.title

--- a/scrapers/EvilErotic.yml
+++ b/scrapers/EvilErotic.yml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
 name: Evil Erotic
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - evilerotic.com/models/
+    scraper: performerScraper
 sceneByName:
   action: scrapeJson
   queryURL: "https://evilerotic.com/api/search?q={}"
@@ -25,6 +30,32 @@ jsonScrapers:
               - regex: "^(.+)$"
                 with: "https://evilerotic.com/videos/${1}"
 xPathScrapers:
+  performerScraper:
+    performer:
+      Name: //h1[@class="model-hero-name"]
+      Image: //div[contains(@class, "model-info-photo")]/img/@src
+      URLs: //meta[@property="og:url"]/@content
+      Birthdate:
+        selector: //span[@class="model-info-label" and text()="Birthday:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)(st|nd|rd|th)
+                with: $1
+          - parseDate: 2 January
+      Country: //span[@class="model-info-label" and text()="Country:"]/following-sibling::span/text()
+      Ethnicity: //span[@class="model-info-label" and text()="Ethnicity:"]/following-sibling::span/text()
+      Height:
+        selector: //span[@class="model-info-label" and text()="Height:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*CM.*
+                with: $1
+      Weight:
+        selector: //span[@class="model-info-label" and text()="Weight:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*KG.*
+                with: $1
   sceneScraper:
     scene:
       Title: //h1[@class="vd-title"]

--- a/scrapers/TGirlsHouse.yml
+++ b/scrapers/TGirlsHouse.yml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
 # This is a sub-studio of Evil Erotic, but it has a separate search API, so it gets its own scraper.
 name: TGirls House
+performerByName:
+  action: scrapeJson
+  queryURL: "https://tgirlshouse.com/models/{}"
+  scraper: performerSearchScraper
 performerByURL:
   - action: scrapeXPath
     url:
@@ -20,6 +24,16 @@ sceneByURL:
       - tgirlshouse.com/videos/
     scraper: sceneScraper
 jsonScrapers:
+  performerSearchScraper:
+    performer:
+      Name: models.#.name
+      Image: models.#.image
+      URLs:
+        selector: models.#.slug
+        postProcess:
+          - replace:
+              - regex: "^(.+)$"
+                with: "https://tgirlshouse.com/models/${1}"
   sceneSearchScraper:
     scene:
       Title: videos.#.title

--- a/scrapers/TGirlsHouse.yml
+++ b/scrapers/TGirlsHouse.yml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
 # This is a sub-studio of Evil Erotic, but it has a separate search API, so it gets its own scraper.
 name: TGirls House
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - tgirlshouse.com/models/
+    scraper: performerScraper
 sceneByName:
   action: scrapeJson
   queryURL: "https://tgirlshouse.com/api/search?q={}"
@@ -26,6 +31,32 @@ jsonScrapers:
               - regex: "^(.+)$"
                 with: "https://tgirlshouse.com/videos/${1}"
 xPathScrapers:
+  performerScraper:
+    performer:
+      Name: //h1[@class="model-hero-name"]
+      Image: //div[contains(@class, "model-info-photo")]/img/@src
+      URLs: //meta[@property="og:url"]/@content
+      Birthdate:
+        selector: //span[@class="model-info-label" and text()="Birthday:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)(st|nd|rd|th)
+                with: $1
+          - parseDate: 2 January
+      Country: //span[@class="model-info-label" and text()="Country:"]/following-sibling::span/text()
+      Ethnicity: //span[@class="model-info-label" and text()="Ethnicity:"]/following-sibling::span/text()
+      Height:
+        selector: //span[@class="model-info-label" and text()="Height:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*CM.*
+                with: $1
+      Weight:
+        selector: //span[@class="model-info-label" and text()="Weight:"]/following-sibling::span/text()
+        postProcess:
+          - replace:
+              - regex: (\d+)\s*KG.*
+                with: $1
   sceneScraper:
     scene:
       Title: //h1[@class="vd-title"]

--- a/scrapers/TGirlsHouse.yml
+++ b/scrapers/TGirlsHouse.yml
@@ -71,6 +71,8 @@ xPathScrapers:
           - replace:
               - regex: (\d+)\s*KG.*
                 with: $1
+      Gender:
+        fixed: transgender_female
   sceneScraper:
     scene:
       Title: //h1[@class="vd-title"]

--- a/scrapers/TGirlsHouse.yml
+++ b/scrapers/TGirlsHouse.yml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
-name: Evil Erotic
+# This is a sub-studio of Evil Erotic, but it has a separate search API, so it gets its own scraper.
+name: TGirls House
 sceneByName:
   action: scrapeJson
-  queryURL: "https://evilerotic.com/api/search?q={}"
+  queryURL: "https://tgirlshouse.com/api/search?q={}"
   scraper: sceneSearchScraper
 sceneByQueryFragment:
   action: scrapeXPath
@@ -11,7 +12,7 @@ sceneByQueryFragment:
 sceneByURL:
   - action: scrapeXPath
     url:
-      - evilerotic.com/videos/
+      - tgirlshouse.com/videos/
     scraper: sceneScraper
 jsonScrapers:
   sceneSearchScraper:
@@ -23,7 +24,7 @@ jsonScrapers:
         postProcess:
           - replace:
               - regex: "^(.+)$"
-                with: "https://evilerotic.com/videos/${1}"
+                with: "https://tgirlshouse.com/videos/${1}"
 xPathScrapers:
   sceneScraper:
     scene:

--- a/scrapers/TGirlsHouse.yml
+++ b/scrapers/TGirlsHouse.yml
@@ -3,7 +3,7 @@
 name: TGirls House
 performerByName:
   action: scrapeJson
-  queryURL: "https://tgirlshouse.com/models/{}"
+  queryURL: "https://tgirlshouse.com/api/search?q={}"
   scraper: performerSearchScraper
 performerByURL:
   - action: scrapeXPath


### PR DESCRIPTION
## Scraper type(s)
- [x] performerByName
- [x] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByURL

## Examples to test

### performerByName

- (Evil Erotic): scarlet
- (TGirls House): raine
 
### performerByURL

- https://tgirlshouse.com/models/raine
- https://evilerotic.com/models/scarlet

### sceneByName

- (Evil Erotic): surprise
- (Tgirls House): poolside

### sceneByURL

- https://evilerotic.com/videos/hijab-dreaming
- https://tgirlshouse.com/videos/secret-visit

## Short description

This adds scrapers for Evil Erotic and sub-studio/site TGirls House, with performer and scene scraping by URL and searching by text.

resolves #2755 
