### PR TITLE
Trim "Tour - " prefix from RawAttack titles

### DIFF
--- a/scrapers/Spizoo.yml
+++ b/scrapers/Spizoo.yml
@@ -44,8 +44,10 @@ xPathScrapers:
       Title:
         selector: //div[@class="title" or @class="row"]//h1 | //div[@class="title-trailer"]//h2 | //h2[contains(@class, "titular")] | //title
         postProcess:
-          # RawAttack titles have a trailing dash and space
+          # RawAttack titles have leading "Tour - " and trailing " - "
           - replace:
+              - regex: ^Tour\s\-\s*
+                with:
               - regex: \s\-\s*$
                 with:
       Date:


### PR DESCRIPTION
## Scraper type(s)
- [X] sceneByQueryFragment
- [X] sceneByURL

## Examples to test

https://www.rawattack.com/updates/Blonde-Bambi-Blitz-Asks-For-Help.html

Before: `Tour - Blonde Bambi Blitz Asks For Help`
After: `Blonde Bambi Blitz Asks For Help`

## Short description

Among the various title sub-selectors, when scraping RawAttack, the scraper falls back to using the page `<title>`. When logged out, it has this "Tour" prefix, which had been getting picked up.