### PR TITLE
Update SARJ-LLC.py

### DIFF
--- a/scrapers/SARJ-LLC/SARJ-LLC.py
+++ b/scrapers/SARJ-LLC/SARJ-LLC.py
@@ -66,6 +66,8 @@ def query(fragment, query_type):
 
         scraper = globals()['scrape_' + ('movie' if query_type == 'scene' else query_type)]
         res = scraper('https://metartnetwork.com', date, name)
+        if res is None:
+               res = scraper('https://www.rylskyart.com', date, name)
     return res
 
 def search(s_type, name):


### PR DESCRIPTION
RylskyArt content is no longer indexed on metartnetwork.com.

Fixes RylskyArt scraping by adding rylskyart.com fallback.

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

## Short description

Describe the general changes
