### PR TITLE
Fix AEBN age-gate cookie and stale movie selectors

### DIFF
--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -88,7 +88,7 @@ xPathScrapers:
     group:
       Name: //h1[@class="dts-section-page-heading-title"]|//div[@class="dts-section-page-heading-title"]/h1
       Director:
-        selector: //li[@class='section-detail-list-item-director']//span//a
+        selector: //li[@class='section-detail-list-item-director']//a
         concat: ", "
       Duration: //li[@class='section-detail-list-item-duration'][contains(span,"Running Time")]/text()
       Date:
@@ -100,7 +100,7 @@ xPathScrapers:
           - parseDate: Jan 2, 2006
       Synopsis: //div[@class="dts-section-page-detail-description-body"]//text()
       Studio:
-        Name: //div[@class='dts-studio-name-wrapper']/a/text()
+        Name: //li[@class='section-detail-list-item-studio']//a/text()
       FrontImage:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
         postProcess:
@@ -119,18 +119,18 @@ driver:
       Cookies:
         - Name: "ageGated"
           Domain: "vod.aebn.com"
-          Value: ""
+          Value: "true"
           Path: "/"
     - CookieURL: "https://gay.aebn.com"
       Cookies:
         - Name: "ageGated"
           Domain: "gay.aebn.com"
-          Value: ""
+          Value: "true"
           Path: "/"
     - CookieURL: "https://straight.aebn.com"
       Cookies:
         - Name: "ageGated"
           Domain: "straight.aebn.com"
-          Value: ""
+          Value: "true"
           Path: "/"
 # Last Updated September 17, 2025


### PR DESCRIPTION
Fixes #2809

## Problem

Scraping an AEBN movie URL (`groupByURL`) fails with:

```
scrapeGroupURL: input: scrapeGroupURL Internal system error. Error <runtime error: index out of range [0] with length 0>
```

## Root cause

1. **Age gate bypass cookie is wrong.** The `ageGated` cookie was set to an empty value (`Value: ""`). AEBN now requires `ageGated=true`; an empty/absent value redirects every request to `https://*.aebn.com/avs/gate`, which contains none of the scraper's selectors, so the scrape returns no result and Stash panics.
2. **Director selector** — the `<a>` is no longer nested inside `<span>` (`//span//a` matches nothing).
3. **Studio selector** — the class was renamed from `dts-studio-name-wrapper` to `section-detail-list-item-studio`.

## Changes

- Set `ageGated` to `"true"` for `vod`, `gay`, and `straight` (all three domains verified to bypass the gate with `true`).
- `Director`: `//li[...director]//span//a` → `//li[...director]//a`
- `Studio`: `//div[@class='dts-studio-name-wrapper']/a/text()` → `//li[@class='section-detail-list-item-studio']//a/text()`

## Notes

- The `Date` (`section-detail-list-item-release-date`) and `BackImage` (`dts-movie-boxcover-back`) elements no longer exist on the redesigned AEBN movie page, so those fields return empty regardless.

## Related

- Fixes #2809.
- The underlying panic (`runtime error: index out of range [0] with length 0`) is a Stash-core issue that surfaces whenever a scraper returns no result. It is already fixed upstream in stashapp/stash#6220 (see also stashapp/stash#6325, stashapp/stash#5974), so users on older Stash builds will still see "Internal system error" until they update Stash.
