### PR TITLE
Added ProductionDate support to sceneScraper

### DIFF
--- a/scrapers/AEBN.yml
+++ b/scrapers/AEBN.yml
@@ -1,19 +1,19 @@
 name: "AEBN"
 performerByURL:
-  - action: scrapeXPath
-    url:
-      - aebn.com
-    scraper: performerScraper
+- action: scrapeXPath
+  url:
+  - aebn.com
+  scraper: performerScraper
 sceneByURL:
-  - action: scrapeXPath
-    url:
-      - aebn.com
-    scraper: sceneScraper
+- action: scrapeXPath
+  url:
+  - aebn.com
+  scraper: sceneScraper
 groupByURL:
-  - action: scrapeXPath
-    url:
-      - aebn.com
-    scraper: movieScraper
+- action: scrapeXPath
+  url:
+  - aebn.com
+  scraper: movieScraper
 xPathScrapers:
   performerScraper:
     performer:
@@ -21,57 +21,66 @@ xPathScrapers:
       Gender:
         selector: //li[@class="section-detail-list-item-gender"]/text()
         postProcess:
-          - map:
-              TS: transgender_female
+        - map:
+            TS: transgender_female
       URLs: //link[@rel="canonical"]/@href
       Birthdate:
         selector: //div[@class='section-detail dts-list-attributes']/ul/li[contains(.,"Birth Date")]
         postProcess:
-          - replace:
-              - regex: .+:\s(.+)
-                with: $1
-              - regex: "Sept"
-                with: "Sep"
-          - parseDate: Jan 2, 2006
+        - replace:
+          - regex: .+:\s(.+)
+            with: $1
+          - regex: "Sept"
+            with: "Sep"
+        - parseDate: Jan 2, 2006
       Height:
         selector: //li[@class='section-detail-list-item-height']/text()
         postProcess:
-          - replace:
-              - regex: .+\((\d+).+\)
-                with: $1
+        - replace:
+          - regex: .+\((\d+).+\)
+            with: $1
       Weight:
         selector: //li[@class='section-detail-list-item-weight']/text()
         postProcess:
-          - replace:
-              - regex: .+\((\d+).+\)
-                with: $1
-      EyeColor: 
+        - replace:
+          - regex: .+\((\d+).+\)
+            with: $1
+      EyeColor:
         selector: //li[@class='section-detail-list-item-eye-color']/text()
       Ethnicity:
         selector: //li[@class='section-detail-list-item-ethnicity']/text()
         postProcess:
-          - map:
-              White: Caucasian
+        - map:
+            White: Caucasian
       HairColor:
         selector: //li[@class='section-detail-list-item-hair-color']/text()
       Details:
-        selector: //div[@class='dts-section-page-detail-description-body']  
-      Image: 
+        selector: //div[@class='dts-section-page-detail-description-body']
+      Image:
         selector: //div[@class='dts-section-page-detail-main-image-wrapper']/picture/img/@src
         postProcess:
-          - replace:
-              - regex: ^([^?]+).*$
-                with: "https:$1"
+        - replace:
+          - regex: ^([^?]+).*$
+            with: "https:$1"
   sceneScraper:
     scene:
       Title: //h1[@class="dts-section-page-heading-title"]|//div[@class="dts-section-page-heading-title"]/h1
       Date:
         selector: //li[@class="section-detail-list-item-release-date"]/text()
         postProcess:
-          - replace:
-              - regex: "Sept"
-                with: "Sep"
-          - parseDate: Jan 2, 2006
+        - replace:
+          - regex: "Sept"
+            with: "Sep"
+        - parseDate: Jan 2, 2006
+      ProductionDate:
+        selector: //a[@id="footerMovieSpecific2257Link"]/@href
+        postProcess:
+        - replace:
+          - regex: .*\/movies\/(\d+).*
+            with: "https://m.aebn.net/movie/2257/$1"
+        - subScraper:
+            selector: //div[contains(text(), "Production Date")]/span[@class="description"]
+        - parseDate: Jan 2, 2006
       Details:
         selector: //div[@class="dts-section-page-detail-description-body"]//text()
       Performers:
@@ -81,9 +90,9 @@ xPathScrapers:
       Image:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
         postProcess:
-          - replace:
-              - regex: ^([^?]+).*$
-                with: "https:$1" 
+        - replace:
+          - regex: ^([^?]+).*$
+            with: "https:$1"
   movieScraper:
     group:
       Name: //h1[@class="dts-section-page-heading-title"]|//div[@class="dts-section-page-heading-title"]/h1
@@ -94,43 +103,50 @@ xPathScrapers:
       Date:
         selector: //li[@class="section-detail-list-item-release-date"]/text()
         postProcess:
-          - replace:
-              - regex: "Sept"
-                with: "Sep"
-          - parseDate: Jan 2, 2006
+        - replace:
+          - regex: "Sept"
+            with: "Sep"
+        - parseDate: Jan 2, 2006
       Synopsis: //div[@class="dts-section-page-detail-description-body"]//text()
       Studio:
         Name: //li[@class='section-detail-list-item-studio']//a/text()
       FrontImage:
         selector: //picture[@class="dts-movie-boxcover-front"]/img/@src
         postProcess:
-          - replace:
-              - regex: ^([^?]+).*$
-                with: "https:$1"
+        - replace:
+          - regex: ^([^?]+).*$
+            with: "https:$1"
       BackImage:
         selector: //picture[@class="dts-movie-boxcover-back"]/img/@src
         postProcess:
-          - replace:
-              - regex: ^([^?]+).*$
-                with: "https:$1"
+        - replace:
+          - regex: ^([^?]+).*$
+            with: "https:$1"
 driver:
   cookies:
-    - CookieURL: "https://vod.aebn.com"
-      Cookies:
-        - Name: "ageGated"
-          Domain: "vod.aebn.com"
-          Value: "true"
-          Path: "/"
-    - CookieURL: "https://gay.aebn.com"
-      Cookies:
-        - Name: "ageGated"
-          Domain: "gay.aebn.com"
-          Value: "true"
-          Path: "/"
-    - CookieURL: "https://straight.aebn.com"
-      Cookies:
-        - Name: "ageGated"
-          Domain: "straight.aebn.com"
-          Value: "true"
-          Path: "/"
-# Last Updated September 17, 2025
+  - CookieURL: "https://vod.aebn.com"
+    Cookies:
+    - Name: "ageGated"
+      Domain: "vod.aebn.com"
+      Value: "true"
+      Path: "/"
+  - CookieURL: "https://gay.aebn.com"
+    Cookies:
+    - Name: "ageGated"
+      Domain: "gay.aebn.com"
+      Value: "true"
+      Path: "/"
+  - CookieURL: "https://straight.aebn.com"
+    Cookies:
+    - Name: "ageGated"
+      Domain: "straight.aebn.com"
+      Value: "true"
+      Path: "/"
+  - CookieURL: "https://m.aebn.net"
+    Cookies:
+    - Name: "ageGated"
+      Domain: "m.aebn.net"
+      Value: "true"
+      Path: "/"
+
+# Last Updated September 2, 2026


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://straight.aebn.com/straight/movies/36489/debbie-does-dallas
- https://straight.aebn.com/straight/movies/134771/velvet-high
- https://straight.aebn.com/straight/movies/313594/eat-my-nasty-ass-cum#scene-1282953

## Short description

- Added scraping of the `ProductionDate` field to `sceneScraper`
- `ProductionDate` is available on a separate corresponding 2257 link
  - The available 2257 link is not structured data, but has a structured mobile version (m.aebn.net...)
- `subScraper` is invoked to parse the mobile 2257 link