### PR TITLE
KB Productions scraper: add sites

### DIFF
--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -102,7 +102,7 @@ studio_map = {
     "vrhush.com": "VRHush",
     "wankitnow.com": "Wank It Now",
     "xful.com": "Xful",
-    "xxxtryout.com": "XXXTryout",
+    "xxxtryout.com": "XXX Tryout",
     "yesgirlz.com": "Yes Girlz",
     "yummycouple.com": "Yummy Couple",
     "z-filmz-originals.com": "Z-Filmz",

--- a/scrapers/KBProductions/KBProductions.py
+++ b/scrapers/KBProductions/KBProductions.py
@@ -27,6 +27,7 @@ studio_map = {
     "boppingbabes.com": "Bopping Babes",
     "cannonprod.com": "Cannon Productions",
     "comeinside.com": "Come Inside",
+    "cosplayxgirls.com": "CosplayXGirls",
     "cougarseason.com": "Cougar Season",
     "creampiethais.com": "Creampie Thais",
     "darkshade.com": "Darkshade",
@@ -93,6 +94,7 @@ studio_map = {
     "theartemixxx.com": "The ArtemiXXX",
     "topwebmodels.com": "Top Web Models",
     "topwebmodels-interviews.com": "TWM Interviews",
+    "trashyneverclassy.com": "Trashy Never Classy",
     "3rdwheel.toughlovex.com": "ToughLoveX",
     "trueanal.com": "True Anal",
     "twmclassics.com": "TWM Classics",
@@ -100,6 +102,7 @@ studio_map = {
     "vrhush.com": "VRHush",
     "wankitnow.com": "Wank It Now",
     "xful.com": "Xful",
+    "xxxtryout.com": "XXXTryout",
     "yesgirlz.com": "Yes Girlz",
     "yummycouple.com": "Yummy Couple",
     "z-filmz-originals.com": "Z-Filmz",
@@ -257,6 +260,8 @@ def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
 
     if bio := raw_performer.get("bio"):
         performer["details"] = strip_tags(bio)
+    elif details := raw_performer.get("details"):
+        performer["details"] = strip_tags(details)
 
     if (birthdate := raw_performer.get("birthdate")) and birthdate != "1969-12-31":
         performer["birthdate"] = birthdate
@@ -291,7 +296,7 @@ def to_scraped_performer(raw_performer: dict) -> ScrapedPerformer:
         performer["height"] = str(height_cm)
 
     if (weight_lb := raw_performer.get("weight")) and (
-        w := re.match(r"(\d+)\slbs", weight_lb)
+        w := re.match(r"(\d+)\slbs?", weight_lb)
     ):
         weight_kg = round(float(w.group(1)) / 2.2046)
         performer["weight"] = str(weight_kg)

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -218,4 +218,4 @@ xPathScrapers:
                 HomoScene: "Homo Scene"
                 LollipopTwinks: "Lollipop Twinks"
                 Twinklight: "Twink Light"
-# Last Updated July 9, 2026
+# Last Updated August 21, 2026

--- a/scrapers/KBProductions/KBProductions.yml
+++ b/scrapers/KBProductions/KBProductions.yml
@@ -20,6 +20,7 @@ sceneByURL:
       - boppingbabes.com/videos
       - cannonprod.com/videos
       - comeinside.com/videos
+      - cosplayxgirls.com/videos
       - cougarseason.com/scenes
       - creampiethais.com/videos
       - darkshade.com/videos
@@ -87,11 +88,13 @@ sceneByURL:
       - tour.shesbrandnew.com/scenes
       - tour.swallowed.com/scenes
       - tour.topwebmodels.com/scenes
+      - trashyneverclassy.com/videos
       - trueanal.com/scenes
       - upskirtjerk.com/videos
       - vrhush.com/scenes
       - wankitnow.com/videos
       - xful.com/videos
+      - xxxtryout.com/videos
       - yesgirlz.com/scenes
       - yummycouple.com/videos
       - z-filmz-originals.com/videos
@@ -112,6 +115,7 @@ performerByURL:
       - bjraw.com/models
       - blackbullchallenge.com/models
       - boppingbabes.com/models
+      - cosplayxgirls.com/characters
       - comeinside.com/models
       - cougarseason.com/models
       # creampiethais.com has no model pages
@@ -146,6 +150,7 @@ performerByURL:
       - nickmarxx.com/models
       - nikkizee.com/models
       - nylonperv.com/models
+      - passionpov.com/models
       - pervect.com/models
       - tour.nympho.com/models
       - tour.poundedpetite.com/models
@@ -161,11 +166,13 @@ performerByURL:
       - sexymodernbull.com/models
       - tour.swallowed.com/models
       - tour.topwebmodels.com/models
+      - trashyneverclassy.com/models
       - trueanal.com/models
       - upskirtjerk.com/models
       - vrhush.com/models
       - wankitnow.com/models
       - xful.com/models
+      - xxxtryout.com/performers
       - yesgirlz.com/models
       # yummycouple.com has no model pages
       - z-filmz-originals.com/models
@@ -211,4 +218,4 @@ xPathScrapers:
                 HomoScene: "Homo Scene"
                 LollipopTwinks: "Lollipop Twinks"
                 Twinklight: "Twink Light"
-# Last Updated December 24, 2025
+# Last Updated July 9, 2026


### PR DESCRIPTION
KB Productions scraper changes:
* Adds scene support for xxxtryout.com, trashyneverclassy.com, and cosplayxgirls.com
* Adds performer support for xxxtryout.com, trashyneverclassy.com, cosplayxgirls.com, and passionpov.com
  * Tolerate LB as an alternative to LBS when looking for weight units (e.g. trashyneverclassy.com)
  * Check `details` field when `bio` isn't present (e.g. cosplayxgirls.com)

Testing:
* Scraped a few scenes & performers from each new site
* Scraped a few performers from already-supported sites to verify no regression

LLM use: just some tab completion in Antigravity IDE when it was able to figure out the patterns.

Other notes:
* I tried adding all of the other sub-studios currently listed under KB Productions on SDB.
  * A4DX appears to me to work with the KB Productions python scraper but currently has its own Community Scraper, so I decided to keep things as they are. It would probably be a good idea to replace the dedicated A4DX scraper with this one if someone more familiar with the studio and any corner cases can verify that there's no issue with this.
  * All of the others use some different or older format that isn't drop-in compatible with the current scrapers.
* The Python scrapers (and probably xpath scraper) are really supporting the Paysite.com/Your Paysite Partner platform, which is imperfectly correlated with studios under KB Productions. It would probably be good to rename it as such, for clarity, and to investigate what other studio sites could be supported. Not opening that "can" right now though because it may contain worms.