### PR TITLE
Update PimpBunny scraper for onlyfans-creators URLs and current markup

### DIFF
--- a/scrapers/PimpBunny.yml
+++ b/scrapers/PimpBunny.yml
@@ -1,43 +1,17 @@
-name: PimpBunny
-sceneByURL:
-  - action: scrapeXPath
-    url:
-      - pimpbunny.com/videos/
-    scraper: sceneScraper
+name: "PimpBunny"
+# Path fragment matches localized URLs (e.g. /es/onlyfans-creators/…) as well as the default locale.
 performerByURL:
   - action: scrapeXPath
     url:
-      - pimpbunny.com/onlyfans-models/
+      - pimpbunny.com/onlyfans-creators/
     scraper: performerScraper
 
 xPathScrapers:
-  sceneScraper:
-    common:
-      $models: //ul[contains(@class, "pages-view-video-models")]
-      $jsonld: //script[@type="application/ld+json"]
-    scene:
-      Title: //h1[contains(@class, "pages-view-video-video-title")]
-      Date:
-        selector: $jsonld
-        postProcess:
-          - replace:
-              - regex: .*"uploadDate"\s*:\s*"(\d{4}-\d{2}-\d{2})".*
-                with: $1
-          - parseDate: 2006-01-02
-      Image: //meta[@property="og:image"]/@content
-      URL: //link[@rel="canonical"]/@href
-      Studio:
-        Name:
-          fixed: PimpBunny
-      Performers:
-        Name: $models//div[contains(@class, "pages-view-video-model-title")]//a
-        URLs: $models//div[contains(@class, "pages-view-video-model-title")]//a/@href
-      Tags:
-        Name: //ul[contains(@class, "pages-view-video-tags")][1]//a
   performerScraper:
     performer:
-      Name: //h1[contains(@class, "ui-heading-h1")]
-      Image: //div[contains(@class, "blocks-model-view-thumbnail")]//img/@data-original
-      Tags:
-        Name: //div[contains(@class,"model-view-top-lists")]/a/text()
-      URLs: //div[contains(@class,"model-view-social-bar")]//a/@href
+      Name: //h1
+      Details: //meta[@property="og:description"]/@content
+      Image: //meta[@property="og:image"]/@content
+      URLs: //meta[@property="og:url"]/@content
+      Aliases: //meta[@name="keywords"]/@content
+# Last Updated May 17, 2026

--- a/scrapers/PimpBunny.yml
+++ b/scrapers/PimpBunny.yml
@@ -26,6 +26,8 @@ xPathScrapers:
                 with: $1
           - parseDate: 2006-01-02
       Image: //meta[@property="og:image"]/@content
+      Details:
+        selector: //div[contains(@class, "pages-view-video-description")][normalize-space()] | //meta[@property="og:description"]/@content
       URL: //link[@rel="canonical"]/@href
       Studio:
         Name:
@@ -34,14 +36,16 @@ xPathScrapers:
         Name: $models//div[contains(@class, "pages-view-video-model-title")]//a
         URLs: $models//div[contains(@class, "pages-view-video-model-title")]//a/@href
       Tags:
-        Name: //ul[contains(@class, "pages-view-video-categories")]//a
+        Name:
+          selector: //ul[contains(@class, "pages-view-video-categories")]//a/text()
   performerScraper:
     performer:
       Name: //div[contains(@class,"model-view-title")]//h1
       Details: //div[contains(@class,"model-view-creator-description")]
       Image: //div[contains(@class,"model-view-thumbnail")]//img/@data-original
       Tags:
-        Name: //div[contains(@class,"model-view-top-lists")]//a
+        Name:
+          selector: //div[contains(@class,"model-view-top-lists")]//a/text()
       URLs: //div[contains(@class,"model-view-social-bar")]//a/@href | //meta[@property="og:url"]/@content
       Aliases:
         selector: //meta[@name="keywords"]/@content

--- a/scrapers/PimpBunny.yml
+++ b/scrapers/PimpBunny.yml
@@ -1,4 +1,9 @@
 name: "PimpBunny"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - pimpbunny.com/videos/
+    scraper: sceneScraper
 # Path fragment matches localized URLs (e.g. /es/onlyfans-creators/…) as well as the default locale.
 performerByURL:
   - action: scrapeXPath
@@ -7,11 +12,38 @@ performerByURL:
     scraper: performerScraper
 
 xPathScrapers:
