### PR TITLE
Update Timestamp.trade.yml

### DIFF
--- a/scrapers/Timestamp.trade.yml
+++ b/scrapers/Timestamp.trade.yml
@@ -13,7 +13,7 @@ sceneByURL:
           
 sceneByFragment:
   action: scrapeJson
-  scraper: sceneScraper
+  scraper: sceneSearch
   queryURL: https://timestamp.trade/hash_lookup?md5={checksum}&ohash={oshash}
 
 galleryByURL: 
@@ -43,6 +43,17 @@ galleryByFragment:
 
 
 jsonScrapers:
+  sceneSearch:
+    scene:
+      Title: 0.title
+      Details: 0.description
+      URL:
+        selector: 0.id
+        postProcess:
+          - replace:
+              - regex: ^
+                with: https://timestamp.trade/scene/
+
   sceneScraper:
     scene:
       Title: title


### PR DESCRIPTION
Add search by hash

_Generated by an automatic template. Can be removed if not applicable._

## Scraper type(s)
- [ ] performerByName
- [ ] performerByFragment
- [ ] performerByURL
- [ ] sceneByName
- [ ] sceneByQueryFragment
- [x] sceneByFragment
- [ ] sceneByURL
- [ ] groupByURL
- [ ] galleryByFragment
- [ ] galleryByURL
- [ ] imageByFragment
- [ ] imageByURL

## Examples to test

https://timestamp.trade/hash_lookup?md5=3ba22f070649393759cfbb3416c44549&ohash=2eed38acfd7bce4a
returns https://timestamp.trade/scene/a3025401-61d4-4397-8076-dfd67e63d85c


## Short description

File hash based lookup. I assumed I had added this a year ago.