### PR TITLE
Update FamilyTherapyXXX scraper to grab the correct scene thumbnail i…

### DIFF
--- a/scrapers/FamilyTherapyXXX.yml
+++ b/scrapers/FamilyTherapyXXX.yml
@@ -36,11 +36,5 @@ xPathScrapers:
             - map:
                 Family Therapy: Family Therapy XXX
       Image:
-        selector: //meta[@itemprop="contentUrl"]/@content
-        postProcess:
-          - replace:
-              - regex: (https://[^/]+)/wp-content/uploads/\d{4}/\d{2}/(\w+)\.\w+
-                with: $1/?s=$2
-          - subScraper:
-              selector: //div[@id="left-area"]/article[1]//img/@src
+        selector: //meta[@property="og:image"]/@content
 # Last Updated December 19, 2022


### PR DESCRIPTION
## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [X] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test
https://analtherapyxxx.com/intro-to-anal/
https://analtherapyxxx.com/weekend-alone/
https://familytherapyxxx.com/mother-sons-late-night-conversation/
https://familytherapyxxx.com/the-secret-deal/
https://momcomesfirst.com/hands-on-instruction/
https://momcomesfirst.com/mutual-massage/
https://perfectgirlfriend.com/challenge-run/
https://perfectgirlfriend.com/the-risky-text/

## Short description
Use the readily available `og:image` meta tag for scene thumbnail image instead of the existing convoluted post-processor technique (that often results in the wrong image).  I've tested this on several scenes from all of the applicable studios with no issues.