### PR TITLE
Add additional cookies for Kink sites

### DIFF
--- a/scrapers/Kink.yml
+++ b/scrapers/Kink.yml
@@ -279,4 +279,12 @@ driver:
           Domain: "www.kink.com"
           Value: "1"
           Path: "/"
-# Last Updated April 14, 2026
+        - Name: "age_gate_accepted"
+          Domain: "www.kinkmen.com"
+          Value: "1"
+          Path: "/"
+        - Name: "age_gate_accepted"
+          Domain: "www.kinktrans.com"
+          Value: "1"
+          Path: "/"
+# Last Updated June 6, 2026


### PR DESCRIPTION
Adds additional age_gate_accepted cookies for other domains supported by this scraper. The cookie already exists for the base kink.com domain; however, this scraper declares support for the other domains but doesn't add this cookie.