### PR TITLE
add PandaMovies group scraper

### DIFF
--- a/scrapers/PandaMovies.yml
+++ b/scrapers/PandaMovies.yml
@@ -1,0 +1,32 @@
+name: PandaMovies
+
+groupByURL:
+  - action: scrapeXPath
+    url:
+      - pandamovies.pw/watch-
+    scraper: groupScraper
+
+xPathScrapers:
+  groupScraper:
+    group:
+      Name: '//h3[@itemprop="name"]'
+
+      Date:
+        selector: '//p[strong[normalize-space()="Released Date:"]]/text()[normalize-space()]'
+        postProcess:
+          - parseDate: 'Jan 02, 2006'
+
+      URLs: '//link[@rel="canonical"]/@href'
+
+      Synopsis: '//div[@itemprop="description"]'
+
+      Studio:
+        Name: '//p[strong[normalize-space()="Studio:"]]//a[1]'
+        URL: '//p[strong[normalize-space()="Studio:"]]//a[1]/@href'
+
+      Tags:
+        Name: '//p[strong[normalize-space()="Genres:"]]//a'
+
+      FrontImage: '//div[contains(@class, "mvic-thumb")]//img/@src'
+
+# Last Updated August 6, 2026


### PR DESCRIPTION
## Scraper type(s)

- [x] groupByURL

## Examples to test

- https://pandamovies.pw/watch-facial-fantasy-3-movie-online-free (Facial Fantasy 3)

## Short description

Adds a Group URL XPath scraper for PandaMovies release pages. It imports the release name, date, synopsis, cover, canonical URL, studio, and genres. It intentionally omits performers and player, download, advertising, and tracking URLs because the source page represents the full release rather than an individual split scene.