### PR TITLE
JavBus: robust filename->code extraction in sceneByFragment

### DIFF
--- a/scrapers/JavBus.yml
+++ b/scrapers/JavBus.yml
@@ -6,8 +6,17 @@ sceneByFragment:
     filename:
       - regex: -JG\d
         with: ""
-      - regex: (.*[^a-zA-Z0-9])*([a-zA-Z-]+\d+)(.+)
-        with: $2
+      # Drop disc/site junk tokens that look like codes (CD1, DISC2, JAV24, ...) so the real
+      # code is picked even when such junk appears before it in the filename.
+      - regex: (?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b
+        with: " "
+      # Extract the first LETTERS-DIGITS code and normalize to LETTERS-DIGITS: dashless
+      # (DDT246), spaced/underscored, and double-dash ([GTJ--010]) names all become e.g.
+      # DDT-246 for the javbus.com/<code> lookup. Replaces the previous expression, which
+      # picked the LAST code-like token (e.g. a trailing -CD1), required text after the code
+      # (so a bare code at the end of the name failed), and left dashless codes dashless (404).
+      - regex: ^.*?([A-Za-z]{2,6})[-_ ]*(\d{2,5}).*$
+        with: $1-$2
   scraper: sceneScraper
 sceneByURL:
   - action: scrapeXPath


### PR DESCRIPTION
## Summary
`sceneByFragment` turns the filename into a `javbus.com/<code>` lookup, so the cleaned filename must end up as the **exact** code (e.g. `DDT-246`). The current `queryURLReplace` expression mishandles several common filename shapes and sends malformed or wrong codes to javbus (→ 404 / wrong title). This replaces it with a small, well-scoped pipeline. **Pristine `LETTERS-DIGITS` names are unaffected** — the change is strictly additive in coverage.

## How it works today
```yaml
queryURL: https://www.javbus.com/{filename}
queryURLReplace:
  filename:
    - regex: -JG\d
      with: ""
    - regex: (.*[^a-zA-Z0-9])*([a-zA-Z-]+\d+)(.+)
      with: $2
```
The `{filename}` becomes the URL path segment, so the second rule is responsible for reducing a real-world filename down to the bare code.

## Problems (all engine-independent)
1. **No hyphen normalization** — `$2` keeps the token verbatim, so `DDT246` → `javbus.com/DDT246` and `GTJ--010` → `…/GTJ--010`; javbus expects `DDT-246` / `GTJ-010`.
2. **Greedy selection grabs the wrong token** when a name has more than one code-like token — e.g. a trailing disc tag (`…-CD1`) or a leading site tag.
3. **Whitespace-separated codes don't match at all** (`[a-zA-Z-]+\d+` needs the letters adjacent to the digits), so the raw filename is sent.

Current vs. proposed on representative names (JAV codes are public catalog identifiers):

| filename | current → path | result | proposed |
|---|---|---|---|
| `DDT-246.mp4` | `DDT-246` | ✅ ok | `DDT-246` (unchanged) |
| `DDT246.mp4` | `DDT246` | ❌ 404 | `DDT-246` |
| `DDT 246.mp4` | `DDT 246.mp4` | ❌ 404 | `DDT-246` |
| `[GTJ--010] Title.wmv` | `-010` | ❌ 404 | `GTJ-010` |
| `DDT-246 … Gero-CD1 ….wmv` | `CD1` | ❌ wrong title | `DDT-246` |
| `JAV24-2.HD-DDT284.wmv` | `DDT284` | ❌ 404 | `DDT-284` |

## The fix
```yaml
queryURLReplace:
  filename:
    - regex: -JG\d
      with: ""
    # drop disc/site junk tokens that look like codes (CD1, DISC2, JAV24, …)
    - regex: (?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b
      with: " "
    # extract the first LETTERS-DIGITS token, normalized to LETTERS-DIGITS
    - regex: ^.*?([A-Za-z]{2,6})[-_ ]*(\d{2,5}).*$
      with: $1-$2
```
- **Lazy `.*?`** selects the *first* code-like token — JAV filenames lead with the code, so first-token is correct (and avoids the trailing-`CD1` trap).
- **`[-_ ]*`** absorbs zero, one, or many separators → handles dashless (`DDT246`), spaced (`DDT 246`), underscored, and double-dash (`[GTJ--010]`).
- **`$1-$2`** emits the canonical hyphenated form javbus needs.
- The junk-strip runs **before** extraction so a leading `JAV24` / trailing `CD1` can't shadow the real code.

## Why the junk list is safe
`CD` / `DVD` / `DISC` / `PART` are disc/part indicators and `JAV` is a common site tag — **none are real JAV studio-label prefixes**, so no legitimate code is removed. It only matches a **1–3 digit** suffix (`CD1`, `DISC2`), never a 3+ digit product number. Trivial to trim the list if preferred.

## Compatibility & verification
- No lookahead/backreferences — works in Go's RE2 (Stash's regex engine).
- The **proposed** column was verified against **live javbus.com**: `DDT-246`, `GTJ-010`, and `DDT-284` each resolve to the correct title/studio/date.

## Related
Companion to #2786 (the same normalization for `javdb.yml`); the two are independent and can be reviewed separately. The two pure bug-fix aspects (first-token selection, whitespace handling) and the junk-strip enhancement can be split into separate commits/PRs if you'd prefer a narrower change.
