### PR TITLE
HStream: Update

### DIFF
--- a/scrapers/hstream.yml
+++ b/scrapers/hstream.yml
@@ -1,7 +1,18 @@
 name: HStream
 
-# Using Portrait Poster as Stash Thumbnails
-# By default, the wide-screen video thumbnails are scraped, since they are of much higher resolution and a better fit with other scene thumbnails. If you would prefer to scrape the portrait style poster images, search for and uncomment the "POSTER IMAGE" lines below...
+# Search for the "@FilenameFormats" section to see what style of filenames are supported
+
+# ==================== CUSTOMIZATIONS ====================
+
+# Portrait Poster as Stash Thumbnails
+# By default, the widescreen thumbnail images are scraped, because they are of much higher resolution and a better fit within Stash. If you would prefer to scrape the portrait style poster images, search for and uncomment the "@PosterImage" block(s) below...
+
+# Adding Additional Tags
+# If there are any tags you want to ADD to those that are scraped, search for the "@AdditionalTags" block(s) below
+
+# Removing Unwanted Tags
+# If there are any tags you do NOT want to be scraped, search for and uncomment the "@RemoveTags" block(s) below...
+
 
 # ==================== HStream Login Cookies ====================
 
@@ -37,43 +48,55 @@ driver:
           Domain: "hstream.moe"
           Path: "/"
 
-# ==================== Scene Tagger View ====================
+# ==================== Stash: Scene Tagger View ====================
 
 sceneByFragment: # The "Scrape by Fragment" button
-  # Attempt to convert the scene's current title (filename) into a valid hstream link
-  # Example: "Nozoko Kanojo - 1 [720p]" > "https://hstream.moe/hentai/nozoki-kanojo-1"
+  # Attemp to create a valid HStream URL from the scene's current filename
+  # Example: "Nozoki Kanojo - 01 [1080p-x265][48fps][hstream.moe].mkv" > "https://hstream.moe/hentai/nozoki-kanojo-1"
+
   action: scrapeXPath
   scraper: sceneScraper
   queryURL: https://hstream.moe/hentai/{filename}
   queryURLReplace:
-    filename: # Try from most unique to least unique filename format
-      # Studio first: [studio] {Title} - {ep#} (720p).mkv
-      - regex: ^\[.+?\] (.+) (- )?(\d+) \(\d+(p|k)\)(__\d+)?\.\w{3,4}$
-        with: "$1-$3"
 
-      # Hstream DDL: {Title} - {ep#} [2160p...].mkv
-      - regex: ^(.+?) - (\d+) \[.+?\]\.\w{3,4}$
-        with: "$1-$2"
+    filename:
 
-      # get-sauce downloader: {Title} - {ep#}_merged.mp4
-      - regex: ^(.+?)( - |-)?(\d+)_merged\.\w{3,4}$
-        with: "$1-$3"
+      # --- @FilenameFormats ---
+      # Sorted from most to least strict
+      # Once a filename format is matched, dropping the file extension will prevent other formats down the list from also being matched
 
-      # Generic title: {Title} - {ep#}.mkv
-      - regex: ^(.+?)( - | )(\d+)\.\w{3,4}$
-        with: "$1-$3"
+      # Start by replacing any underscores in the filename with spaces
+      - regex: "_"
+        with: " "
 
