### PR TITLE
PMVHaven: add title search and fix metadata arrays

### DIFF
--- a/scrapers/PMVHaven/PMVHaven.yml
+++ b/scrapers/PMVHaven/PMVHaven.yml
@@ -13,11 +13,24 @@ sceneByFragment:
   action: scrapeJson
   queryURL: https://pmvhaven.com/api/videos/phash?hash={phash}&didstance=8
   scraper: resultScraper
+sceneByName:
+  action: scrapeJson
+  queryURL: https://pmvhaven.com/api/videos/search?q={}&limit=20&page=1
+  scraper: sceneSearchScraper
+sceneByQueryFragment:
+  action: scrapeJson
+  queryURL: https://pmvhaven.com/api/videos/{url}
+  queryURLReplace:
+    url:
+      - regex: .*([a-f0-9]{24}).*
+        with: $1
+  scraper: sceneScraper
 
 jsonScrapers:
   sceneScraper:
     scene:
       Title: data.title
+      Code: data._id
       Date:
         selector: data.uploadDate
         postProcess:
@@ -53,9 +66,30 @@ jsonScrapers:
 
       Details: videos.#.description
       Tags:
-        Name: videos.#.tags.@values
+        Name: videos.#.tags|@flatten
       Performers:
-        Name: videos.#.starsTags.@values
+        Name: videos.#.starsTags|@flatten
+      Image: videos.#.thumbnailUrl
+      Studio:
+        Name: videos.#.uploaderUsername
+      URL:
+        selector: videos.#._id
+        postProcess:
+          - replace:
+            - regex: (.*)
+              with: https://pmvhaven.com/video/$1
+  sceneSearchScraper:
+    scene:
+      Title: videos.#.title
+      Code: videos.#._id
+      Date:
+        selector: videos.#.uploadDate
+        postProcess:
+          - replace:
+              - regex: "T(.*)$"
+                with: ""
+          - parseDate: 2006-01-02
+      Details: videos.#.description
       Image: videos.#.thumbnailUrl
       Studio:
         Name: videos.#.uploaderUsername


### PR DESCRIPTION
## Summary

- Add native scene title search through PMVHaven's search API.
- Add query-fragment lookup so selected results resolve through full detail scraping.
- Map title-search results with scalar fields, including code and canonical URL.
- Keep tags and performers out of title-search results.
- Flatten nested tag and performer arrays returned by hash lookups.

## Rationale

PMVHaven title searches can return multiple scenes. Stash's mapped scraper does not associate tags and performers with an individual result index, so including relationships in search results can combine metadata from different scenes. The dedicated scalar-only search mapper prevents this; selecting a result then resolves full relationships through the detail mapper.

Hash lookup responses expose tag and performer values as nested arrays. Flattening them returns individual metadata values instead of serialized arrays.

## Validation

- CommunityScrapers validator passed.
- Title search returned distinct, selectable results with aligned scalar metadata.
- Selected result resolved to full detail metadata, including code, tags, performers, and canonical URL.
- Existing hash lookup regression checks returned separate tag and performer values.

Closes #2823