### PR TITLE
feat: add JavBus Python scraper (supports censored + uncensored search)

### DIFF
--- a/scrapers/JavBusPython/JavBusPython.yml
+++ b/scrapers/JavBusPython/JavBusPython.yml
@@ -1,0 +1,30 @@
+name: "JavBus Python"
+sceneByFragment:
+  action: script
+  script:
+    - python3
+    - javbus.py
+sceneByName:
+  action: script
+  script:
+    - python3
+    - javbus.py
+    - searchName
+sceneByQueryFragment:
+  action: script
+  script:
+    - python3
+    - javbus.py
+    - validSearch
+sceneByURL:
+  - action: script
+    url:
+      - https://www.javbus.com
+      - https://www.seejav.bid
+      - https://www.cdnbus.lol
+      - https://www.dmmbus.lol
+      - https://www.seedmm.cfd
+    script:
+      - python3
+      - javbus.py
+      - validSearch

--- a/scrapers/JavBusPython/JavBusPython.yml
+++ b/scrapers/JavBusPython/JavBusPython.yml
@@ -15,7 +15,6 @@ sceneByQueryFragment:
   script:
     - python3
     - javbus.py
-    - validSearch
 sceneByURL:
   - action: script
     url:
@@ -27,4 +26,3 @@ sceneByURL:
     script:
       - python3
       - javbus.py
-      - validSearch

--- a/scrapers/JavBusPython/javbus.py
+++ b/scrapers/JavBusPython/javbus.py
@@ -1,5 +1,5 @@
 import json, re, sys, urllib.request, ssl
-ctx = ssl._create_unverified_context()
+ctx = ssl.create_default_context()
 H = {"User-Agent": "Mozilla/5.0","Accept-Language": "zh-CN","Cookie": "over18=18; existmag=mag"}
 D = "https://www.javbus.com"
 
@@ -10,7 +10,8 @@ def fetch(url):
         return None
 
 def ec(t):
-    m = re.search(r"([A-Za-z0-9]{2,12})[-_ ]?(\d{2,5})", t, re.IGNORECASE)
+    t = re.sub(r"(?i)\b(CD|DVD|DISC|PART|JAV)[-_ ]?\d{1,3}\b", " ", t or "")
+    m = re.search(r"^.*?([A-Za-z][A-Za-z0-9]*?[A-Za-z])[-_ ]*(\d{2,5}).*$", t)
     return f"{m.group(1).upper()}-{m.group(2)}" if m else None
 
 def ps(h):
@@ -59,14 +60,15 @@ def ss(u):
     r["date"] = m.group(1).strip() if m else ""
     m = re.search("長度[^<]*</span>\\s*([^<\\n]+)", h)
     dv = re.search(r"\d+", m.group(1)) if m else None
-    r["duration"] = int(dv.group()) if dv else 0
+    if dv:
+        r["duration"] = int(dv.group()) * 60
     m = re.search("導演[^<]*</span>[^>]*<a[^>]*>([^<]+)", h)
     r["director"] = m.group(1).strip() if m else ""
     m = re.search("發行商[^<]*</span>\\s*<a[^>]*>([^<]+)", h)
     if not m:
         m = re.search("製作商[^<]*</span>\\s*<a[^>]*>([^<]+)", h)
     r["studio"] = {"name": m.group(1).strip()} if m else {}
-    r["tags"] = [{"name": t} for t in re.findall('class="genre">.*?<a[^>]*>([^<]+)', h, re.DOTALL)]
+    r["tags"] = [{"name": t} for t in re.findall('class="genre"><label>.*?<a[^>]*>([^<]+)', h, re.DOTALL)]
     r["performers"] = [{"name": p} for p in re.findall('class="star-name"[^>]*><a[^>]*>([^<]+)', h, re.DOTALL)]
     m = re.search('class="bigImage"[^>]*><img[^>]*src="([^"]+)"', h)
     if m:
@@ -75,15 +77,18 @@ def ss(u):
     return r
 
 f = json.loads(sys.stdin.read())
-n = f.get("name", "")
-u = f.get("url", "")
-c = ec(n or u)
+mode = sys.argv[1] if len(sys.argv) > 1 else ""
+u = f.get("url") or (f.get("urls") or [""])[0]
+n = f.get("name") or f.get("title") or ""
+c = ec(f.get("code") or n or u)
 
-if len(sys.argv) > 1 and sys.argv[1] == "searchName":
-    print(json.dumps(search(c) if c else []))
+if mode == "searchName":
+    print(json.dumps(search(c) if c else []))   # sceneByName → list
 elif u:
-    print(json.dumps(ss(u)))
+    print(json.dumps(ss(u)))                    # object
 elif c:
-    print(json.dumps(search(c)))
+    hits = search(c)                            # fragment 路径 → 单个对象
+    hit = next((x for x in hits if x.get("code", "").upper() == c.upper()), hits[0] if hits else None)
+    print(json.dumps(ss(hit["url"]) if hit else {}))
 else:
-    print(json.dumps([]))
+    print(json.dumps([] if mode == "searchName" else {}))