-      # URL Title: hstream-url-as-filename.mp4
-      - regex: ^(.+?-\d+)\.\w{3,4}$
+      # Fansubber: [Fansubber] {Title} - {ep#} [1080p][bfbc439f].mkv
+      - regex: ^\[.+?\] (.+?) (- )?(\d+) (\[|\().+\.\w{3,4}$
+        with: "$1 $3"
+
+      # # get-sauce downloader: {Title} - {ep#} merged.mkv
+      - regex: ^(\w.+?)( - |-)?(\d+) merged\.\w{3,4}$
+        with: "$1 $3"
+
+      # # Hstream DDL: {Title} - {ep#} [2160p...].mkv
+      - regex: ^(\w.+?) - (\d+) \[.+?\]\.\w{3,4}$
+        with: "$1 $2"
+
+      # URL Filename: hstream-url-as-filename.mkv
+      - regex: ^(\w.+?-\d+)\.\w{3,4}$
         with: "$1"
 
-      # --- Convert parsed title to URL ---
+      # Generic: {Title} - {ep#}.mkv
+      - regex: ^(\w.+?)( - | )(\d+)\.\w{3,4}$
+        with: "$1 $3"
+
+      # --- Convert to URL ---
+      # Remove any illegal characters and convert the parsed text into a URL
 
       # Remove non-word characters
       - regex: "[^A-Za-z\\d\\-\\s]+"
         with: ""
 
-      # Remove dash dividers
+      # Remove any dash dividers
       - regex: " - "
         with: " "
 
@@ -86,7 +109,9 @@ sceneByFragment: # The "Scrape by Fragment" button
         with: $1
 
 sceneByName: # The "Query Search" box
-  # Search HStream by title to return a list of results (no episode #)
+  # Search HStream by title to return a list of results
+  # Note: HStream does NOT support episode numbers when searching, only a series title
+
   action: scrapeXPath
   queryURL: https://hstream.moe/search?search={}
   scraper: sceneSearch
@@ -96,7 +121,8 @@ sceneByQueryFragment: # After using the "Query Search" box, scrape the selected 
   queryURL: "{url}"
   scraper: sceneScraper
 
-# ==================== Scene Details Page ====================
+
+# ==================== Stash: Scene Details Page ====================
 
 sceneByURL: # The "Scrape URL" button
   - action: scrapeXPath
@@ -104,16 +130,21 @@ sceneByURL: # The "Scrape URL" button
       - hstream.moe/hentai/
     scraper: sceneScraper
 
-# ==================== Group New\Edit Page ====================
+
+# ==================== Stash: Group New\Edit Page ====================
+
 groupByURL: # The "Scrape URL" button
   - action: scrapeXPath
     url:
       - hstream.moe/hentai/
     scraper: groupScraper
 
-# ==================== Scrapers ====================
+
+# ==================== HStream Scrapers ====================
+
 xPathScrapers:
-  # ---------- Episode Page ----------
+
+  # -------------------------------- Episode Page --------------------------------
   sceneScraper:
     scene:
       Title:
@@ -130,12 +161,13 @@ xPathScrapers:
       Image:
         selector: //meta[@property="og:image"]/@content
 
-        # ******* POSTER IMAGE *******
+        # ******* @PosterImage *******
+        # Uncomment the lines below to scrape portrait style poster images
         # postProcess:
         #   - replace:
-        #       # 1) gallery  ➜  cover
-        #       - regex: gallery
-        #         with: cover
+        #       # 1) Turn “…/gallery‑…” into “…/cover‑…”
+        #       - regex: '/gallery-'
+        #       with: '/cover-'
         #       # 2) trim the trailing “-0” (or “-1”, etc.)
         #       - regex: (-ep-\d+)-\d+\.webp$
         #         with: $1.webp
@@ -145,13 +177,20 @@ xPathScrapers:
       Tags:
         Name:
           selector: //h2[contains(text(), "Genres")]/following-sibling::div/a/text()
-          concat: ___
+          concat: ___ # Convert the array of tags into a text-string, with each tag separated by '___'
           postProcess:
             - replace:
-                # Append specific tags
+                # ******* @AdditionalTags *******
+                # Append the "Hentai" tag to the text-string created by 'concat:' above
                 - regex: $
                   with: "___Hentai"
-          split: ___
+
+                # ******* @removeTags *******
+                # Uncomment the lines below to not include these tags when scraping (case-insensitive)
+                # - regex: (?i)(1080p|4K|48Fps|4K 48FPS|Uncensored|Censored)
+                #   with: ""
+
+          split: ___ # Split the text-string of tags back into an array
 
       Groups: # When scraping from the "Scene Edit Tab", a group can also be created\assigned
         URLs: //h1/a[contains(@href, '/hentai/')]/@href
@@ -166,10 +205,11 @@ xPathScrapers:
           selector: //img[contains(@src, 'cover-')]/@src
           postProcess:
             - replace:
+                # Prepend the domain to the URL, turning a relative path into an absolute path
                 - regex: ^
                   with: "https://hstream.moe"
 
-  # ---------- Series Page ----------
+  # -------------------------------- Series Page --------------------------------
   groupScraper:
     group:
       Name:
@@ -203,19 +243,23 @@ xPathScrapers:
       Tags:
         Name:
           selector: //h2[contains(text(), "Genres")]/following-sibling::div/a/text()
-          concat: ___
+          concat: ___ # Convert the array of tags into a text-string, with each tag separated by '___'
           postProcess:
             - replace:
-                # Remove variable/unwanted tags
-                - regex: (?i)(1080p|4K|48Fps|4K 48FPS|Uncensored|Censored)
-                  with: ""
-                # Append specific tags
+                # ******* @AdditionalTags *******
+                # Append the "Hentai" tag to the text-string created by 'concat:' above
                 - regex: $
                   with: "___Hentai"
-          split: ___
 
-  # ---------- Search Results Page ----------
-  # HStream searches do NOT support episode #
+                # ******* @RemoveTags *******
+                # Uncomment the lines below to not include these tags when scraping (case-insensitive)
+                # - regex: (?i)(1080p|4K|48Fps|4K 48FPS|Uncensored|Censored)
+                #   with: ""
+
+          split: ___ # Split the text-string of tags back into an array
+
+  # -------------------------------- Search Results Page --------------------------------
+  # Note: HStream does NOT support episode numbers when searching, only a series title
   sceneSearch:
     scene:
       URL: //div[contains(@class,'p-1')]/a[contains(@href, "hentai")]/@href
@@ -225,19 +269,21 @@ xPathScrapers:
         selector: //div[contains(@class,'relative')]/img/@src
         postProcess:
           - replace:
-              # 1) make relative paths absolute
+              # 1) Prepend the domain to the URL, turning a relative path into an absolute path
               - regex: "^/"
                 with: https://hstream.moe/
 
-              # ******* POSTER IMAGE *******
-              # # 2) turn “…/gallery‑…” into “…/cover‑…”
-              # - regex: '/gallery-'
-              #   with: '/cover-'
-              # # 3) drop the “‑thumbnail” tag
-              # - regex: '-thumbnail'
-              #   with:
-              # # 4) remove the extra frame index after the episode number
+              # ******* @PosterImage *******
+              # Uncomment the lines below to scrape portrait style poster images
+              # # 2) Turn “…/gallery‑…” into “…/cover‑…”
+              # - regex: "/gallery-"
+              #   with: "/cover-"
+              # # 3) Drop the “‑thumbnail” tag
+              # - regex: "-thumbnail"
+              #   with: ""
+              # # 4) Remove the extra frame index after the episode number
               # - regex: '(-ep-\d+)-\d+\.webp$'
               #   with: $1.webp
+
 
 # Last Updated August 01, 2026


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL
- [x] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Short description

Updated\Fixed potential parsing errors in the `queryURLReplace` regex's, added `@GoTo` commenting references, some code refactoring.
