### PR TITLE
Add BeefcakeHunter scraper

### DIFF
--- a/scrapers/BeefcakeHunter.yml
+++ b/scrapers/BeefcakeHunter.yml
@@ -1,0 +1,59 @@
+name: BeefcakeHunter
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - beefcakehunter.com/video/
+    scraper: sceneScraper
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //h2[@class="sunday-funday-video-title"]
+      Details:
+        selector: //div[@id="dslc-theme-content-inner"]//p
+        concat: "\n\n"
+      Date:
+        selector: //meta[@property="article:published_time"]/@content
+        postProcess:
+          - replace:
+              - regex: ^(\d{4}-\d{2}-\d{2}).*
+                with: $1
+      Image: //video[@class="wp-video-shortcode"]/@poster
+      Tags:
+        Name:
+          # The site renders no clickable tag (or performer) links anywhere
+          # on the scene page; the only signal is this CSS class dump, which
+          # mixes descriptive tags and performer names in the same flat
+          # taxonomy with no reliable way to tell them apart per-page. So
+          # everything here - including performer names - comes through as
+          # a Tag.
+          selector: //div[contains(@class, "t7-video-single")]/@class
+          postProcess:
+            - javascript: |
+                if (!value) return [];
+                return value
+                  .split(/\s+/)
+                  .filter(function (c) {
+                    return c.indexOf("video-category-") === 0;
+                  })
+                  .map(function (c) {
+                    return c
+                      .replace("video-category-", "")
+                      .split("-")
+                      .map(function (w) {
+                        return w.charAt(0).toUpperCase() + w.slice(1);
+                      })
+                      .join(" ");
+                  });
+          split: ","
+      Performers:
+        Name:
+          # Victor is the site's host/narrator and is on-screen having sex
+          # with the guest model in every scene, so he's always credited.
+          # The guest model can't be reliably identified (see Tags above),
+          # so is intentionally left out of Performers.
+          fixed: Victor
+      Studio:
+        Name:
+          fixed: Beefcake Hunter
+        URL:
+          fixed: https://beefcakehunter.com/


### PR DESCRIPTION
## Summary
- Adds an xPath-based scraper for [Beefcake Hunter](https://beefcakehunter.com/) (scene only)

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples used in testing
- [x] Verified scene scraping against:
  - https://beefcakehunter.com/video/beefcake-mason-is-back/
  - https://beefcakehunter.com/video/riding-masons-cock/

## Notes
- The site renders no clickable tag or performer links anywhere on the scene page; the only signal is a CSS class dump on the video wrapper (`video-category-{slug}`), which mixes descriptive tags and performer names in the same flat WordPress taxonomy with no reliable way to tell them apart per scene. So all of those tags — including the guest model's name — are scraped as Tags rather than Performers.
- Victor, the site's host/main actor, is on-screen in every scene, so he's always credited as a fixed Performer. The guest models are not.
- `/video-category/{slug}/` pages are just taxonomy archives (identical template to a plain tag archive) with no bio/image data, so no `performerByURL` scraper is included.