### PR TITLE
SexLikeReal: fix scene performer scraping

### DIFF
--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -67,7 +67,7 @@ xPathScrapers:
       Tags:
         Name: //div/ul/li/a/span | //div[@style]/p/a[starts-with(@href,"/tags")]/text()
       Performers:
-        Name: //a[starts-with(@href,"/pornstars/")]/text()
+        Name: //a[starts-with(@href,"/pornstars/")]//text()
       Studio:
         Name:
           selector: //h2/a[starts-with(@href,"/studios/")]/text()
@@ -113,4 +113,4 @@ xPathScrapers:
 #           Domain: .www.sexlikereal.com
 #           Path: /
 #           Value: "true"
-# Last Updated May 5, 2026
+# Last Updated July 14, 2026

--- a/scrapers/SexLikeReal.yml
+++ b/scrapers/SexLikeReal.yml
@@ -12,7 +12,7 @@ sceneByQueryFragment:
 sceneByURL:
   - action: scrapeXPath
     url:
-      - sexlikereal.com
+      - sexlikereal.com/scenes/
     scraper: sceneScraper
 
 # as of 2025-10-24, code link does not work, either at /scenes or /
@@ -67,7 +67,7 @@ xPathScrapers:
       Tags:
         Name: //div/ul/li/a/span | //div[@style]/p/a[starts-with(@href,"/tags")]/text()
       Performers:
-        Name: //a[starts-with(@href,"/pornstars/")]//text()
+        Name: //a[starts-with(@href,"/pornstars/")]/span/text()
       Studio:
         Name:
           selector: //h2/a[starts-with(@href,"/studios/")]/text()

--- a/scrapers/SexLikeReal_Trans.yml
+++ b/scrapers/SexLikeReal_Trans.yml
@@ -12,7 +12,7 @@ sceneByQueryFragment:
 sceneByURL:
   - action: scrapeXPath
     url:
-      - sexlikereal.com/trans/
+      - sexlikereal.com/trans/scenes/
     scraper: sceneScraper
 
 # as of 2025-10-24, code link does not work, either at /scenes or /
@@ -67,7 +67,7 @@ xPathScrapers:
       Tags:
         Name: //div/ul/li/a/span
       Performers:
-        Name: //a[starts-with(@href,"/trans/pornstars/")]/text()
+        Name: //a[starts-with(@href,"/trans/pornstars/")]/span/text()
       Studio:
         Name:
           selector: //h3/a[starts-with(@href,"/trans/studios/")]/text()
@@ -113,4 +113,4 @@ xPathScrapers:
 #           Domain: .www.sexlikereal.com
 #           Path: /
 #           Value: "true"
-# Last Updated December 1, 2025
+# Last Updated July 14, 2026


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://www.sexlikereal.com/scenes/naked-sunday-with-milka-way-90fps-87425
- https://www.sexlikereal.com/scenes/busty-luna-doll-wants-to-fuck-83262
- https://www.sexlikereal.com/trans/scenes/just-for-you-2493

## Short description

The performer name text is now nested in a span tag within the a tag.
