### PR TITLE
[Pornhub] Use TLS impersonation

### DIFF
--- a/scrapers/Pornhub/Pornhub.yml
+++ b/scrapers/Pornhub/Pornhub.yml
@@ -158,6 +158,7 @@ xPathScrapers:
         Name: $videoDetails//a[@data-label="channel"] | $studioButton
 
 driver:
+  useSurf: true
   cookies:
     - CookieURL: "https://www.pornhub.com"
       Cookies:


### PR DESCRIPTION
Their API recently changed and now blocks all requests without impersonation with 403 Forbidden.

Add TLS impersonation according to recent change: stashapp/stash#6806

Tested and it does work after adding impersonation.