### PR TITLE
[Rule34Video] fix Tags selector

### DIFF
--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -104,4 +104,4 @@ driver:
           Value: "1"
           Domain: "rule34video.com"
           Path: "/"
-# Last Updated May 19, 2026
+# Last Updated August 19, 2026

--- a/scrapers/Rule34Video.yml
+++ b/scrapers/Rule34Video.yml
@@ -57,7 +57,7 @@ xPathScrapers:
               - regex: '.+thumbnailUrl": "(http[^"]+)".+'
                 with: $1
       Tags:
-        Name: //a[@class="tag_item"]
+        Name: //span[@data-item-type="category"]//a//span | //a[@class="tag_item"]
       Studio:
         Name: $article//div[text()="Artist"]/following-sibling::span/a/span
         URL: $article//div[text()="Artist"]/following-sibling::span/a/@href


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByURL

## Examples to test

- https://rule34video.com/videos/3063279/jackerman-mother-s-warmth-ep-2-60fps/
- https://rule34video.com/videos/3070735/ff7-tifa-bare-thighjob-bulgings/
- https://rule34video.com/video/3092765/selina-s-sabotage-jackerman/

## Short description

Before the recent Rule34video UI change, the Tags selector used to include categories as well. With the latest scraper fix #2756
 they no longer were. This adds the categories back into the selection
