### PR TITLE
OfficialDreddXXX: add scraper for site

### DIFF
--- a/scrapers/OfficialDreddXXX.yml
+++ b/scrapers/OfficialDreddXXX.yml
@@ -1,0 +1,32 @@
+name: OfficialDreddXXX
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - officialdreddxxx.com/scene/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: //h1[contains(@class,"elementor-heading-title")]
+      Details:
+        selector: //div[contains(@class,"elementor-widget-theme-post-content")]//p[1]
+      Date:
+        selector: //li[@itemprop="datePublished"]//time
+        postProcess:
+          - parseDate: January 2, 2006
+      Image:
+        selector: //meta[@property="og:image"]/@content
+      URL:
+        selector: //link[@rel="canonical"]/@href
+      Tags:
+        Name:
+          selector: //a[contains(@href,"/scene-category/") and not(contains(@href,"/upcoming"))]
+      Performers:
+        Name:
+          selector: //a[contains(@href,"/pornstar/")]
+        URL:
+          selector: //a[contains(@href,"/pornstar/")]/@href
+      Studio:
+        Name:
+          fixed: DreddXXX

--- a/scrapers/OfficialDreddXXX.yml
+++ b/scrapers/OfficialDreddXXX.yml
@@ -25,8 +25,6 @@ xPathScrapers:
       Performers:
         Name:
           selector: //a[contains(@href,"/pornstar/")]
-        URL:
-          selector: //a[contains(@href,"/pornstar/")]/@href
       Studio:
         Name:
           fixed: DreddXXX


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

-https://officialdreddxxx.com/scene/gia-lola/ (multiple performer scene)
-https://officialdreddxxx.com/scene/martina-smeraldi/

## Short description

URL scene scraper for public links for officialdreddxxx.com, hardcodes the studio to what it is in StashDB.  Scrapes scene date, performers, details and tags.  The only thing I couldn't get is hardcoding Dredd into the scene (lol).  He is in every scene
