### PR TITLE
Fix AdultEmpire Studio selector

### DIFF
--- a/scrapers/AdultEmpire.yml
+++ b/scrapers/AdultEmpire.yml
@@ -92,7 +92,7 @@ xPathScrapers:
               - regex: "Show (Less|More)$"
                 with: ""
       Studio:
-        Name: //a[@label="Studio"]/text()
+        Name: //small[contains(text(),"Studio")]/following-sibling::a/text()
       FrontImage: //a[@id="front-cover"]/@data-href
       BackImage: //a[@id="back-cover"]/@href
       # Rating is not yet implemented in the UX
@@ -149,7 +149,7 @@ xPathScrapers:
       Director: //a[@label="Director"]/text()
       Image: //a[@id="front-cover"]/@data-href
       Studio:
-        Name: //a[@label="Studio"]/text()
+        Name: //small[contains(text(),"Studio")]/following-sibling::a/text()
       Groups:
         Name: //div[contains(@class, "title-rating-section")]//h1/text()
         URL: //link[@rel="canonical"]/@href


### PR DESCRIPTION
## Problem

The `Studio` field is empty when scraping AdultEmpire (movie + scene).

## Root cause

The studio link no longer has `label="Studio"`. The redesigned page now renders:

```html
<li><small>Studio: </small><a href="/23901/studio/..." Label="Studio - Details">Pink'o</a></li>
```

So `//a[@label="Studio"]/text()` matches nothing.

## Changes

- `movieScraper` Studio: `//a[@label="Studio"]/text()` → `//small[contains(text(),"Studio")]/following-sibling::a/text()`
- `sceneScraper` Studio: same change

## Related note (separate issue)

AdultEmpire now enforces a mandatory AVS age gate (`/AgeVerification`) — the `ageConfirmed` cookie is ignored (the server sets it itself but still redirects). Scraping now requires a verified-account `etoken` cookie; the scraper already has an `etoken` placeholder for this. This is a broader regression than a selector change and should be tracked separately.

Also, `Director` no longer appears on the AdultEmpire movie page at all (see the `<!-- directors TODO -->` in the page source), so that field returns empty regardless of selector.

Related historical issues: #2151 (AdultEmpire not passing age verification), #2258 (AdultDVDEmpire login cookie support).
