### PR TITLE
Fix Details and Date filters for FamilyTherapyXXX scraper

### DIFF
--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -13,20 +13,17 @@ xPathScrapers:
     scene:
       Title: //h1/text()
       Date:
-        selector: //meta[@itemprop="uploadDate"]/@content
+        selector: //span[@class="published"]/text()
         postProcess:
-          - replace:
-              - regex: (?i)(T\d+.+)
-                with: ""
-          - parseDate: 2006-01-02
+          - parseDate: Jan 2, 2006
       Details:
-        selector: //div[@class="entry-content"]/p/text()
+        selector: //div[@class="entry-content"]/text()[normalize-space()] | //div[@class="entry-content"]/p/text()[normalize-space()]
         concat: "\n"
       Tags:
         Name: //p[@class="post-meta"]//a/text()
       Performers:
         Name:
-          selector: //div[@class="entry-content"]/p[contains(text(),'***')]
+          selector: //div[@class="entry-content"]/p/[contains(text(),'***')]
           postProcess:
             - replace:
                 - regex: \*+|Starring\s+


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test
https://analtherapyxxx.com/intro-to-anal/
https://analtherapyxxx.com/weekend-alone/
https://familytherapyxxx.com/mother-sons-late-night-conversation/
https://familytherapyxxx.com/the-secret-deal/
https://momcomesfirst.com/hands-on-instruction/
https://momcomesfirst.com/mutual-massage/
https://perfectgirlfriend.com/challenge-run/
https://perfectgirlfriend.com/the-risky-text/

## Short description
Two changes here:
1. Updated the `Details` selector to handle both direct text and paragraph content, and
2. Switched to using the published date from the page instead of the no-longer-present `uploadDate` meta tag

These changes were necessary to fix bugs where the `Date` and `Details` fields were not being scraped correctly or at all.