### PR TITLE
Irmãos Dotados: fix performer names to sentence case

### DIFF
--- a/scrapers/IrmaosDotados.yml
+++ b/scrapers/IrmaosDotados.yml
@@ -35,7 +35,12 @@ xPathScrapers:
           fixed: "Irmãos Dotados"
   performerScraper:
     performer:
-      Name: //div[@class="heading-block border-bottom-0 mb-4 text-center"]/h3
+      Name:
+        selector: //div[@class="heading-block border-bottom-0 mb-4 text-center"]/h3
+        postProcess:
+          - javascript: |
+              if (!value) return "";
+              return value.toLowerCase().replace(/(^|\s)\S/g, (c) => c.toUpperCase());
       Image: //div[@class="col-md-6 col-12"]/img/@src
       Gender:
         fixed: Male


### PR DESCRIPTION
## Summary
- Apologies, I thought I had tackled this in #2851. Performer names on Irmãos Dotados are often published in all caps, and this PR converts them to sentence case via a postProcess step on the `Name` field.

## Scraper type(s)
- [x] performerByURL

## Examples used in testing
- [x] Verified performer name casing against:
  - https://irmaosdotados.com.br/model/333 (DAVID ANTÔNNI → David Antônni — confirms accented characters are handled correctly)
  - https://irmaosdotados.com.br/model/347, /340, /303, /301, /201, /103 (re-verified against previously tested profiles)

## Notes
- Uses a `toLowerCase()` + per-word `toUpperCase()` regex rather than a fixed `map`, since names vary per performer.