### PR TITLE
Add gothgirlsvip.com support to Spizoo scraper.

### DIFF
--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -6,6 +6,7 @@ sceneByURL:
       - drdaddypov.com/updates/
       - firstclasspov.com/updates/
       - gothgirlfriends.com/updates/
+      - gothgirlfriendsvip.com/updates
       - mrluckylife.com/updates/
       - mrluckylife.com/members/
       - mrluckypov.com/updates/
@@ -69,6 +70,7 @@ xPathScrapers:
                 drdaddypov: Dr. Daddy POV
                 firstclasspov: First Class POV
                 gothgirlfriends: Goth Girlfriends
+                gothgirlfriendsvip: Goth GirlfriendsVIP
                 mrluckylife: Mr. LuckyLIFE
                 mrluckypov: Mr. LuckyPOV
                 mrluckyraw: Mr. LuckyRaw
@@ -94,4 +96,4 @@ driver:
           Domain: ".mrluckylife.com"
           Path: "/"
           Value: ""
-# Last Updated August 11, 2024
+# Last Updated July 4, 2026


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [X] sceneByQueryFragment
- [X] sceneByURL

## Examples to test

[Scene page](https://www.gothgirlfriendsvip.com/updates/Asteria-Jade-Fills-The-Room-With-Moans-While-Getting-Fucked.html) / [Scrape](https://stashdb.org/edits/019f2bbb-b79f-78fe-9527-e5a3cfab0d79)

## Short description

Adds URL pattern and studio name mapping for gothgirlfriendsvip.com