### PR TITLE
javdb: extract JAV code from filename in sceneByFragment

### DIFF
--- a/scrapers/javdb.yml
+++ b/scrapers/javdb.yml
@@ -6,6 +6,15 @@ sceneByFragment:
     filename:
       - regex: \..+$
         with: ""
+      # Drop disc/site junk tokens that look like codes (CD1, DISC2, JAV24, ...) so the real
+      # code is picked even when such junk appears before it in the filename.
+      - regex: (?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b
+        with: " "
+      # Extract the first LETTERS-DIGITS code and normalize it: dashless (DDT246),
+      # spaced/underscored, and double-dash ([GTJ--010]) filenames all become the
+      # hyphenated form (e.g. DDT-246) that javdb's search requires.
+      - regex: ^.*?([A-Za-z]{2,6})[-_ ]*(\d{2,5}).*$
+        with: $1-$2
   scraper: sceneQueryScraper
 sceneByURL:
   - action: scrapeXPath

--- a/scrapers/javdb.yml
+++ b/scrapers/javdb.yml
@@ -10,11 +10,17 @@ sceneByFragment:
       # code is picked even when such junk appears before it in the filename.
       - regex: (?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b
         with: " "
-      # Extract the first LETTERS-DIGITS code and normalize it: dashless (DDT246),
-      # spaced/underscored, and double-dash ([GTJ--010]) filenames all become the
-      # hyphenated form (e.g. DDT-246) that javdb's search requires.
-      - regex: ^.*?([A-Za-z]{2,6})[-_ ]*(\d{2,5}).*$
-        with: $1-$2
+      # Extract the first code and normalize it to javdb's hyphenated form. The label
+      # may carry leading digits (25ID), trailing digits (T38) or both (3DSVR), and the
+      # number may carry a short letter prefix (MBR-AA048); the disc/number cap keeps
+      # resolution tokens like 720p/1080p from being mistaken for a code. Three ordered
+      # branches pick the leftmost real code:
+      #   1a  label + dash/underscore + number   (number may have an AA-style prefix)
+      #   1b  label + space + number             (number must be pure digits, so a junk
+      #                                            word after the label isn't swallowed)
+      #   2   dashless label immediately followed by digits  (DDT246 -> DDT-246)
+      - regex: ^.*?(?:((?:[A-Za-z]\d{1,4}|\d{0,4}[A-Za-z]{2,6}))[-_]+([A-Za-z]{0,3}\d{2,5})|((?:[A-Za-z]\d{1,4}|\d{0,4}[A-Za-z]{2,6}))[ ]+(\d{2,5})|([A-Za-z]{2,6})(\d{2,5}))\b.*$
+        with: ${1}${3}${5}-${2}${4}${6}
   scraper: sceneQueryScraper
 sceneByURL:
   - action: scrapeXPath


### PR DESCRIPTION
## Problem
`javdb.yml`'s `sceneByFragment` only strips the file extension, then passes the **raw filename** to javdb's search:

```yaml
queryURLReplace:
  filename:
    - regex: \..+$
      with: ""
```

javdb's search expects the **hyphenated** code (e.g. `DDT-246`), so any filename that isn't already exactly that fails to match. Common real-world variants that currently miss:

| filename token | should search |
|---|---|
| `DDT246` (dashless) | `DDT-246` |
| `DDT 246` / `DDT_246` | `DDT-246` |
| `[GTJ--010]` (double dash) | `GTJ-010` |
| `JAV24 ... DDT284` (junk first) | `DDT-284` |
| `DDT-246 ... -CD1` (trailing disc token) | `DDT-246` |

## Fix
Two added `queryURLReplace` steps:

```yaml
- regex: (?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b   # drop disc/site junk tokens
  with: " "
- regex: ^.*?([A-Za-z]{2,6})[-_ ]*(\d{2,5}).*$          # extract first code, normalize
  with: $1-$2
```

- Pristine `DDT-246` → unchanged
- The junk list is conservative (none collide with real JAV label prefixes)
- A matching fix for `JavBus.yml` (same class of filenames) will follow in a separate PR.

Verified against dashless, double-dash, junk-prefix, and trailing-disc-token filenames — all now resolve to the correct code.
