### PR TITLE
Add ProductionDate to sceneScraper

### DIFF
--- a/scrapers/AdultEmpire.yml
+++ b/scrapers/AdultEmpire.yml
@@ -146,6 +146,12 @@ xPathScrapers:
         selector: //small[contains(text(), "Released")]/following-sibling::text()
         postProcess:
           - parseDate: Jan 02 2006
+      ProductionDate:
+        selector: //li[small[text()='Production Year:']]
+        postProcess:
+        - replace:
+          - regex: .*(\d{4})$
+            with: $1
       Director: //a[@label="Director"]/text()
       Image: //a[@id="front-cover"]/@data-href
       Studio:


### PR DESCRIPTION
_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [x] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://www.adultempire.com/861880/debbie-does-dallas-2-porn-videos.html
- https://www.adultempire.com/1787676/debbie-does-dallas-30th-anniversary-porn-videos.html
- https://www.adultempire.com/5129898/better-grab-a-plan-b-porn-videos.html

## Short description

- Added support for new `ProductionDate` field to the `sceneScraper`
- AdultEmpire only provides the production year - excluded use of `parseDate`