### PR TITLE
VRPorn: update selectors

### DIFF
--- a/scrapers/VRPorn.yml
+++ b/scrapers/VRPorn.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../validator/scraper.schema.json
-name: "VRPorn"
+name: VRPorn
 
 sceneByURL:
   - action: scrapeXPath
@@ -22,12 +22,23 @@ xPathScrapers:
       Date:
         selector: //span[contains(@class,"ui-player-title__sub-text")][@data-allow-mismatch]
         postProcess:
-          - parseDate: Jan 02 2006
+          - parseDate: Jan 2 2006
       Details:
-        selector: //div[@class="app-comment-item__content-textarea"]/text()
+        selector: >
+          //div[@class="app-comment-item__content-textarea"]/text()
+          |
+          //div[@class="ui-detail-video__content-inner"]
         concat: "\n"
       Tags:
-        Name: //div[contains(@class,"tags")]//a/text()
+        Name:
+          selector: >
+            //div[contains(@class,"tags")]//a/text()
+            |
+            //a[contains(@class, "btn-tag")]/text()
+          postProcess:
+            - replace:
+                - regex: Adult VR
+                  with: Virtual Reality
       Performers:
         Name: //a[@class="ui-card-model__name"]/text()
       Studio:
@@ -41,4 +52,4 @@ xPathScrapers:
     scene:
       Title: $card/header/a/@title
       URL: $card/header/a/@href
-# Last Updated October 17, 2025
+# Last Updated July 13, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://vrporn.com/trans-vr-solo-shakira-brazil-teases-and-fucks-herself-with-toys/
- https://vrporn.com/trans-erotic-bedtime-tales-2/
- https://vrporn.com/unveiling-her-dark-side/

## Short description

Some of the CSS classes appear to have changed. I added the current ones I could find, while keeping the old ones in case the old
ones exist for some scenes.