### PR TITLE
Add support for ricksyroom.com/bts

### DIFF
--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -75,6 +75,7 @@ studio_map = {
     "queercrush.com": "QueerCrush",
     "red-xxx.com": "Red-XXX",
     "rickysroom.com": "Ricky's Room",
+    "members.rickysroom.com": "Ricky's Room",
     "s3xus.com": "S3XUS",
     "seska.com": "Seska",
     "sextapes.com": "SexTapes",

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -67,6 +67,7 @@ sceneByURL:
       - queercrush.com/videos
       - red-xxx.com/scenes
       - rickysroom.com/videos
+      - rickysroom.com/bts
       - s3xus.com/scenes
       - sextapes.com/videos
       - sexymodernbull.com/videos


### PR DESCRIPTION
## Scraper type(s)
- [X] sceneByURL

## Examples to test

- https://rickysroom.com/bts/bts-party-in-willows-room
- https://rickysroom.com/bts/bts-satisfying-the-senses
- Full listing at https://rickysroom.com/bts

## Short description

Adds /bts pattern to url pattern matching list. Maps `members.` domain to the studio name, as this is what the scraper gets, similar to other sites' bts scrapers mappings.
