### PR TITLE
fix(hstream): update selectors for scene scraper

### DIFF
--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -80,4 +80,4 @@ xPathScrapers:
                 with: $1.webp
 
       URL: //meta[@property="og:url"]/@content
-# Last Updated May 29, 2025
+# Last Updated July 18, 2026

--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -62,7 +62,7 @@ xPathScrapers:
           - parseDate: 2006-01-02
       Details: //p[contains(text(), "Description")]/following-sibling::p
       Tags:
-        Name: //li[@class="inline-block p-1"]/a/text()
+        Name: //a[contains(@href, "tags")]
       Studio:
         Name: (//a[contains(@href, "studios")])[1]
       Image:

--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -60,7 +60,7 @@ xPathScrapers:
               - regex: \s*(\d{4}-\d{2}-\d{2}).*
                 with: $1
           - parseDate: 2006-01-02
-      Details: //p[contains(text(), "Description")]/following-sibling::p
+      Details: //h2[contains(text(), "Description")]/following-sibling::p
       Tags:
         Name: //a[contains(@href, "tags")]
       Studio:

--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -2,11 +2,11 @@ name: hstream
 sceneByName:
   action: scrapeXPath
   queryURL: https://hstream.moe/search?search={}
-  scraper: sceneSearch 
+  scraper: sceneSearch
 sceneByQueryFragment:
   action: scrapeXPath
-  queryURL: "{url}"
-  scraper: sceneScraper     
+  queryURL: '{url}'
+  scraper: sceneScraper
 
 sceneByFragment:
   action: scrapeXPath
@@ -18,7 +18,7 @@ sceneByFragment:
         with: $1
       # Remove non-word characters
       - regex: \W+
-        with: "-"
+        with: '-'
       # Remove leading zeroes
       - regex: 0+(\d)
         with: $1
@@ -29,17 +29,17 @@ sceneByURL:
       - hstream.moe/hentai/
     scraper: sceneScraper
 xPathScrapers:
-  sceneSearch:              
-     scene:
-      URL:   //div[contains(@class,'relative')]/a/@href
+  sceneSearch:
+    scene:
+      URL: //div[contains(@class,'relative')]/a/@href
       Title:
         selector: //div[contains(@class,'relative')]/a/img/@alt
       Image:
         selector: //div[contains(@class,'relative')]/a/img/@src
         postProcess:
-          - replace:          
+          - replace:
               # 1) make relative paths absolute
-              - regex: '^/'                                     
+              - regex: '^/'
                 with: https://hstream.moe/
               # 2) turn “…/gallery‑…” into “…/cover‑…”
               - regex: '/gallery-'
@@ -65,16 +65,16 @@ xPathScrapers:
         Name: //li[@class="inline-block p-1"]/a/text()
       Studio:
         Name: (//a[contains(@href, "studios")])[1]
-      Image: 
+      Image:
         selector: //meta[@property="og:image"]/@content
         postProcess:
           - replace:
-                  # 1) gallery  ➜  cover
-                  - regex: gallery
-                    with: cover
-                  # 2) trim the trailing “-0” (or “-1”, etc.)
-                  - regex: (-ep-\d+)-\d+\.webp$
-                    with: $1.webp    
+              # 1) gallery  ➜  cover
+              - regex: gallery
+                with: cover
+              # 2) trim the trailing “-0” (or “-1”, etc.)
+              - regex: (-ep-\d+)-\d+\.webp$
+                with: $1.webp
 
       URL: //meta[@property="og:url"]/@content
 # Last Updated May 29, 2025

--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -16,7 +16,10 @@ sceneByFragment:
       # Strip out everything after the first [
       - regex: ([^[]+)\s.*
         with: $1
-      # Remove non-word characters
+      # Remove apostrophes
+      - regex: "'"
+        with: ''
+      # Replace non-word characters with hyphen
       - regex: \W+
         with: '-'
       # Remove leading zeroes

--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -31,11 +31,11 @@ sceneByURL:
 xPathScrapers:
   sceneSearch:
     scene:
-      URL: //div[contains(@class,'relative')]/a/@href
+      URL: //div[contains(@class,'p-1')]/a[contains(@href, "hentai")]/@href
       Title:
-        selector: //div[contains(@class,'relative')]/a/img/@alt
+        selector: //div[contains(@class,'relative')]/img/@alt
       Image:
-        selector: //div[contains(@class,'relative')]/a/img/@src
+        selector: //div[contains(@class,'relative')]/img/@src
         postProcess:
           - replace:
               # 1) make relative paths absolute


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://hstream.moe/hentai/lamour-fou-de-lautomate-2
L'amour fou de l'automate

## Short description

this PR updates the hstream.moe scraper to account for site changes
