### PR TITLE
Add GayRoom scraper

### DIFF
--- a/scrapers/GayRoom.yml
+++ b/scrapers/GayRoom.yml
@@ -1,0 +1,265 @@
+name: GayRoom
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - bathhousebait.com/video/
+      - boysdestroyed.com/video/
+      - damnthatsbig.com/video/
+      - gaycastings.com/video/
+      - gaycreeps.com/video/
+      - gayroom.com/video/
+      - gayviolations.com/video/
+      - manroyale.com/video/
+      - massagebait.com/video/
+      - menpov.com/video/
+      - officecock.com/video/
+      - outhim.com/video/
+      - showerbait.com/video/
+      - thickandbig.com/video/
+    scraper: sceneScraper
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - bathhousebait.com/models/
+      - boysdestroyed.com/models/
+      - damnthatsbig.com/models/
+      - gaycastings.com/models/
+      - gaycreeps.com/models/
+      - gayroom.com/models/
+      - gayviolations.com/models/
+      - manroyale.com/models/
+      - massagebait.com/models/
+      - menpov.com/models/
+      - officecock.com/models/
+      - outhim.com/models/
+      - showerbait.com/models/
+      - thickandbig.com/models/
+    scraper: performerScraper
+xPathScrapers:
+  sceneScraper:
+    common:
+      $nuxtData: //script[@id="__NUXT_DATA__"]/text()
+    scene:
+      Title:
+        selector: $nuxtData
+        postProcess:
+          - javascript: &locateRelease |
+              // Every site in the network is the same Nuxt SPA; the page
+              // renders no data into the DOM itself. Instead the data is
+              // SSR'd as a flattened, reference-based JSON array (devalue
+              // format) in a __NUXT_DATA__ script tag. Unflatten it, then
+              // find the single release object for the current page (as
+              // opposed to the list of recommended releases, which is also
+              // present in the payload).
+              function resolve(arr, i) {
+                if (typeof i !== "number") return i;
+                var v = arr[i];
+                if (v === null || typeof v !== "object") return v;
+                if (Array.isArray(v)) {
+                  if (typeof v[0] === "string") {
+                    return v[0] === "EmptyRef" ? null : resolve(arr, v[1]);
+                  }
+                  return v.map(function (x) {
+                    return resolve(arr, x);
+                  });
+                }
+                var obj = {};
+                for (var k in v) obj[k] = resolve(arr, v[k]);
+                return obj;
+              }
+              if (!value) return "";
+              var root = resolve(JSON.parse(value), 0);
+              var release = null;
+              for (var k in root.data) {
+                var v = root.data[k];
+                if (v && v.title && !v.items) {
+                  release = v;
+                  break;
+                }
+              }
+              return release ? JSON.stringify(release) : "";
+          - javascript: |
+              if (!value) return "";
+              return JSON.parse(value).title || "";
+      Details:
+        selector: $nuxtData
+        postProcess:
+          - javascript: *locateRelease
+          - javascript: |
+              if (!value) return "";
+              return JSON.parse(value).description || "";
+      URLs:
+        selector: $nuxtData
+        postProcess:
+          - javascript: *locateRelease
+          - javascript: |
+              if (!value) return [];
+              // Nearly every release is also mirrored on gayroom.com (the
+              // network's flagship/hub site) under the same slug, even when
+              // it's not the release's own site.
+              var release = JSON.parse(value);
+              var urls = ["https://" + release.site.slug + ".com/video/" + release.cachedSlug];
+              if (release.site.slug !== "gayroom") {
+                urls.push("https://gayroom.com/video/" + release.cachedSlug);
+              }
+              return urls;
+        split: ","
+      Date:
+        selector: $nuxtData
+        postProcess:
+          - javascript: *locateRelease
+          - javascript: |
+              if (!value) return "";
+              var releasedAt = JSON.parse(value).releasedAt;
+              return releasedAt ? releasedAt.substring(0, 10) : "";
+      Image:
+        selector: $nuxtData
+        postProcess:
+          - javascript: *locateRelease
+          - javascript: |
+              if (!value) return "";
+              var release = JSON.parse(value);
+              return release.posterUrl || release.thumbUrl || "";
+      Tags:
+        Name:
+          selector: $nuxtData
+          postProcess:
+            - javascript: *locateRelease
+            - javascript: |
+                if (!value) return [];
+                return JSON.parse(value).tags || [];
+          split: ","
+      Performers:
+        Name:
+          selector: $nuxtData
+          postProcess:
+            - javascript: *locateRelease
+            - javascript: |
+                if (!value) return [];
+                return (JSON.parse(value).actors || []).map(function (a) {
+                  return a.name;
+                });
+          split: ","
+        URLs:
+          selector: $nuxtData
+          postProcess:
+            - javascript: *locateRelease
+            - javascript: |
+                if (!value) return [];
+                // A performer's profile only resolves on the same domain as
+                // the release itself, not necessarily the sponsor's domain
+                // (releases are frequently cross-posted across the network).
+                var release = JSON.parse(value);
+                var host = release.site.slug + ".com";
+                return (release.actors || []).map(function (a) {
+                  return "https://" + host + "/models/" + a.cached_slug;
+                });
+          split: ","
+      Studio:
+        Name:
+          selector: $nuxtData
+          postProcess:
+            - javascript: *locateRelease
+            - javascript: |
+                if (!value) return "";
+                return JSON.parse(value).sponsor.name || "";
+        URL:
+          selector: $nuxtData
+          postProcess:
+            - javascript: *locateRelease
+            - javascript: |
+                if (!value) return "";
+                return "https://" + JSON.parse(value).sponsor.cachedSlug + ".com/";
+
+  performerScraper:
+    common:
+      $nuxtData: //script[@id="__NUXT_DATA__"]/text()
+    performer:
+      Name:
+        selector: $nuxtData
+        postProcess:
+          - javascript: &locatePerformer |
+              function resolve(arr, i) {
+                if (typeof i !== "number") return i;
+                var v = arr[i];
+                if (v === null || typeof v !== "object") return v;
+                if (Array.isArray(v)) {
+                  if (typeof v[0] === "string") {
+                    return v[0] === "EmptyRef" ? null : resolve(arr, v[1]);
+                  }
+                  return v.map(function (x) {
+                    return resolve(arr, x);
+                  });
+                }
+                var obj = {};
+                for (var k in v) obj[k] = resolve(arr, v[k]);
+                return obj;
+              }
+              if (!value) return "";
+              var root = resolve(JSON.parse(value), 0);
+              for (var k in root.data) {
+                var v = root.data[k];
+                if (v && v.name && !v.items) {
+                  return JSON.stringify(v);
+                }
+              }
+              return "";
+          - javascript: |
+              if (!value) return "";
+              return JSON.parse(value).name || "";
+      Gender:
+        selector: $nuxtData
+        postProcess:
+          - javascript: *locatePerformer
+          - javascript: |
+              if (!value) return "";
+              var gender = JSON.parse(value).gender;
+              return { guy: "Male", girl: "Female" }[gender] || "";
+      URLs:
+        # The performer JSON payload (unlike a release) doesn't carry a
+        # "site" field, so the current domain can't be read from the data.
+        # Instead read it off the favicon path, which every site in the
+        # network serves as /images/sites/{slug}/{slug}-favicon.ico.
+        selector: $nuxtData | //link[@rel="icon"]/@href
+        concat: "@@SPLIT@@"
+        postProcess:
+          - javascript: |
+              function resolve(arr, i) {
+                if (typeof i !== "number") return i;
+                var v = arr[i];
+                if (v === null || typeof v !== "object") return v;
+                if (Array.isArray(v)) {
+                  if (typeof v[0] === "string") {
+                    return v[0] === "EmptyRef" ? null : resolve(arr, v[1]);
+                  }
+                  return v.map(function (x) {
+                    return resolve(arr, x);
+                  });
+                }
+                var obj = {};
+                for (var k in v) obj[k] = resolve(arr, v[k]);
+                return obj;
+              }
+              if (!value) return [];
+              var parts = value.split("@@SPLIT@@");
+              var faviconPart = parts[0].indexOf("/images/sites/") === 0 ? parts[0] : parts[1] || "";
+              var jsonPart = faviconPart === parts[0] ? parts[1] || "" : parts[0];
+              var root = resolve(JSON.parse(jsonPart), 0);
+              var performer = null;
+              for (var k in root.data) {
+                var v = root.data[k];
+                if (v && v.name && !v.items) {
+                  performer = v;
+                  break;
+                }
+              }
+              if (!performer) return [];
+              var siteMatch = faviconPart.match(/\/images\/sites\/([^/]+)\//);
+              var site = siteMatch ? siteMatch[1] : "";
+              var urls = [];
+              if (site) urls.push("https://" + site + ".com/models/" + performer.cachedSlug);
+              if (site !== "gayroom") urls.push("https://gayroom.com/models/" + performer.cachedSlug);
+              return urls;
+        split: ","
+# No performer images: model pages don't expose an actual profile photo
+# (only a still frame from one of their scenes, or null).


### PR DESCRIPTION
## Summary
- Adds an xPath-based scraper for the [GayRoom network](https://gayroom.com/) (scene + performer), covering parent gayroom.com, and 13 sub sites: bathhousebait.com, boysdestroyed.com, damnthatsbig.com, gaycastings.com, gaycreeps.com, gayviolations.com, manroyale.com, massagebait.com, menpov.com, officecock.com, outhim.com, showerbait.com, thickandbig.com

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples used in testing
- [x] Verified scene scraping against:
  - https://boysdestroyed.com/video/afternoon-swim
  - https://boysdestroyed.com/video/better-with-a-friend
  - https://gaycreeps.com/video/jocks-and-cocks
  - https://manroyale.com/video/house-arrest
  - https://gaycastings.com/video/josh
  - https://bathhousebait.com/video/hot-steamy-orgy
  - https://damnthatsbig.com/video/give-it-to-me-bro
  - https://gayviolations.com/video/break-time-blowjob
  - https://menpov.com/video/free-ballin-at-the-park
  - https://officecock.com/video/business-meeting-fornication
  - https://outhim.com/video/gym-locker-room-group-fucking
  - https://showerbait.com/video/house-kreeping
  - https://thickandbig.com/video/my-straight-roommate
  - https://massagebait.com/video/5-star-massage
  - https://gayroom.com/video/backseat-suck (native)
  - https://gayroom.com/video/michael-s-holiday-deep-warming (mirror of a boysdestroyed.com scene)
- [x] Verified performer scraping against:
  - https://boysdestroyed.com/models/alec-grey
  - https://gaycreeps.com/models/jordan-boss
  - https://manroyale.com/models/jimmy-clay--11
  - https://gaycastings.com/models/josh--2
  - https://bathhousebait.com/models/shane-frost--23
  - https://damnthatsbig.com/models/brenner-bolton
  - https://gayviolations.com/models/ricky-larkin--2
  - https://menpov.com/models/joey-moriarty
  - https://officecock.com/models/jayden-grey--2
  - https://outhim.com/models/tyler-sweet--8
  - https://showerbait.com/models/tom-bentley
  - https://thickandbig.com/models/dylan-knight
  - https://massagebait.com/models/arad-winwin
  - https://gayroom.com/models/antonio-paul (native)
  - https://gayroom.com/models/michael-angel (mirror of a boysdestroyed.com performer)


## Notes
- All 14 sites share the same Nuxt SPA codebase; scene/model pages render no data into the DOM itself, so the scraper parses the embedded `__NUXT_DATA__` payload (a devalue-format flattened JSON array).
- Studio is derived from the release's sub-studio (the true content owner) rather than the browsing domain, since scenes are frequently cross-posted across the network. Helpful in the case of using a gayroom.com link and its main published site is Men POV.
- Scene URLs includes both the native page URL and the equivalent gayroom.com mirrored link, since every release is also mirrored there under the same slug.
- Performer URLs similarly includes both the native page and the gayroom.com mirror.
- Performer Image is intentionally omitted, since model pages don't expose a profile photo ("Image Coming Soon" across the profiles I went through).