### PR TITLE
Modify Boobpedia scraper for URL handling

### DIFF
--- a/scrapers/Boobpedia.yml
+++ b/scrapers/Boobpedia.yml
@@ -126,11 +126,16 @@ xPathScrapers:
                     - regex: ^
                       with: https://www.boobpedia.com
       URLs:
-        selector: //script[contains(.,"wgPageName")]
+        selector: //script[contains(.,"wgPageName")] | //tr[td//text()[contains(., 'Links and profiles') or contains(., 'Databases')]]/following-sibling::tr[not(td[@colspan='2' and @style])]//a/@href
         postProcess:
-          - replace:
-              - regex: '.+wgPageName":"([^"]+)".+'
-                with: "https://www.boobpedia.com/boobs/$1"
+        - javascript: |
+            if (value.indexOf("wgPageName") !== -1) {
+              var match = value.match(/"wgPageName"\s*:\s*"([^"]+)"/);
+              if (match) {
+                return "https://www.boobpedia.com/boobs/" + match[1];
+              }
+            }
+            return value;
       Details:
         selector: //div[@class="mw-parser-output"]/p
         concat: "\n\n"
@@ -444,4 +449,4 @@ xPathScrapers:
               "Zambian": "Zambia"
               "Zimbabwean": "Zimbabwe"
               "Åland Island": "Åland Islands"
-# Last Updated September 17, 2025
+# Last Updated September 2, 2026


### PR DESCRIPTION
Updated URL selector and Javascript post-processing for scraping multiple external URLs.

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [x] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [ ] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

- https://www.boobpedia.com/boobs/Margaux_M
- https://www.boobpedia.com/boobs/Aiden_Ashley

## Short description

- Prior version only returned the Boobpedia URL
- Additionally the scraper now returns any available external URLs listed in the "Databases" and "Links and profiles" cells.