### PR TITLE
Affect3DStore: set URL to make it work with search result

### DIFF
--- a/scrapers/Affect3DStore/Affect3DStore.py
+++ b/scrapers/Affect3DStore/Affect3DStore.py
@@ -78,6 +78,8 @@ def scene_from_url(_url: str) -> ScrapedScene | None:
         # image
         if main_product_photo := tree.xpath('//img[@alt="main product photo"]/@src'):
             scene['image'] = main_product_photo[0]
+        # url
+        scene["urls"] = [_url]
     except Exception as e:
         log.error("Error scraping scene from URL: %s" % e)
         return None


### PR DESCRIPTION
## Scraper type(s)
- [x] sceneByName
- [x] sceneByQueryFragment
- [x] sceneByFragment
- [x] sceneByURL

## Examples to test

- Flying High

## Short description

Just a tiny change for when searching by title. This sets the `urls` property of the scene so that it scrapes a URL for a search result.