--- a/scrapers/JavBusPython/javbus.py
+++ b/scrapers/JavBusPython/javbus.py
@@ -1,0 +1,89 @@
+import json, re, sys, urllib.request, ssl
+ctx = ssl._create_unverified_context()
+H = {"User-Agent": "Mozilla/5.0","Accept-Language": "zh-CN","Cookie": "over18=18; existmag=mag"}
+D = "https://www.javbus.com"
+
+def fetch(url):
+    try:
+        return urllib.request.urlopen(urllib.request.Request(url, headers=H), timeout=15, context=ctx).read().decode("utf-8", errors="replace")
+    except:
+        return None
+
+def ec(t):
+    m = re.search(r"([A-Za-z0-9]{2,12})[-_ ]?(\d{2,5})", t, re.IGNORECASE)
+    return f"{m.group(1).upper()}-{m.group(2)}" if m else None
+
+def ps(h):
+    p = '<a class="movie-box" href="(https?://www\\.javbus\\.com/[^"]+)"[^>]*>(.*?)<div class="photo-info">\\s*<span>(.*?)</span>'
+    r = []
+    for u, b, i in re.findall(p, h, re.DOTALL):
+        mt = re.search(r'^([^<]+)(?:<br|<div)', i, re.DOTALL)
+        title = mt.group(1).strip() if mt else ""
+        cd = re.findall(r'<date>(.*?)</date>', i)
+        code = cd[0] if len(cd) > 0 else ""
+        date = cd[1] if len(cd) > 1 else ""
+        if title:
+            display = f"{code} - {title}" if code else title
+            result = {"title": display, "url": u}
+            if code:
+                result["code"] = code
+            if date:
+                result["date"] = date
+            mi = re.search(r'<img[^>]*src="([^"]+)"', b)
+            if mi:
+                img = mi.group(1)
+                result["image"] = f"https://www.javbus.com{img}" if img.startswith("/") else img
+            r.append(result)
+    return r
+
+def search(c):
+    for p in [f"{D}/search/{c}", f"{D}/uncensored/search/{c}"]:
+        h = fetch(p)
+        if h:
+            r = ps(h)
+            if r:
+                return r
+    return []
+
+def ss(u):
+    h = fetch(u)
+    if not h:
+        return {}
+    r = {}
+    m = re.search(r"<h3>(.*?)</h3>", h)
+    raw = m.group(1).strip() if m else ""
+    r["title"] = re.sub(r'^[A-Za-z0-9]+-[A-Za-z0-9]+\s+', '', raw)
+    m = re.search("識別碼[\\s:]*</span>\\s*<span[^>]*>([^<]+)", h)
+    r["code"] = m.group(1).strip() if m else ""
+    m = re.search("發行日期[^<]*</span>\\s*([^<\\n]+)", h)
+    r["date"] = m.group(1).strip() if m else ""
+    m = re.search("長度[^<]*</span>\\s*([^<\\n]+)", h)
+    dv = re.search(r"\d+", m.group(1)) if m else None
+    r["duration"] = int(dv.group()) if dv else 0
+    m = re.search("導演[^<]*</span>[^>]*<a[^>]*>([^<]+)", h)
+    r["director"] = m.group(1).strip() if m else ""
+    m = re.search("發行商[^<]*</span>\\s*<a[^>]*>([^<]+)", h)
+    if not m:
+        m = re.search("製作商[^<]*</span>\\s*<a[^>]*>([^<]+)", h)
+    r["studio"] = {"name": m.group(1).strip()} if m else {}
+    r["tags"] = [{"name": t} for t in re.findall('class="genre">.*?<a[^>]*>([^<]+)', h, re.DOTALL)]
+    r["performers"] = [{"name": p} for p in re.findall('class="star-name"[^>]*><a[^>]*>([^<]+)', h, re.DOTALL)]
+    m = re.search('class="bigImage"[^>]*><img[^>]*src="([^"]+)"', h)
+    if m:
+        s = m.group(1)
+        r["image"] = f"{D}{s}" if s.startswith("/") else s
+    return r
+
+f = json.loads(sys.stdin.read())
+n = f.get("name", "")
+u = f.get("url", "")
+c = ec(n or u)
+
+if len(sys.argv) > 1 and sys.argv[1] == "searchName":
+    print(json.dumps(search(c) if c else []))
+elif u:
+    print(json.dumps(ss(u)))
+elif c:
+    print(json.dumps(search(c)))
+else:
+    print(json.dumps([]))


### PR DESCRIPTION
## Summary

New **JavBus Python scraper** supporting both censored and uncensored search.

- `sceneByFragment` / `sceneByQueryFragment` / `sceneByName` / `sceneByURL`
- Searches `javbus.com/search/<code>` first, falls back to `/uncensored/search/<code>` when no censored results
- Hardcoded `Cookie: over18=18; existmag=mag` to bypass the site's age gate
- Stdlib-only (urllib + regex), no third-party dependencies

### Scraper types
- [x] sceneByFragment
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByURL

### Examples to test
- Censored: `SSIS-123` → https://www.javbus.com/SSIS-123
- Uncensored: `HEYZO-3016` → https://www.javbus.com/HEYZO-3016

### Notes
- Code extraction strips junk tokens (`CD1`, `DISC2`, `JAV24`, ...), supports alphanumeric prefixes (`s2mbd-055` → `S2MBD-055`), normalizes dashless codes (`DDT246` → `DDT-246`), and ignores dates before the code
- Fragment paths return a single scene object; `sceneByName` returns a list
- Duration returned in seconds (Stash convention)
