### PR TITLE
Add United Content scraper

### DIFF
--- a/scrapers/UnitedContent/UnitedContent.py
+++ b/scrapers/UnitedContent/UnitedContent.py
@@ -1,0 +1,104 @@
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+
+import requests
+
+from py_common import log
+from py_common.types import ScrapedScene
+from py_common.util import scraper_args
+
+API_URL = "https://api.fundorado.com/api/videodetail/{}"
+IMAGE_CDN = "https://s01.uni73d.net"
+PARENT_STUDIO = "United Content"
+
+STUDIOS = {
+    "orgasmabuse.com": "Orgasm Abuse",
+    "rfmovies.com": "RF studio",
+    "taworship.com": "TA Worship",
+    "texasbukkake.com": "Texas Bukkake",
+    "tickleabuse.com": "Tickle Abuse",
+}
+
+SCENE_URL = re.compile(r"https?://(?:www\.)?([\w.-]+)/video/(\d+)")
+
+# The API serialises publication dates as midnight in Europe/Amsterdam, which is
+# always 22:00 or 23:00 UTC on the previous day depending on daylight saving.
+AMSTERDAM_MAX_OFFSET = timedelta(hours=2)
+
+
+def localized(field: dict | None) -> str:
+    if not field:
+        return ""
+    return field.get("en") or next(iter(field.values()), "")
+
+
+def release_date(timestamp: str | None) -> str | None:
+    if not timestamp:
+        return None
+    published = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    if published.year < 1970:
+        return None
+    return (published + AMSTERDAM_MAX_OFFSET).date().isoformat()
+
+
+def cover_image(video: dict) -> str | None:
+    for key in ("artwork", "artwork_f16", "cover"):
+        url = (video.get(key) or {}).get("large")
+        if url:
+            return url if url.startswith("http") else IMAGE_CDN + url
+    return None
+
+
+def scene_from_url(url: str) -> ScrapedScene | None:
+    match = SCENE_URL.match(url)
+    if not match:
+        log.error(f"Not a supported scene URL: {url}")
+        return None
+
+    hostname, video_id = match.group(1).lower(), match.group(2)
+    studio = STUDIOS.get(hostname)
+    if not studio:
+        log.error(f"Unknown United Content site: {hostname}")
+        return None
+
+    response = requests.get(API_URL.format(video_id), timeout=10)
+    response.raise_for_status()
+    video = response.json().get("video")
+    if not video:
+        log.error(f"No scene found with id {video_id}")
+        return None
+
+    scene: ScrapedScene = {
+        "title": localized(video.get("title")),
+        "details": localized(video.get("description")),
+        "code": str(video["id"]),
+        "urls": [f"https://{hostname}/video/{video['id']}/{video['slug']}"],
+        "studio": {"name": studio, "parent": {"name": PARENT_STUDIO}},
+        "performers": [{"name": actor["name"]} for actor in video.get("actors", [])],
+        "tags": [{"name": localized(genre.get("title"))} for genre in video.get("genres", [])],
+    }
+
+    if date := release_date(video.get("publication_date")):
+        scene["date"] = date
+    if image := cover_image(video):
+        scene["image"] = image
+    if duration := (video.get("meta") or {}).get("duration_seconds"):
+        scene["duration"] = duration
+
+    return scene
+
+
+if __name__ == "__main__":
+    op, args = scraper_args()
+
+    result = None
+    match op, args:
+        case "scene-by-url", {"url": url} if url:
+            result = scene_from_url(url)
+        case _:
+            log.error(f"Not implemented: Operation: {op}, arguments: {json.dumps(args)}")
+            sys.exit(1)
+
+    print(json.dumps(result))

--- a/scrapers/UnitedContent/UnitedContent.yml
+++ b/scrapers/UnitedContent/UnitedContent.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=../../validator/scraper.schema.json
+name: United Content
+# requires: py_common
+sceneByURL:
+  - action: script
+    url:
+      - orgasmabuse.com/video/
+      - rfmovies.com/video/
+      - taworship.com/video/
+      - texasbukkake.com/video/
+      - tickleabuse.com/video/
+    script:
+      - python
+      - UnitedContent.py
+      - scene-by-url
+# Last Updated July 9, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://orgasmabuse.com/video/304276/orgasm-train-jae-lynn
- https://rfmovies.com/video/422379/foot-fetish-lovers-dark-ariels-new-victim-arcadia
- https://taworship.com/video/307236/sleepy-alex-coal
- https://texasbukkake.com/video/476833/bukkake-facials-for-chantelle-fox-and-hanna-shaw
- https://tickleabuse.com/video/488095/tickle-heaven-with-elena-james-and-valentina-boux

## Short description

Adds a scene scraper for the five United Content sites: Orgasm Abuse, RF studio, TA Worship, Texas Bukkake and Tickle Abuse.

All five are the same React SPA served over a shared JSON API, so the page source is an empty `<div id="root">` and there's nothing to select on. The scraper reads `api.fundorado.com/api/videodetail/{id}` instead, keyed off the numeric ID in the URL. The endpoint needs no auth, headers or cookies.

Two notes on why it looks the way it does:

**Studio comes from the URL hostname.** The API's own studio field can't be used: a scene on tickleabuse.com credits "Taworship.com", and one on orgasmabuse.com credits an outside production company ("DirtyDeesProd"). The `labels` field is no better, since orgasmabuse, taworship and tickleabuse all share the same five label IDs, and `meta.supplier` varies between "United content", "UC Default" and "JOHN". The hostname is the only reliable signal, so each site maps to a fixed studio under a shared `United Content` parent.

**Python rather than YAML**, which I'd otherwise have preferred here. `publication_date` is midnight Europe/Amsterdam serialised as UTC, so it always lands at 22:00 or 23:00 on the *previous* day (confirmed across a 680-timestamp sample; the API's own "no date" sentinel, `1899-12-31T23:40:28Z`, is 1900-01-01 in Amsterdam local mean time). Taking the UTC date verbatim would date every scene a day early, and `parseDate` can't shift timezones while `subtractDays` subtracts from today rather than from the value. The scraper converts, and omits the sentinel instead of emitting an 1899 date.

Scraping the API also avoids the sites' `filter_bad_words` setting, which censors rendered titles (`******* ******s for Chantelle Fox and Hanna Shaw`) where the API returns them clean.

Tested against 95 real scenes sampled across all five sites: 94 scrape clean, and the one failure is a genuine API 404 on a stale search-index entry. No malformed dates, no blank tag or performer names, and all sampled cover images resolve. Passes `validate.js`.