### PR TITLE
fix(JavBus): add Cookie header to bypass age verification

### DIFF
--- a/scrapers/JavBus.yml
+++ b/scrapers/JavBus.yml
@@ -116,4 +116,6 @@ driver:
       Value: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36
     - Key: Accept-Language
       Value: zh-cn
+    - Key: Cookie
+      Value: over18=18; existmag=mag
 # Last Updated September 17, 2025


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

List a few links/titles/names/filenames/codes to test

## Short description

Describe the general changes
