### PR TITLE
Updated Details selector and Title selector of ChastityBabes

### DIFF
--- a/scrapers/chastitybabes.yml
+++ b/scrapers/chastitybabes.yml
@@ -11,11 +11,7 @@ xPathScrapers:
       $performerTitle: //h1[@id="post-title"]/text()
     scene:
       Title:
-        selector: $performerTitle
-        postProcess:
-          - replace:
-            - regex: (.*) – (.*)
-              with: $2
+        selector: //meta[@property="og:title"]/@content
       Date:
         selector: //meta[@property="article:published_time"]/@content
         postProcess:
@@ -24,7 +20,12 @@ xPathScrapers:
               with: ""
           - parseDate: 2006-01-02
       Details: 
-        selector: //div[@class="postcontent"]/p
+        selector: //div[@class="postcontent"]/p//text()
+        concat: "\n\n"
+        postProcess:
+          - replace:
+            - regex: ([^.!?])\n\n
+              with: "$1 "
       Performers: 
         Name: 
           selector: $performerTitle
@@ -47,4 +48,4 @@ xPathScrapers:
             - regex: "\t"
               with: ""
 
-# Last Updated April 11, 2026
+# Last Updated June 5, 2026


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [x ] sceneByURL

## Examples to test

https://www.chastitybabes.com/archives/187
https://www.chastitybabes.com/archives/4697

## Short description

Now reading the title from the page metadata
Updated the Details selector so that now:
- Multi paragraph descriptions are all read
- \<br> breaks are now converted to \n\n
- Using "//div[@Class="postcontent"]/p//text()" allows for text in \<a href> to be read. To prevent them from getting newlines the newlines are removed when the character before the newline is not a ".", "!" or "?"
