### PR TITLE
Add Irmãos Dotados scraper

### DIFF
--- a/scrapers/IrmaosDotados.yml
+++ b/scrapers/IrmaosDotados.yml
@@ -1,0 +1,70 @@
+name: "Irmãos Dotados"
+sceneByURL:
+  - action: scrapeXPath
+    url:
+      - irmaosdotados.com.br/video/
+    scraper: sceneScraper
+    queryURL: https://irmaosdotados.com.br/idioma.php?lgn=en&pg={url}
+    queryURLReplace:
+      url:
+        - regex: ^https?://[^/]+
+          with: ""
+performerByURL:
+  - action: scrapeXPath
+    url:
+      - irmaosdotados.com.br/model/
+    scraper: performerScraper
+    queryURL: https://irmaosdotados.com.br/idioma.php?lgn=en&pg={url}
+    queryURLReplace:
+      url:
+        - regex: ^https?://[^/]+
+          with: ""
+xPathScrapers:
+  sceneScraper:
+    scene:
+      Title: //meta[@property="og:title"]/@content
+      Details:
+        selector: //div[@class="mt-0 text-white"]
+        postProcess:
+          - replace:
+              - regex: ^"|"$
+                with: ""
+      Image: //meta[@property="og:image"]/@content
+      Studio:
+        Name:
+          fixed: "Irmãos Dotados"
+  performerScraper:
+    performer:
+      Name: //div[@class="heading-block border-bottom-0 mb-4 text-center"]/h3
+      Image: //div[@class="col-md-6 col-12"]/img/@src
+      Gender:
+        fixed: Male
+      Height:
+        selector: //div[@class="text-white"]/li[contains(.,"Height and weight")]
+        postProcess:
+          - replace:
+              - regex: '.*Height and weight:\s*([\d.,]+)\s*cm.*'
+                with: "$1"
+          - javascript: |
+              if (!value) return "";
+              return Math.round(parseFloat(value.replace(",", ".")) * 100).toString();
+      Weight:
+        selector: //div[@class="text-white"]/li[contains(.,"Height and weight")]
+        postProcess:
+          - replace:
+              - regex: '.*/\s*([\d.]+)\s*kg.*'
+                with: "$1"
+      PenisLength:
+        selector: //div[@class="text-white"]/li[contains(.,"Dick size")]
+        postProcess:
+          - replace:
+              - regex: '.*Dick size:\s*([\d.]+).*'
+                with: "$1"
+      Details:
+        selector: //div[@class="text-white"]/li[contains(.,"Age") or contains(.,"Position")]
+        concat: "\n"
+
+# CDP is required so the redirect through idioma.php (which sets the English
+# session cookie) is followed with cookies intact, like a real browser would.
+driver:
+  useCDP: true


### PR DESCRIPTION
## Summary
- Adds an xPath-based scraper for [Irmãos Dotados](https://irmaosdotados.com.br/) (scene and performer)

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples used in testing
- [x] Verified scene scraping against:
  - https://irmaosdotados.com.br/video/751
  - https://irmaosdotados.com.br/video/655
  - https://irmaosdotados.com.br/video/351
- [x] Verified performer scraping against:
  - https://irmaosdotados.com.br/model/301
  - https://irmaosdotados.com.br/model/201
  - https://irmaosdotados.com.br/model/103

## Notes
- The site defaults to Portuguese, and there's an English toggle behind a popup that works by hitting `/idioma.php?lgn=en&pg=<path>`, which sets an English session cookie before redirecting back to the page. Since a plain HTTP client doesn't carry that cookie across the redirect, the scraper uses `driver: useCDP: true` so Stash fetches through a browser session instead.
- The scene page has no performer or tag links (checked directly in the page HTML), and only title, description, and thumbnail are public, so `Performers` and `Tags` are left off the scene scraper.
- Some scenes only have a partial English translation on the site itself (video/655) has an English title but a Portuguese-only description, so `Details` will occasionally come through untranslated. The scraper will reflect as much English as the site serves.
- Stats on performer profiles are metric but adjusted slightly. Height is converted (1.62 to 162) via a postProcess step, and it also normalizes the occasional comma-as-decimal profile ("1,78") to a period first.