### PR TITLE
add rate‑limiting helper with SQLite persistence

### DIFF
--- a/scrapers/py_common/ratelimit.py
+++ b/scrapers/py_common/ratelimit.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import py_common.log as log
+from py_common.deps import ensure_requirements
+
+ensure_requirements("pyrate_limiter", "requests_ratelimiter")
+from pyrate_limiter import SQLiteBucket
+from requests_ratelimiter import LimiterSession
+
+def get_limiter_session(**kwargs) -> LimiterSession:
+    if not kwargs:
+        kwargs = {"per_second": 1, "per_minute": 40}
+        
+    return LimiterSession(
+        **kwargs,
+        bucket_class=SQLiteBucket,
+        bucket_kwargs={"path": str(Path(__file__).parent / "ratelimit.db")}
+    )


### PR DESCRIPTION
- Provide 'get_limiter_session()' to obtain a 'LimiterSession'  with configurable request limits and persistent state.
-  Store bucket state in a local SQLite file, enabling consistent throttling across separate process invocations.

Simple addition but may be beneficial to keep the required db in a single location. This may also serve as a base if somebody wants to add a new limiter with a different strategy.