### PR TITLE
Larger images from TeenMegaWorld

### DIFF
--- a/scrapers/TeenMegaWorld.yml
+++ b/scrapers/TeenMegaWorld.yml
@@ -80,6 +80,8 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: https://teenmegaworld.net/
+              - regex: -1x
+                with: -2x
       Studio: &studio
         Name: //a[contains(@class, "video-site-link")]
     gallery:
@@ -119,4 +121,6 @@ xPathScrapers:
           - replace:
               - regex: ^
                 with: https://teenmegaworld.net/
-# Last Updated September 22, 2025
+              - regex: -1x
+                with: -2x
+# Last Updated August 17, 2026


### PR DESCRIPTION
Use 2x images instead of 1x images. At least most of them seem to be actual resolutions instead of upscales. At least all the relatively new scenes and the older scenes with fixed covers.
3x and 4x seem to be all upscales, so those are not usable.

Example scenes:
https://teenmegaworld.net/content/contentthumbs/40/65/514065-1x.webp
https://teenmegaworld.net/content/contentthumbs/40/65/514065-2x.webp

https://teenmegaworld.net/content/contentthumbs/04/19/490419-1x.webp
https://teenmegaworld.net/content/contentthumbs/04/19/490419-2x.webp

For some older cases the images are the same like:
https://teenmegaworld.net/content/contentthumbs/66/41/346641-1x.jpg
https://teenmegaworld.net/content/contentthumbs/66/41/346641-2x.jpg

Example performers:
https://teenmegaworld.net/content/contentthumbs/72/54/7254-set-1x.webp
https://teenmegaworld.net/content/contentthumbs/72/54/7254-set-2x.webp

https://teenmegaworld.net/content/contentthumbs/67/07/6707-set-1x.jpg
https://teenmegaworld.net/content/contentthumbs/67/07/6707-set-2x.jpg