### PR TITLE
DreddXXX: Handle most of members site content

### DIFF
--- a/scrapers/DreddXXX.yml
+++ b/scrapers/DreddXXX.yml
@@ -2,8 +2,13 @@ name: Dredd XXX
 sceneByURL:
   - action: scrapeXPath
     url:
-      - officialdreddxxx.com/scene/
+      - https://officialdreddxxx.com/scene/
+      - https://www.officialdreddxxx.com/scene/
     scraper: sceneScraper
+  - action: scrapeXPath
+    url:
+      - https://members.officialdreddxxx.com/scene/
+    scraper: membersScraper
 xPathScrapers:
   sceneScraper:
     scene:
@@ -23,7 +28,30 @@ xPathScrapers:
       Performers:
         Name: //a[contains(@href, "pornstar")]
 
+  membersScraper:
+    scene:
+      Title:
+        selector: //h1[contains(@class,"elementor-heading-title")]
+      Details:
+        selector: //div[@data-widget_type="theme-post-content.default"]//p[1]
+      URLs:
+        selector: //link[@rel="canonical"]/@href
+      Date:
+        selector: //li[@itemprop="datePublished"]//time
+        postProcess:
+          - parseDate: January 2, 2006
+      Studio:
+        Name:
+          fixed: DreddXXX
+      Tags:
+        Name:
+          selector: //a[contains(@href,"/scene-category/") and not(contains(@href,"/upcoming"))]
+      Performers:
+        Name:
+          selector: //a[contains(@href,"/pornstar/")]
+
 driver:
+  useCDP: true
   headers:
     - Key: User-Agent
       Value: stash-scraper/1.0


### PR DESCRIPTION
Scrapes scene if you are logged in with member site.  I couldn't get image to download, but if you have access getting scene image is easy.  User will have to add Dredd afterwards just like public scene scraper.  Some scenes don't have a public link, this can be the community scraper version for non-public links

Scene tested: 
https://members.officialdreddxxx.com/scene/scarlett-alexis/