+  sceneScraper:
+    common:
+      $models: //ul[contains(@class, "pages-view-video-models")]
+      $jsonld: //script[@type="application/ld+json"]
+    scene:
+      Title: //h1[contains(@class, "pages-view-video-video-title")]
+      Date:
+        selector: $jsonld
+        postProcess:
+          - replace:
+              - regex: .*"uploadDate"\s*:\s*"(\d{4}-\d{2}-\d{2})".*
+                with: $1
+          - parseDate: 2006-01-02
+      Image: //meta[@property="og:image"]/@content
+      URL: //link[@rel="canonical"]/@href
+      Studio:
+        Name:
+          fixed: PimpBunny
+      Performers:
+        Name: $models//div[contains(@class, "pages-view-video-model-title")]//a
+        URLs: $models//div[contains(@class, "pages-view-video-model-title")]//a/@href
+      Tags:
+        Name: //ul[contains(@class, "pages-view-video-categories")]//a
   performerScraper:
     performer:
-      Name: //h1
-      Details: //meta[@property="og:description"]/@content
-      Image: //meta[@property="og:image"]/@content
-      URLs: //meta[@property="og:url"]/@content
-      Aliases: //meta[@name="keywords"]/@content
-# Last Updated May 17, 2026
+      Name: //div[contains(@class,"model-view-title")]//h1
+      Details: //div[contains(@class,"model-view-creator-description")]
+      Image: //div[contains(@class,"model-view-thumbnail")]//img/@data-original
+      Tags:
+        Name: //div[contains(@class,"model-view-top-lists")]//a
+      URLs: //div[contains(@class,"model-view-social-bar")]//a/@href | //meta[@property="og:url"]/@content
+      Aliases:
+        selector: //meta[@name="keywords"]/@content
+        split: ", "
+# Last Updated May 27, 2026

--- a/scrapers/PimpBunny.yml
+++ b/scrapers/PimpBunny.yml
@@ -26,8 +26,7 @@ xPathScrapers:
                 with: $1
           - parseDate: 2006-01-02
       Image: //meta[@property="og:image"]/@content
-      Details:
-        selector: //div[contains(@class, "pages-view-video-description")][normalize-space()] | //meta[@property="og:description"]/@content
+      Details: //div[contains(@class, "pages-view-video-description")] | //meta[@property="og:description"]/@content
       URL: //link[@rel="canonical"]/@href
       Studio:
         Name:
@@ -36,18 +35,16 @@ xPathScrapers:
         Name: $models//div[contains(@class, "pages-view-video-model-title")]//a
         URLs: $models//div[contains(@class, "pages-view-video-model-title")]//a/@href
       Tags:
-        Name:
-          selector: //ul[contains(@class, "pages-view-video-categories")]//a/text()
+        Name: //ul[contains(@class, "pages-view-video-categories")]//a
   performerScraper:
     performer:
       Name: //div[contains(@class,"model-view-title")]//h1
       Details: //div[contains(@class,"model-view-creator-description")]
       Image: //div[contains(@class,"model-view-thumbnail")]//img/@data-original
       Tags:
-        Name:
-          selector: //div[contains(@class,"model-view-top-lists")]//a/text()
+        Name: //div[contains(@class,"model-view-top-lists")]//a
       URLs: //div[contains(@class,"model-view-social-bar")]//a/@href | //meta[@property="og:url"]/@content
       Aliases:
         selector: //meta[@name="keywords"]/@content
         split: ", "
-# Last Updated May 27, 2026
+# Last Updated May 28, 2026

--- a/scrapers/PimpBunny.yml
+++ b/scrapers/PimpBunny.yml
@@ -17,7 +17,7 @@ xPathScrapers:
       $models: //ul[contains(@class, "pages-view-video-models")]
       $jsonld: //script[@type="application/ld+json"]
     scene:
-      Title: //h1[contains(@class, "pages-view-video-video-title")]
+      Title: //*[contains(@class, "pages-view-video-video-title")]
       Date:
         selector: $jsonld
         postProcess:


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

### sceneByURL
- https://pimpbunny.com/videos/kacey-kayy-s-hunting-blind-jerk-off-instructions/
- https://pimpbunny.com/videos/alannasworldx-friends-jerk-off-instruction/

### performerByURL
- https://pimpbunny.com/onlyfans-creators/stellaexclusive-leaked/
- https://pimpbunny.com/onlyfans-creators/alannasworldx-leaks/

## Short description

Update PimpBunny for current site markup:
- Performer URLs: `onlyfans-models` → `onlyfans-creators`
- Performer fields: bio, thumbnail, top-list tags, social URLs (+ `og:url` fallback), keyword aliases
- Scene tags: `pages-view-video-tags` → `pages-view-video-categories`
- Scene details: add description scraping; fix invalid `[normalize-space()]` xpath
- Tag selectors: use `//a` form consistent with other scrapers