### PR TITLE
Add Angel of Bogota scraper

### DIFF
--- a/scrapers/AngelOfBogota.yml
+++ b/scrapers/AngelOfBogota.yml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=../validator/scraper.schema.json
+# Angel of Bogota runs on a NATS CMS "tour" site (an Angular SPA with no
+# server-rendered scene data), so scene details are pulled directly from the
+# CMS's JSON content API instead of scraping the page markup.
+name: Angel of Bogota
+sceneByURL:
+  - action: scrapeJson
+    url:
+      - tour.angelofbogota.com/video/
+    queryURL: https://angelofcash.com/tour_api.php/content/sets?cms_area_id=1bf1ff96-f98e-4bb8-adbf-94ed89d246ad&cms_block_id=100026&data_types=1&slug={url}
+    queryURLReplace:
+      url:
+        - regex: .+/video/([^/?#]+).*
+          with: $1
+    scraper: sceneScraper
+jsonScrapers:
+  sceneScraper:
+    scene:
+      Title:
+        selector: sets.0.name
+        postProcess:
+          - replace:
+              - regex: \s+
+                with: " "
+      Details: sets.0.description
+      Date: sets.0.added_nice
+      Code: sets.0.cms_set_id
+      Image:
+        selector: sets.0.preview_formatted.thumb.1920-1080.0.[fileuri,signature].@tostr
+        postProcess:
+          - replace:
+              - regex: ^\["(.*)","(.*)"\]$
+                with: $1?$2
+          - javascript: 'return "https://c8b7fa4b1f.mjedge.net" + value;'
+      Tags:
+        Name: sets.0.data_types.#(shortname=="tags").data_values.#.name
+      Performers:
+        Name: sets.0.data_types.#(shortname=="models").data_values.#.name
+      Studio:
+        Name:
+          fixed: Angel of Bogota
+driver:
+  headers:
+    - Key: X-NATS-cms-area-id
+      Value: 1bf1ff96-f98e-4bb8-adbf-94ed89d246ad
+    - Key: X-nats-entity-decode
+      Value: "1"

--- a/scrapers/AngelOfBogota.yml
+++ b/scrapers/AngelOfBogota.yml
@@ -24,6 +24,7 @@ jsonScrapers:
                 with: " "
       Details: sets.0.description
       Date: sets.0.added_nice
+      Code: sets.0.slug
       Image:
         selector: sets.0.preview_formatted.thumb.1920-1080.0.[fileuri,signature].@tostr
         postProcess:

--- a/scrapers/AngelOfBogota.yml
+++ b/scrapers/AngelOfBogota.yml
@@ -36,7 +36,8 @@ jsonScrapers:
               # "\/path\/to\/file" instead of "/path/to/file".
               - regex: \\/
                 with: /
-          - javascript: 'return "https://c8b7fa4b1f.mjedge.net" + value;'
+              - regex: ^
+                with: https://c8b7fa4b1f.mjedge.net
       Tags:
         Name: sets.0.data_types.#(shortname=="tags").data_values.#.name
       Performers:

--- a/scrapers/AngelOfBogota.yml
+++ b/scrapers/AngelOfBogota.yml
@@ -24,13 +24,17 @@ jsonScrapers:
                 with: " "
       Details: sets.0.description
       Date: sets.0.added_nice
-      Code: sets.0.cms_set_id
       Image:
         selector: sets.0.preview_formatted.thumb.1920-1080.0.[fileuri,signature].@tostr
         postProcess:
           - replace:
               - regex: ^\["(.*)","(.*)"\]$
                 with: $1?$2
+              # gjson's @tostr re-serializes the array without unescaping the
+              # forward slashes it JSON-escaped, so fileuri comes through as
+              # "\/path\/to\/file" instead of "/path/to/file".
+              - regex: \\/
+                with: /
           - javascript: 'return "https://c8b7fa4b1f.mjedge.net" + value;'
       Tags:
         Name: sets.0.data_types.#(shortname=="tags").data_values.#.name


### PR DESCRIPTION
## Summary
- Adds a scene scraper for Angel of Bogota (tour.angelofbogota.com)

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples used in testing:
  - https://tour.angelofbogota.com/video/file-49-the-pregnancy-test
  - https://tour.angelofbogota.com/video/file-39-not-that-easy
  - https://tour.angelofbogota.com/video/episode-1-1

## Notes
- The site renders scene pages client-side, so there's no scrapable HTML. This uses `scrapeJson` against the CMS's own `tour_api.php/content/sets` content API instead.
- Performers/Tags paths are wired up (`data_types` filtered by `shortname`), but none of the above test scenes has named models or tags attached on the site, so they scrape empty for these examples (but it may be used in future).