### PR TITLE
JavBus: don't prepend base URL to absolute (DMM) cover image src

### DIFF
--- a/scrapers/JavBus.yml
+++ b/scrapers/JavBus.yml
@@ -66,8 +66,8 @@ xPathScrapers:
         selector: //*[@id="waterfall"]/div[1]/div/div[1]/img/@src
         postProcess:
           - replace:
-            - regex: ^
-              with: https://www.javbus.com
+            - regex: ^/
+              with: https://www.javbus.com/
 
   sceneSearch: 
     scene: 
@@ -96,8 +96,8 @@ xPathScrapers:
         selector: //div[@class="row movie"]/div[@class="col-md-9 screencap"]/a[@class="bigImage"]/img/@src
         postProcess:
           - replace:
-            - regex: ^
-              with: https://www.javbus.com
+            - regex: ^/
+              with: https://www.javbus.com/
       Studio:
         Name: //div[@class="col-md-3 info"]//span[contains(text(), '發行商')]/../a/text()
 


### PR DESCRIPTION
## Problem
Both `Image` fields in `JavBus.yml` (scene + performer) run this post-process:

```yaml
postProcess:
  - replace:
    - regex: ^
      with: https://www.javbus.com
```

`regex: ^` matches the start of the string, so the base URL is prepended to **every** `img/@src` unconditionally. For titles whose cover is hosted on DMM, the page's `img/@src` is already an **absolute** URL (`https://pics.dmm.co.jp/...`), so the result is a malformed double-scheme URL:

```
https://www.javbus.comhttps://pics.dmm.co.jp/digital/video/xxx/xxxpl.jpg
```

…which fails to load as a cover.

## Fix
Anchor the prepend to a leading slash so it only applies to **relative** srcs:

```yaml
postProcess:
  - replace:
    - regex: ^/
      with: https://www.javbus.com/
```

- Relative `/pics/cover/x.jpg` → `https://www.javbus.com/pics/cover/x.jpg` (unchanged behavior)
- Absolute `https://pics.dmm.co.jp/...` → passes through untouched

Applied to both the scene and performer `Image` fields. Verified against a DMM-hosted title (cover now resolves correctly) and a javbus-hosted (relative) title (still resolves).
